### PR TITLE
Simplify error handling by returning Result from handle_connected_inner

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -9,8 +9,14 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 
+[package.metadata.docs.rs]
+all-features = true
+
 [badges]
 maintenance = { status = "experimental" }
+
+[features]
+dangerous_configuration = ["rustls/dangerous_configuration"]
 
 [dependencies]
 blake2 = "0.8"
@@ -26,10 +32,10 @@ rustls = { version = "0.14", features = ["quic"] }
 slab = "0.4"
 slog = "2.2"
 webpki = "0.18"
-webpki-roots = "0.15"
 
 [dev-dependencies]
 assert_matches = "1.1"
 hex-literal = "0.1.1"
 slog-term = "2"
 untrusted = "0.6.2"
+webpki-roots = "0.15"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -13,7 +13,7 @@ workspace = ".."
 maintenance = { status = "experimental" }
 
 [dependencies]
-blake2 = "0.7"
+blake2 = "0.8"
 byteorder = "1.1"
 bytes = "0.4.7"
 constant_time_eq = "0.1"

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -31,6 +31,7 @@ impl From<ConnectionHandle> for usize {
 }
 
 pub struct Connection {
+    pub app_closed: bool,
     /// DCID of Initial packet
     pub initial_id: ConnectionId,
     pub local_id: ConnectionId,
@@ -301,6 +302,7 @@ impl Connection {
             );
         }
         Self {
+            app_closed: false,
             initial_id,
             local_id,
             remote_id,
@@ -928,7 +930,7 @@ impl Connection {
         remote: SocketAddrV6,
         mut packet: Packet,
         state: State,
-    ) -> State {
+    ) -> Result<State, ConnectionError> {
         match state {
             State::Handshake(mut state) => {
                 match packet.header {
@@ -943,16 +945,10 @@ impl Connection {
                         if state.clienthello_packet.is_none() {
                             // Received Retry as a server
                             debug!(ctx.log, "received retry from client"; "connection" => %conn_id);
-                            ctx.events.push_back((
-                                self.handle,
-                                Event::ConnectionLost {
-                                    reason: TransportError::PROTOCOL_VIOLATION.into(),
-                                },
-                            ));
-                            State::handshake_failed(TransportError::PROTOCOL_VIOLATION, None)
+                            Err(TransportError::PROTOCOL_VIOLATION.into())
                         } else if state.clienthello_packet.unwrap() > number {
                             // Retry corresponds to an outdated Initial; must be a duplicate, so ignore it
-                            State::Handshake(state)
+                            Ok(State::Handshake(state))
                         } else if self
                             .decrypt(
                                 true,
@@ -966,16 +962,7 @@ impl Connection {
                                 self.read_tls(&mut state.tls, &frame);
                             } else {
                                 debug!(ctx.log, "invalid retry payload");
-                                ctx.events.push_back((
-                                    self.handle,
-                                    Event::ConnectionLost {
-                                        reason: TransportError::PROTOCOL_VIOLATION.into(),
-                                    },
-                                ));
-                                return State::handshake_failed(
-                                    TransportError::PROTOCOL_VIOLATION,
-                                    None,
-                                );
+                                return Err(TransportError::PROTOCOL_VIOLATION.into());
                             }
                             match state.tls.process_new_packets() {
                                 Ok(()) => {
@@ -1004,29 +991,20 @@ impl Connection {
                                     state.tls.write_tls(&mut outgoing).unwrap();
                                     self.transmit_handshake(&outgoing);
                                     // Prepare to receive Handshake packets that start stream 0 from offset 0
-                                    State::Handshake(state::Handshake {
+                                    Ok(State::Handshake(state::Handshake {
                                         tls,
                                         clienthello_packet: state.clienthello_packet,
                                         remote_id_set: state.remote_id_set,
-                                    })
+                                    }))
                                 }
                                 Err(e) => {
                                     debug!(ctx.log, "handshake failed"; "reason" => %e);
-                                    ctx.events.push_back((
-                                        self.handle,
-                                        Event::ConnectionLost {
-                                            reason: TransportError::TLS_HANDSHAKE_FAILED.into(),
-                                        },
-                                    ));
-                                    State::handshake_failed(
-                                        TransportError::TLS_HANDSHAKE_FAILED,
-                                        None,
-                                    )
+                                    Err(TransportError::TLS_HANDSHAKE_FAILED.into())
                                 }
                             }
                         } else {
                             debug!(ctx.log, "failed to authenticate retry packet");
-                            State::Handshake(state)
+                            Ok(State::Handshake(state))
                         }
                     }
                     Header::Long {
@@ -1050,7 +1028,7 @@ impl Connection {
                             ).is_err()
                         {
                             debug!(ctx.log, "failed to authenticate handshake packet");
-                            return State::Handshake(state);
+                            return Ok(State::Handshake(state));
                         };
                         self.on_packet_authenticated(ctx, now, number as u64);
                         // Complete handshake (and ultimately send Finished)
@@ -1070,16 +1048,7 @@ impl Connection {
                                 ) => self.read_tls(&mut state.tls, &frame),
                                 Frame::Stream(frame::Stream { .. }) => {
                                     debug!(ctx.log, "non-stream-0 stream frame in handshake");
-                                    ctx.events.push_back((
-                                        self.handle,
-                                        Event::ConnectionLost {
-                                            reason: TransportError::PROTOCOL_VIOLATION.into(),
-                                        },
-                                    ));
-                                    return State::handshake_failed(
-                                        TransportError::PROTOCOL_VIOLATION,
-                                        None,
-                                    );
+                                    return Err(TransportError::PROTOCOL_VIOLATION.into());
                                 }
                                 Frame::Ack(ack) => {
                                     self.on_ack_received(ctx, now, ack);
@@ -1091,7 +1060,7 @@ impl Connection {
                                             reason: ConnectionError::ConnectionClosed { reason },
                                         },
                                     ));
-                                    return State::Draining(state.into());
+                                    return Ok(State::Draining);
                                 }
                                 Frame::ApplicationClose(reason) => {
                                     ctx.events.push_back((
@@ -1100,23 +1069,14 @@ impl Connection {
                                             reason: ConnectionError::ApplicationClosed { reason },
                                         },
                                     ));
-                                    return State::Draining(state.into());
+                                    return Ok(State::Draining);
                                 }
                                 Frame::PathChallenge(value) => {
                                     self.handshake_pending.path_challenge(number as u64, value);
                                 }
                                 _ => {
                                     debug!(ctx.log, "unexpected frame type in handshake"; "connection" => %id, "type" => %frame.ty());
-                                    ctx.events.push_back((
-                                        self.handle,
-                                        Event::ConnectionLost {
-                                            reason: TransportError::PROTOCOL_VIOLATION.into(),
-                                        },
-                                    ));
-                                    return State::handshake_failed(
-                                        TransportError::PROTOCOL_VIOLATION,
-                                        None,
-                                    );
+                                    return Err(TransportError::PROTOCOL_VIOLATION.into());
                                 }
                             }
                         }
@@ -1132,17 +1092,7 @@ impl Connection {
                                     self.set_params(params);
                                 } else {
                                     debug!(ctx.log, "remote didn't send transport params");
-                                    ctx.events.push_back((
-                                        self.handle,
-                                        Event::ConnectionLost {
-                                            reason: TransportError::TRANSPORT_PARAMETER_ERROR
-                                                .into(),
-                                        },
-                                    ));
-                                    return State::handshake_failed(
-                                        TransportError::TLS_HANDSHAKE_FAILED,
-                                        None,
-                                    );
+                                    return Err(TransportError::TLS_HANDSHAKE_FAILED.into());
                                 }
                                 trace!(
                                     ctx.log,
@@ -1175,7 +1125,7 @@ impl Connection {
                                     }
                                 }
                                 self.crypto = Some(Crypto::new_1rtt(&state.tls, self.side));
-                                State::Established(state::Established { tls: state.tls })
+                                Ok(State::Established(state::Established { tls: state.tls }))
                             }
                             Ok(()) => {
                                 trace!(ctx.log, "handshake ongoing"; "connection" => %id);
@@ -1185,21 +1135,15 @@ impl Connection {
                                 if !response.is_empty() {
                                     self.transmit_handshake(&response);
                                 }
-                                State::Handshake(state::Handshake {
+                                Ok(State::Handshake(state::Handshake {
                                     tls: state.tls,
                                     clienthello_packet: state.clienthello_packet,
                                     remote_id_set: state.remote_id_set,
-                                })
+                                }))
                             }
                             Err(e) => {
                                 debug!(ctx.log, "handshake failed"; "reason" => %e);
-                                ctx.events.push_back((
-                                    self.handle,
-                                    Event::ConnectionLost {
-                                        reason: TransportError::TLS_HANDSHAKE_FAILED.into(),
-                                    },
-                                ));
-                                State::handshake_failed(TransportError::TLS_HANDSHAKE_FAILED, None)
+                                Err(TransportError::TLS_HANDSHAKE_FAILED.into())
                             }
                         }
                     }
@@ -1209,7 +1153,7 @@ impl Connection {
                         if self.side == Side::Server =>
                     {
                         trace!(ctx.log, "dropping duplicate Initial");
-                        State::Handshake(state)
+                        Ok(State::Handshake(state))
                     }
                     /*Header::Long {
                         ty: types::ZERO_RTT,
@@ -1258,13 +1202,7 @@ impl Connection {
                     }*/
                     Header::Long { ty, .. } => {
                         debug!(ctx.log, "unexpected packet type"; "type" => format!("{:02X}", ty));
-                        ctx.events.push_back((
-                            self.handle,
-                            Event::ConnectionLost {
-                                reason: TransportError::PROTOCOL_VIOLATION.into(),
-                            },
-                        ));
-                        State::handshake_failed(TransportError::PROTOCOL_VIOLATION, None)
+                        Err(TransportError::PROTOCOL_VIOLATION.into())
                     }
                     Header::VersionNegotiate {
                         destination_id: id, ..
@@ -1272,37 +1210,22 @@ impl Connection {
                         let mut payload = io::Cursor::new(&packet.payload[..]);
                         if packet.payload.len() % 4 != 0 {
                             debug!(ctx.log, "malformed version negotiation"; "connection" => %id);
-                            ctx.events.push_back((
-                                self.handle,
-                                Event::ConnectionLost {
-                                    reason: TransportError::PROTOCOL_VIOLATION.into(),
-                                },
-                            ));
-                            return State::handshake_failed(
-                                TransportError::PROTOCOL_VIOLATION,
-                                None,
-                            );
+                            return Err(TransportError::PROTOCOL_VIOLATION.into());
                         }
                         while payload.has_remaining() {
                             let version = payload.get::<u32>().unwrap();
                             if version == VERSION {
                                 // Our version is supported, so this packet is spurious
-                                return State::Handshake(state);
+                                return Ok(State::Handshake(state));
                             }
                         }
                         debug!(ctx.log, "remote doesn't support our version");
-                        ctx.events.push_back((
-                            self.handle,
-                            Event::ConnectionLost {
-                                reason: ConnectionError::VersionMismatch,
-                            },
-                        ));
-                        State::Draining(state.into())
+                        Err(ConnectionError::VersionMismatch)
                     }
                     // TODO: SHOULD buffer these to improve reordering tolerance.
                     Header::Short { .. } => {
                         trace!(ctx.log, "dropping short packet during handshake");
-                        State::Handshake(state)
+                        Ok(State::Handshake(state))
                     }
                 }
             }
@@ -1310,19 +1233,17 @@ impl Connection {
                 let id = self.local_id.clone();
                 if let Header::Long { .. } = packet.header {
                     trace!(ctx.log, "discarding unprotected packet"; "connection" => %id);
-                    return State::Established(state);
+                    return Ok(State::Established(state));
                 }
                 let (payload, number) = match self.decrypt_packet(false, packet) {
                     Ok(x) => x,
                     Err(None) => {
                         trace!(ctx.log, "failed to authenticate packet"; "connection" => %id);
-                        return State::Established(state);
+                        return Ok(State::Established(state));
                     }
                     Err(Some(e)) => {
                         warn!(ctx.log, "got illegal packet"; "connection" => %id);
-                        ctx.events
-                            .push_back((self.handle, Event::ConnectionLost { reason: e.into() }));
-                        return State::closed(e);
+                        return Err(e.into());
                     }
                 };
                 self.on_packet_authenticated(ctx, now, number);
@@ -1335,16 +1256,14 @@ impl Connection {
                     // Forget about unacknowledged handshake packets
                     self.handshake_cleanup(&ctx.config);
                 }
-                match self
-                    .process_payload(ctx, now, number, payload.into(), &mut state.tls)
-                    .and_then(|x| {
-                        self.drive_tls(ctx, &mut state.tls)?;
-                        Ok(x)
-                    }) {
-                    Err(e) => State::closed(e),
-                    Ok(true) => State::Draining(state.into()),
-                    Ok(false) => State::Established(state),
-                }
+                let closed =
+                    self.process_payload(ctx, now, number, payload.into(), &mut state.tls)?;
+                self.drive_tls(ctx, &mut state.tls)?;
+                Ok(if closed {
+                    State::Draining
+                } else {
+                    State::Established(state)
+                })
             }
             State::HandshakeFailed(state) => {
                 if let Ok((payload, _)) = self.decrypt_packet(true, packet) {
@@ -1352,13 +1271,13 @@ impl Connection {
                         match frame {
                             Frame::ConnectionClose(_) | Frame::ApplicationClose(_) => {
                                 trace!(ctx.log, "draining");
-                                return State::Draining(state.into());
+                                return Ok(State::Draining);
                             }
                             _ => {}
                         }
                     }
                 }
-                State::HandshakeFailed(state)
+                Ok(State::HandshakeFailed(state))
             }
             State::Closed(state) => {
                 if let Ok((payload, _)) = self.decrypt_packet(false, packet) {
@@ -1366,16 +1285,16 @@ impl Connection {
                         match frame {
                             Frame::ConnectionClose(_) | Frame::ApplicationClose(_) => {
                                 trace!(ctx.log, "draining");
-                                return State::Draining(state.into());
+                                return Ok(State::Draining);
                             }
                             _ => {}
                         }
                     }
                 }
-                State::Closed(state)
+                Ok(State::Closed(state))
             }
-            State::Draining(x) => State::Draining(x),
-            State::Drained => State::Drained,
+            State::Draining => Ok(State::Draining),
+            State::Drained => Ok(State::Drained),
         }
     }
 
@@ -2071,25 +1990,17 @@ impl Connection {
             self.reset_idle_timeout(&ctx.config, now);
             ctx.dirty_conns.insert(self.handle);
         }
+
+        self.app_closed = true;
         self.state = Some(match self.state.take().unwrap() {
             State::Handshake(_) => State::HandshakeFailed(state::HandshakeFailed {
                 reason,
                 alert: None,
-                app_closed: true,
             }),
-            State::HandshakeFailed(x) => State::HandshakeFailed(state::HandshakeFailed {
-                app_closed: true,
-                ..x
-            }),
-            State::Established(_) => State::Closed(state::Closed {
-                reason,
-                app_closed: true,
-            }),
-            State::Closed(x) => State::Closed(state::Closed {
-                app_closed: true,
-                ..x
-            }),
-            State::Draining(_) => State::Draining(state::Draining { app_closed: true }),
+            State::HandshakeFailed(x) => State::HandshakeFailed(x),
+            State::Established(_) => State::Closed(state::Closed { reason }),
+            State::Closed(x) => State::Closed(x),
+            State::Draining => State::Draining,
             State::Drained => unreachable!(),
         });
     }
@@ -2488,6 +2399,17 @@ impl From<ConnectionError> for io::Error {
     }
 }
 
+impl From<state::CloseReason> for ConnectionError {
+    fn from(cr: state::CloseReason) -> ConnectionError {
+        match cr {
+            state::CloseReason::Connection(conn_close) => conn_close.error_code.into(),
+            state::CloseReason::Application(app_close) => {
+                ConnectionError::ApplicationClosed { reason: app_close }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Fail, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum ReadError {
     /// No more data is currently available on this stream.
@@ -2516,7 +2438,7 @@ pub enum State {
     Established(state::Established),
     HandshakeFailed(state::HandshakeFailed),
     Closed(state::Closed),
-    Draining(state::Draining),
+    Draining,
     /// Waiting for application to call close so we can dispose of the resources
     Drained,
 }
@@ -2525,7 +2447,6 @@ impl State {
     pub fn closed<R: Into<state::CloseReason>>(reason: R) -> Self {
         State::Closed(state::Closed {
             reason: reason.into(),
-            app_closed: false,
         })
     }
 
@@ -2536,7 +2457,6 @@ impl State {
         State::HandshakeFailed(state::HandshakeFailed {
             reason: reason.into(),
             alert,
-            app_closed: false,
         })
     }
 
@@ -2544,17 +2464,8 @@ impl State {
         match *self {
             State::HandshakeFailed(_) => true,
             State::Closed(_) => true,
-            State::Draining(_) => true,
+            State::Draining => true,
             State::Drained => true,
-            _ => false,
-        }
-    }
-
-    pub fn is_app_closed(&self) -> bool {
-        match *self {
-            State::HandshakeFailed(ref x) => x.app_closed,
-            State::Closed(ref x) => x.app_closed,
-            State::Draining(ref x) => x.app_closed,
             _ => false,
         }
     }
@@ -2587,7 +2498,6 @@ pub mod state {
         // Closed
         pub reason: CloseReason,
         pub alert: Option<Box<[u8]>>,
-        pub app_closed: bool,
     }
 
     #[derive(Clone)]
@@ -2614,39 +2524,6 @@ pub mod state {
 
     pub struct Closed {
         pub reason: CloseReason,
-        pub app_closed: bool,
-    }
-
-    pub struct Draining {
-        pub app_closed: bool,
-    }
-
-    impl From<Handshake> for Draining {
-        fn from(_: Handshake) -> Self {
-            Draining { app_closed: false }
-        }
-    }
-
-    impl From<HandshakeFailed> for Draining {
-        fn from(x: HandshakeFailed) -> Self {
-            Draining {
-                app_closed: x.app_closed,
-            }
-        }
-    }
-
-    impl From<Established> for Draining {
-        fn from(_: Established) -> Self {
-            Draining { app_closed: false }
-        }
-    }
-
-    impl From<Closed> for Draining {
-        fn from(x: Closed) -> Self {
-            Draining {
-                app_closed: x.app_closed,
-            }
-        }
     }
 }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -5,7 +5,7 @@ use std::{io, str};
 
 use blake2::{
     digest::{Input, VariableOutput},
-    Blake2b,
+    VarBlake2b,
 };
 use bytes::{Buf, BufMut, BytesMut};
 use ring::aead;
@@ -106,11 +106,11 @@ pub const ACK_DELAY_EXPONENT: u8 = 3;
 //pub const TLS_MAX_EARLY_DATA: u32 = 0xffff_ffff;
 
 pub fn reset_token_for(key: &[u8], id: &ConnectionId) -> [u8; RESET_TOKEN_SIZE] {
-    let mut mac = Blake2b::new_keyed(key, RESET_TOKEN_SIZE);
-    mac.process(id);
+    let mut mac = VarBlake2b::new_keyed(key, RESET_TOKEN_SIZE);
+    mac.input(id.as_ref());
     // TODO: Server ID??
     let mut result = [0; RESET_TOKEN_SIZE];
-    mac.variable_result(&mut result).unwrap();
+    mac.variable_result(|res| result.copy_from_slice(res));
     result
 }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -15,9 +15,7 @@ use ring::hmac::SigningKey;
 use rustls::quic::{ClientQuicExt, ServerQuicExt};
 pub use rustls::{Certificate, NoClientAuth, PrivateKey, TLSError};
 pub use rustls::{ClientConfig, ClientSession, ServerConfig, ServerSession, Session};
-use rustls::{KeyLogFile, ProtocolVersion};
 use webpki::DNSNameRef;
-use webpki_roots;
 
 use endpoint::EndpointError;
 use packet::{ConnectionId, AEAD_TAG_SIZE};
@@ -78,20 +76,8 @@ impl DerefMut for TlsSession {
     }
 }
 
-pub fn build_client_config() -> ClientConfig {
-    let mut config = ClientConfig::new();
-    config
-        .root_store
-        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    config.versions = vec![ProtocolVersion::TLSv1_3];
-    config.key_log = Arc::new(KeyLogFile::new());
-    config
-}
-
 pub fn build_server_config() -> ServerConfig {
-    let mut config = ServerConfig::new(NoClientAuth::new());
-    config.key_log = Arc::new(KeyLogFile::new());
-    config
+    ServerConfig::new(NoClientAuth::new())
 }
 
 fn to_vec(side: Side, params: &TransportParameters) -> Vec<u8> {

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -84,14 +84,12 @@ pub fn build_client_config() -> ClientConfig {
         .root_store
         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     config.versions = vec![ProtocolVersion::TLSv1_3];
-    config.alpn_protocols = vec![ALPN_PROTOCOL.into()];
     config.key_log = Arc::new(KeyLogFile::new());
     config
 }
 
 pub fn build_server_config() -> ServerConfig {
     let mut config = ServerConfig::new(NoClientAuth::new());
-    config.set_protocols(&[ALPN_PROTOCOL.into()]);
     config.key_log = Arc::new(KeyLogFile::new());
     config
 }
@@ -434,8 +432,6 @@ fn handshake_secret(conn_id: &ConnectionId) -> SigningKey {
     buf.put_slice(conn_id);
     hkdf::extract(&key, &buf)
 }
-
-const ALPN_PROTOCOL: &str = "hq-11";
 
 #[cfg(test)]
 mod test {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -820,7 +820,7 @@ impl Endpoint {
         stream: StreamId,
         data: &[u8],
     ) -> Result<usize, WriteError> {
-        let r = self.connections[conn.0].write(stream, data);
+        let r = self.connections[conn.0].write(&self.ctx.config, stream, data);
         match r {
             Ok(n) => {
                 self.ctx.dirty_conns.insert(conn);
@@ -865,7 +865,7 @@ impl Endpoint {
         self.ctx.dirty_conns.insert(conn); // May need to send flow control frames after reading
         match self.connections[conn.0].read(stream, buf) {
             x @ Err(ReadError::Finished) | x @ Err(ReadError::Reset { .. }) => {
-                self.connections[conn.0].maybe_cleanup(stream);
+                self.connections[conn.0].maybe_cleanup(&self.ctx.config, stream);
                 x
             }
             x => x,
@@ -891,7 +891,7 @@ impl Endpoint {
         self.ctx.dirty_conns.insert(conn); // May need to send flow control frames after reading
         match self.connections[conn.0].read_unordered(stream) {
             x @ Err(ReadError::Finished) | x @ Err(ReadError::Reset { .. }) => {
-                self.connections[conn.0].maybe_cleanup(stream);
+                self.connections[conn.0].maybe_cleanup(&self.ctx.config, stream);
                 x
             }
             x => x,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -9,7 +9,7 @@ use {
     varint, ConnectionId, StreamId, TransportError, MAX_CID_SIZE, MIN_CID_SIZE, RESET_TOKEN_SIZE,
 };
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Type(u8);
 
 impl From<u8> for Type {
@@ -46,6 +46,15 @@ macro_rules! frame_types {
     {$($name:ident = $val:expr,)*} => {
         impl Type {
             $(pub const $name: Type = Type($val);)*
+        }
+
+        impl fmt::Debug for Type {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match self.0 {
+                    $($val => f.write_str(stringify!($name)),)*
+                    _ => write!(f, "Type({:02x})", self.0)
+                }
+            }
         }
 
         impl fmt::Display for Type {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -23,7 +23,6 @@ extern crate slog;
 #[cfg(test)]
 extern crate untrusted;
 extern crate webpki;
-extern crate webpki_roots;
 
 use std::fmt;
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -57,6 +57,9 @@ pub use transport_error::Error as TransportError;
 /// The QUIC protocol version implemented
 pub const VERSION: u32 = 0xff00_000b;
 
+/// TLS ALPN value for HTTP over QUIC
+pub const ALPN_QUIC_HTTP: &str = "hq-11";
+
 /// Whether an endpoint was the initiator of a connection
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Side {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -58,7 +58,7 @@ pub use transport_error::Error as TransportError;
 pub const VERSION: u32 = 0xff00_000b;
 
 /// TLS ALPN value for HTTP over QUIC
-pub const ALPN_QUIC_HTTP: &str = "hq-11";
+pub const ALPN_QUIC_HTTP: &[u8] = b"hq-11";
 
 /// Whether an endpoint was the initiator of a connection
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -28,16 +28,12 @@ pub enum Header {
 }
 
 impl Header {
-    pub fn destination_id(&self) -> &ConnectionId {
+    pub fn destination_id(&self) -> ConnectionId {
         use self::Header::*;
-        match *self {
-            Long {
-                ref destination_id, ..
-            } => destination_id,
-            Short { ref id, .. } => id,
-            VersionNegotiate {
-                ref destination_id, ..
-            } => destination_id,
+        match self {
+            Long { destination_id, .. } => *destination_id,
+            Short { id, .. } => *id,
+            VersionNegotiate { destination_id, .. } => *destination_id,
         }
     }
 

--- a/quinn-proto/src/stream.rs
+++ b/quinn-proto/src/stream.rs
@@ -136,6 +136,9 @@ impl Recv {
 
     pub fn buffer(&mut self, data: Bytes, offset: u64) {
         // TODO: Dedup
+        if data.len() == 0 {
+            return;
+        }
         self.buffered.push_back((data, offset));
     }
 

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -89,6 +89,7 @@ fn server_config() -> Config {
     };
 
     let mut tls_server_config = crypto::build_server_config();
+    tls_server_config.set_protocols(&["hq-11".into()]);
     tls_server_config
         .set_single_cert(certs, keys[0].clone())
         .unwrap();
@@ -107,6 +108,7 @@ fn client_config() -> Config {
     let anchor_vec = vec![anchor];
 
     let mut tls_client_config = crypto::build_client_config();
+    tls_client_config.set_protocols(&["hq-11".into()]);
     tls_client_config
         .root_store
         .add_server_trust_anchors(&webpki::TLSServerTrustAnchors(&anchor_vec));

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -89,7 +89,7 @@ fn server_config() -> Config {
     };
 
     let mut tls_server_config = crypto::build_server_config();
-    tls_server_config.set_protocols(&["hq-11".into()]);
+    tls_server_config.set_protocols(&[ALPN_QUIC_HTTP.into()]);
     tls_server_config
         .set_single_cert(certs, keys[0].clone())
         .unwrap();

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -89,7 +89,7 @@ fn server_config() -> Config {
     };
 
     let mut tls_server_config = crypto::build_server_config();
-    tls_server_config.set_protocols(&[ALPN_QUIC_HTTP.into()]);
+    tls_server_config.set_protocols(&[str::from_utf8(ALPN_QUIC_HTTP).unwrap().into()]);
     tls_server_config
         .set_single_cert(certs, keys[0].clone())
         .unwrap();
@@ -108,7 +108,7 @@ fn client_config() -> Config {
     let anchor_vec = vec![anchor];
 
     let mut tls_client_config = crypto::build_client_config();
-    tls_client_config.set_protocols(&["hq-11".into()]);
+    tls_client_config.set_protocols(&[str::from_utf8(ALPN_QUIC_HTTP).unwrap().into()]);
     tls_client_config
         .root_store
         .add_server_trust_anchors(&webpki::TLSServerTrustAnchors(&anchor_vec));

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -5,7 +5,7 @@ use bytes::{Buf, BufMut};
 use coding::{self, BufExt, BufMutExt};
 use frame;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Error(u16);
 
 impl Error {
@@ -34,6 +34,17 @@ macro_rules! errors {
         impl Error {
             $(#[doc = $desc] pub const $name: Self = Error($val);)*
         }
+
+        impl fmt::Debug for Error {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match self.0 {
+                    $($val => f.write_str(stringify!($name)),)*
+                    x if x >= 0x100 && x < 0x1ff => write!(f, "Error::frame({:?})", frame::Type::from(x as u8)),
+                    _ => write!(f, "Error({:04x})", self.0),
+                }
+            }
+        }
+
         impl fmt::Display for Error {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 if self.0 >= 0x100 && self.0 <= 0x1ff {

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -10,10 +10,16 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 
+[package.metadata.docs.rs]
+all-features = true
+
 [badges]
 codecov = { repository = "djc/quinn" }
 maintenance = { status = "experimental" }
 travis-ci = { repository = "djc/quinn" }
+
+[features]
+dangerous_configuration = ["quinn-proto/dangerous_configuration"]
 
 [dependencies]
 bytes = "0.4.7"
@@ -30,6 +36,7 @@ tokio-io = "0.1"
 tokio-timer = "0.2.1"
 untrusted = "0.6.2"
 webpki = "0.18"
+webpki-roots = "0.15"
 
 [dev-dependencies]
 slog-term = "2"
@@ -37,3 +44,14 @@ structopt = "0.2.7"
 tokio = "0.1.6"
 tokio-current-thread = "0.1"
 url = "1.7"
+
+[[example]]
+name = "server"
+
+[[example]]
+name = "interop"
+required-features = ["dangerous_configuration"]
+
+[[example]]
+name = "client"
+required-features = ["dangerous_configuration"]

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -91,6 +91,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     */
 
     let mut builder = quinn::Endpoint::new();
+    builder.set_protocols(&["hq-11".into()]);
     builder.logger(log.clone());
     if options.keylog {
         builder.enable_keylog();

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -38,11 +38,11 @@ struct Opt {
 
     #[structopt(parse(from_os_str), long = "ca")]
     ca: Option<PathBuf>,
-    /*
+
     /// whether to accept invalid (e.g. self-signed) TLS certificates
     #[structopt(long = "accept-insecure-certs")]
     accept_insecure_certs: bool,
-
+    /*
     /// file to read/write session tickets to
     #[structopt(long = "session-cache", parse(from_os_str))]
     session_cache: Option<PathBuf>,
@@ -91,14 +91,20 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     */
 
     let mut builder = quinn::Endpoint::new();
+    let mut client_config = quinn::ClientConfigBuilder::new();
     builder.set_protocols(&[quinn::ALPN_QUIC_HTTP]);
     builder.logger(log.clone());
     if options.keylog {
-        builder.enable_keylog();
+        client_config.enable_keylog();
     }
     if let Some(ca_path) = options.ca {
-        builder.add_certificate_authority(&fs::read(&ca_path)?)?;
+        client_config.add_certificate_authority(&fs::read(&ca_path)?)?;
     }
+    if options.accept_insecure_certs {
+        client_config.accept_insecure_certs();
+    }
+
+    let client_config = client_config.build();
 
     let (endpoint, driver, _) = builder.bind("[::]:0")?;
     let mut runtime = Runtime::new()?;
@@ -108,7 +114,8 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     let start = Instant::now();
     runtime.block_on(
         endpoint
-            .connect(
+            .connect_with(
+                &client_config,
                 &remote,
                 url.host_str().ok_or(format_err!("URL missing host"))?,
             )?.map_err(|e| format_err!("failed to connect: {}", e))

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -91,7 +91,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     */
 
     let mut builder = quinn::Endpoint::new();
-    builder.set_protocols(&[quinn::ALPN_QUIC_HTTP.into()]);
+    builder.set_protocols(&[quinn::ALPN_QUIC_HTTP]);
     builder.logger(log.clone());
     if options.keylog {
         builder.enable_keylog();

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -91,7 +91,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     */
 
     let mut builder = quinn::Endpoint::new();
-    builder.set_protocols(&["hq-11".into()]);
+    builder.set_protocols(&[quinn::ALPN_QUIC_HTTP.into()]);
     builder.logger(log.clone());
     if options.keylog {
         builder.enable_keylog();

--- a/quinn/examples/interop.rs
+++ b/quinn/examples/interop.rs
@@ -84,7 +84,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
                 stream
                     .map_err(|e| format_err!("failed to open stream: {}", e))
                     .and_then(move |stream| get(stream))
-                    .and_then(|data| {
+                    .and_then(move |data| {
                         println!("read {} bytes, closing", data.len());
                         stream_data = true;
                         conn.close(0, b"done").map_err(|_| unreachable!())

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -105,14 +105,14 @@ fn run(log: Logger, options: Opt) -> Result<()> {
 
     let mut runtime = Runtime::new()?;
 
-    let mut builder = quinn::Endpoint::new();
+    let mut builder = quinn::EndpointBuilder::from_config(quinn::Config {
+        max_remote_bi_streams: 64,
+        ..Default::default()
+    });
     builder
         .set_protocols(&[quinn::ALPN_QUIC_HTTP])
         .logger(log.clone())
-        .config(quinn::Config {
-            max_remote_bi_streams: 64,
-            ..Default::default()
-        }).listen();
+        .listen();
 
     if options.keylog {
         builder.enable_keylog();

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -107,6 +107,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
 
     let mut builder = quinn::Endpoint::new();
     builder
+        .set_protocols(&["hq-11".into()])
         .logger(log.clone())
         .config(quinn::Config {
             max_remote_bi_streams: 64,

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -107,7 +107,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
 
     let mut builder = quinn::Endpoint::new();
     builder
-        .set_protocols(&[quinn::ALPN_QUIC_HTTP.into()])
+        .set_protocols(&[quinn::ALPN_QUIC_HTTP])
         .logger(log.clone())
         .config(quinn::Config {
             max_remote_bi_streams: 64,

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -107,7 +107,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
 
     let mut builder = quinn::Endpoint::new();
     builder
-        .set_protocols(&["hq-11".into()])
+        .set_protocols(&[quinn::ALPN_QUIC_HTTP.into()])
         .logger(log.clone())
         .config(quinn::Config {
             max_remote_bi_streams: 64,

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -302,6 +302,14 @@ impl<'a> EndpointBuilder<'a> {
         Ok(self)
     }
 
+    pub fn set_protocols(&mut self, protocols: &[String]) -> &mut Self {
+        {
+            let tls_server_config = Arc::get_mut(&mut self.config.tls_server_config).unwrap();
+            tls_server_config.set_protocols(protocols);
+        }
+        self
+    }
+
     pub fn from_socket(
         self,
         socket: std::net::UdpSocket,

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -69,6 +69,7 @@ use std::cell::RefCell;
 use std::collections::{hash_map, VecDeque};
 use std::net::{SocketAddr, SocketAddrV6, ToSocketAddrs};
 use std::rc::Rc;
+use std::str;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{io, mem};
@@ -304,10 +305,14 @@ impl<'a> EndpointBuilder<'a> {
         Ok(self)
     }
 
-    pub fn set_protocols(&mut self, protocols: &[String]) -> &mut Self {
+    pub fn set_protocols(&mut self, protocols: &[&[u8]]) -> &mut Self {
         {
             let tls_server_config = Arc::get_mut(&mut self.config.tls_server_config).unwrap();
-            tls_server_config.set_protocols(protocols);
+            let protocols_strings = protocols
+                .iter()
+                .map(|p| str::from_utf8(p).unwrap().into())
+                .collect::<Vec<_>>();
+            tls_server_config.set_protocols(&protocols_strings);
         }
         self
     }

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -88,7 +88,9 @@ use tokio_udp::UdpSocket;
 
 use quinn::{ConnectionHandle, Directionality, Side, StreamId};
 
-pub use quinn::{ClientConfig, Config, ConnectError, ConnectionError, ConnectionId, ListenKeys};
+pub use quinn::{
+    ClientConfig, Config, ConnectError, ConnectionError, ConnectionId, ListenKeys, ALPN_QUIC_HTTP,
+};
 
 /// Errors that can occur during the construction of an `Endpoint`.
 #[derive(Debug, Fail)]

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -63,6 +63,7 @@ extern crate tokio_timer;
 extern crate tokio_udp;
 extern crate untrusted;
 extern crate webpki;
+extern crate webpki_roots;
 
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -81,7 +82,7 @@ use futures::task::{self, Task};
 use futures::unsync::oneshot;
 use futures::Stream as FuturesStream;
 use futures::{Async, Future, Poll, Sink};
-use rustls::{Certificate, KeyLogFile, PrivateKey, TLSError};
+use rustls::{Certificate, KeyLogFile, PrivateKey, ProtocolVersion, TLSError};
 use slog::Logger;
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_timer::Delay;
@@ -89,9 +90,7 @@ use tokio_udp::UdpSocket;
 
 use quinn::{ConnectionHandle, Directionality, Side, StreamId};
 
-pub use quinn::{
-    ClientConfig, Config, ConnectError, ConnectionError, ConnectionId, ListenKeys, ALPN_QUIC_HTTP,
-};
+pub use quinn::{Config, ConnectError, ConnectionError, ConnectionId, ListenKeys, ALPN_QUIC_HTTP};
 
 /// Errors that can occur during the construction of an `Endpoint`.
 #[derive(Debug, Fail)]
@@ -145,6 +144,7 @@ struct EndpointInner {
     timers: FuturesUnordered<Timer>,
     incoming: futures::sync::mpsc::Sender<NewConnection>,
     driver: Option<Task>,
+    default_client_config: ClientConfig,
 }
 
 impl EndpointInner {
@@ -245,6 +245,7 @@ pub struct EndpointBuilder<'a> {
     logger: Logger,
     listen: Option<ListenKeys>,
     config: Config,
+    client_config: ClientConfig,
 }
 
 #[allow(missing_docs)]
@@ -257,9 +258,13 @@ impl<'a> EndpointBuilder<'a> {
         self.logger = logger;
         self
     }
-    pub fn config(&mut self, config: Config) -> &mut Self {
-        self.config = config;
-        self
+
+    /// Start a builder with a specific initial low-level configuration.
+    pub fn from_config(config: Config) -> Self {
+        Self {
+            config,
+            ..Self::default()
+        }
     }
 
     /// Prefer `listen_with_keys`.
@@ -274,10 +279,11 @@ impl<'a> EndpointBuilder<'a> {
         self
     }
 
+    /// Enable NSS-compatible cryptographic key logging to the `SSLKEYLOGFILE` environment variable.
+    ///
+    /// Useful for debugging encrypted communications with protocol analyzers such as Wireshark.
     pub fn enable_keylog(&mut self) -> &mut Self {
         {
-            let tls_client_config = Arc::get_mut(&mut self.config.tls_client_config).unwrap();
-            tls_client_config.key_log = Arc::new(KeyLogFile::new());
             let tls_server_config = Arc::get_mut(&mut self.config.tls_server_config).unwrap();
             tls_server_config.key_log = Arc::new(KeyLogFile::new());
         }
@@ -296,18 +302,10 @@ impl<'a> EndpointBuilder<'a> {
         Ok(self)
     }
 
-    pub fn add_certificate_authority(&mut self, der: &[u8]) -> Result<&mut Self, Error> {
-        {
-            let tls_client_config = Arc::get_mut(&mut self.config.tls_client_config).unwrap();
-            let anchor =
-                webpki::trust_anchor_util::cert_der_as_trust_anchor(untrusted::Input::from(der))?;
-            tls_client_config
-                .root_store
-                .add_server_trust_anchors(&webpki::TLSServerTrustAnchors(&[anchor]));
-        }
-        Ok(self)
-    }
-
+    /// Set the application-layer protocols to accept.
+    ///
+    /// When set, clients which don't declare support for at least one of the supplied protocols will be rejected.
+    // TODO: Cite IANA registery for ALPN IDs
     pub fn set_protocols(&mut self, protocols: &[&[u8]]) -> &mut Self {
         {
             let tls_server_config = Arc::get_mut(&mut self.config.tls_server_config).unwrap();
@@ -317,6 +315,14 @@ impl<'a> EndpointBuilder<'a> {
                 .collect::<Vec<_>>();
             tls_server_config.set_protocols(&protocols_strings);
         }
+        self
+    }
+
+    /// Set the default configuration used for outgoing connections.
+    ///
+    /// The default can be overriden by using `Endpoint:;connect_with`.
+    pub fn default_client_config(&mut self, config: ClientConfig) -> &mut Self {
+        self.client_config = config;
         self
     }
 
@@ -341,6 +347,7 @@ impl<'a> EndpointBuilder<'a> {
             timers: FuturesUnordered::new(),
             incoming: send,
             driver: None,
+            default_client_config: self.client_config,
         }));
         Ok((Endpoint(rc.clone()), Driver(rc), recv))
     }
@@ -353,19 +360,127 @@ impl<'a> EndpointBuilder<'a> {
 
 impl<'a> Default for EndpointBuilder<'a> {
     fn default() -> Self {
-        Endpoint::new()
+        Self {
+            reactor: None,
+            logger: Logger::root(slog::Discard, o!()),
+            listen: None,
+            config: Config::default(),
+            client_config: ClientConfig::default(),
+        }
+    }
+}
+
+/// Helper for creating new outgoing connections.
+pub struct ClientConfigBuilder {
+    config: quinn::ClientConfig,
+}
+
+impl ClientConfigBuilder {
+    /// Create a new builder with default options set.
+    pub fn new() -> Self {
+        let mut config = quinn::ClientConfig::new();
+        config
+            .root_store
+            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+        config.versions = vec![ProtocolVersion::TLSv1_3];
+        Self { config }
+    }
+
+    /// Add a trusted certificate authority.
+    pub fn add_certificate_authority(&mut self, der: &[u8]) -> Result<&mut Self, Error> {
+        {
+            let anchor =
+                webpki::trust_anchor_util::cert_der_as_trust_anchor(untrusted::Input::from(der))?;
+            self.config
+                .root_store
+                .add_server_trust_anchors(&webpki::TLSServerTrustAnchors(&[anchor]));
+        }
+        Ok(self)
+    }
+
+    /// Enable NSS-compatible cryptographic key logging to the `SSLKEYLOGFILE` environment variable.
+    ///
+    /// Useful for debugging encrypted communications with protocol analyzers such as Wireshark.
+    pub fn enable_keylog(&mut self) -> &mut Self {
+        self.config.key_log = Arc::new(KeyLogFile::new());
+        self
+    }
+
+    /// Set application-layer protocols to declare support for.
+    pub fn set_protocols(&mut self, protocols: &[&[u8]]) -> &mut Self {
+        self.config.alpn_protocols = protocols
+            .iter()
+            .map(|p| {
+                str::from_utf8(p)
+                    .expect("non-UTF8 protocols unsupported")
+                    .into()
+            }).collect();
+        self
+    }
+
+    /// Begin connecting from `endpoint` to `addr`.
+    pub fn build(self) -> ClientConfig {
+        ClientConfig {
+            tls_config: Arc::new(self.config),
+        }
+    }
+
+    /// DANGEROUS - Connect even if the server presents an invalid certificate.
+    ///
+    /// Restricted by the `dangerous_configuration` feature. Use with care.
+    ///
+    /// This allows connecting to servers whose certificates aren't signed by a trusted authority, e.g. servers using
+    /// self-signed certificates. This allows an attacker to impersonate the server and therefore read and modify
+    /// traffic, but is useful for applications where trust is not expected or is enforced by external means.
+    ///
+    /// Convenience method for specifying a custom `ServerCertVerifier` in the TLS configuration.
+    #[cfg(feature = "dangerous_configuration")]
+    pub fn accept_insecure_certs(&mut self) -> &mut Self {
+        struct NullVerifier;
+        impl rustls::ServerCertVerifier for NullVerifier {
+            fn verify_server_cert(
+                &self,
+                _roots: &rustls::RootCertStore,
+                _presented_certs: &[Certificate],
+                _dns_name: webpki::DNSNameRef,
+                _ocsp_response: &[u8],
+            ) -> Result<rustls::ServerCertVerified, TLSError> {
+                Ok(rustls::ServerCertVerified::assertion())
+            }
+        }
+
+        self.config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(NullVerifier));
+        self
+    }
+}
+
+impl Default for ClientConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Configuration for outgoing connections
+#[derive(Clone)]
+pub struct ClientConfig {
+    /// TLS configuration to use.
+    ///
+    /// `versions` *must* be `vec![ProtocolVersion::TLSv1_3]`.
+    pub tls_config: Arc<quinn::ClientConfig>,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        ClientConfigBuilder::default().build()
     }
 }
 
 impl Endpoint {
     /// Begin constructing an `Endpoint`
     pub fn new<'a>() -> EndpointBuilder<'a> {
-        EndpointBuilder {
-            reactor: None,
-            logger: Logger::root(slog::Discard, o!()),
-            listen: None,
-            config: Config::default(),
-        }
+        EndpointBuilder::default()
     }
 
     /// Connect to a remote endpoint.
@@ -377,7 +492,20 @@ impl Endpoint {
         server_name: &str,
     ) -> Result<impl Future<Item = NewClientConnection, Error = ConnectionError>, ConnectError>
     {
-        let (fut, conn) = self.connect_inner(addr, server_name)?;
+        self.connect_with(&self.0.borrow().default_client_config, addr, server_name)
+    }
+
+    /// Connect to a remote endpoint using a custom configuration.
+    ///
+    /// May fail immediately due to configuration errors, or in the future if the connection could not be established.
+    pub fn connect_with(
+        &self,
+        config: &ClientConfig,
+        addr: &SocketAddr,
+        server_name: &str,
+    ) -> Result<impl Future<Item = NewClientConnection, Error = ConnectionError>, ConnectError>
+    {
+        let (fut, conn) = self.connect_inner(addr, &config.tls_config, server_name)?;
         Ok(fut.map_err(|_| unreachable!()).and_then(move |err| {
             if let Some(err) = err {
                 Err(err)
@@ -429,6 +557,7 @@ impl Endpoint {
     fn connect_inner(
         &self,
         addr: &SocketAddr,
+        config: &Arc<quinn::ClientConfig>,
         server_name: &str,
     ) -> Result<
         (
@@ -440,7 +569,9 @@ impl Endpoint {
         let (send, recv) = oneshot::channel();
         let handle = {
             let mut endpoint = self.0.borrow_mut();
-            let handle = endpoint.inner.connect(normalize(*addr), server_name)?;
+            let handle = endpoint
+                .inner
+                .connect(normalize(*addr), config, server_name)?;
             endpoint.pending.insert(handle, Pending::new(Some(send)));
             handle
         };

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -855,23 +855,11 @@ impl Connection {
 
     /// The `ConnectionId` used for `conn` locally.
     pub fn local_id(&self) -> ConnectionId {
-        self.0
-            .endpoint
-            .0
-            .borrow()
-            .inner
-            .get_local_id(self.0.conn)
-            .clone()
+        self.0.endpoint.0.borrow().inner.get_local_id(self.0.conn)
     }
     /// The `ConnectionId` used for `conn` by the peer.
     pub fn remote_id(&self) -> ConnectionId {
-        self.0
-            .endpoint
-            .0
-            .borrow()
-            .inner
-            .get_remote_id(self.0.conn)
-            .clone()
+        self.0.endpoint.0.borrow().inner.get_remote_id(self.0.conn)
     }
 
     /// The negotiated application protocol


### PR DESCRIPTION
Prior to this patch, we had duplicated lots of error handling logic inside `handle_connected_inner`, mostly in the way of event recording.  This patch simplifies this by instead returning a `Result`, which allows the caller to handle either case and create events more succinctly than `handle_connected_inner` could.

Also, this changeset moves the `app_closed` property from `connection::State` to `connection::Connection` itself, as it is much simpler to manage that piece of state on the `Connection` itself. 

Closes #51.