### PR TITLE
Client configuration API

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -9,8 +9,14 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 
+[package.metadata.docs.rs]
+all-features = true
+
 [badges]
 maintenance = { status = "experimental" }
+
+[features]
+dangerous_configuration = ["rustls/dangerous_configuration"]
 
 [dependencies]
 blake2 = "0.8"
@@ -26,10 +32,10 @@ rustls = { version = "0.14", features = ["quic"] }
 slab = "0.4"
 slog = "2.2"
 webpki = "0.18"
-webpki-roots = "0.15"
 
 [dev-dependencies]
 assert_matches = "1.1"
 hex-literal = "0.1.1"
 slog-term = "2"
 untrusted = "0.6.2"
+webpki-roots = "0.15"

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1,5 +1,6 @@
 use std::collections::{hash_map, BTreeMap, VecDeque};
 use std::net::SocketAddrV6;
+use std::sync::Arc;
 use std::{cmp, io, mem};
 
 use bytes::{Buf, Bytes, BytesMut};
@@ -8,7 +9,9 @@ use rand::distributions::Distribution;
 use slog::Logger;
 
 use coding::{BufExt, BufMutExt};
-use crypto::{reset_token_for, ConnectError, Crypto, TLSError, TlsSession, ACK_DELAY_EXPONENT};
+use crypto::{
+    reset_token_for, ClientConfig, ConnectError, Crypto, TLSError, TlsSession, ACK_DELAY_EXPONENT,
+};
 use endpoint::{Config, Context, Event, Io, Timer};
 use packet::{
     set_payload_length, types, ConnectionId, Header, Packet, PacketNumber, AEAD_TAG_SIZE,
@@ -376,12 +379,15 @@ impl Connection {
     }
 
     /// Initiate a connection
-    pub fn connect(&mut self, ctx: &Context, server_name: &str) -> Result<(), ConnectError> {
-        let mut tls = TlsSession::new_client(
-            &ctx.config.tls_client_config,
-            server_name,
-            &TransportParameters::new(&ctx.config),
-        ).unwrap();
+    pub fn connect(
+        &mut self,
+        ctx: &Context,
+        config: &Arc<ClientConfig>,
+        server_name: &str,
+    ) -> Result<(), ConnectError> {
+        let mut tls =
+            TlsSession::new_client(config, server_name, &TransportParameters::new(&ctx.config))
+                .unwrap();
         self.server_name = Some(server_name.into());
         let mut outgoing = Vec::new();
         tls.write_tls(&mut outgoing).unwrap();
@@ -995,16 +1001,11 @@ impl Connection {
                                     mem::replace(self, new);
                                     // Send updated ClientHello
                                     let mut outgoing = Vec::new();
-                                    let mut tls = TlsSession::new_client(
-                                        &ctx.config.tls_client_config,
-                                        self.server_name.as_ref().unwrap(),
-                                        &TransportParameters::new(&ctx.config),
-                                    ).unwrap();
                                     state.tls.write_tls(&mut outgoing).unwrap();
                                     self.transmit_handshake(&outgoing);
                                     // Prepare to receive Handshake packets that start stream 0 from offset 0
                                     State::Handshake(state::Handshake {
-                                        tls,
+                                        tls: state.tls,
                                         clienthello_packet: state.clienthello_packet,
                                         remote_id_set: state.remote_id_set,
                                     })

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -15,9 +15,7 @@ use ring::hmac::SigningKey;
 use rustls::quic::{ClientQuicExt, ServerQuicExt};
 pub use rustls::{Certificate, NoClientAuth, PrivateKey, TLSError};
 pub use rustls::{ClientConfig, ClientSession, ServerConfig, ServerSession, Session};
-use rustls::{KeyLogFile, ProtocolVersion};
 use webpki::DNSNameRef;
-use webpki_roots;
 
 use endpoint::EndpointError;
 use packet::{ConnectionId, AEAD_TAG_SIZE};
@@ -78,20 +76,8 @@ impl DerefMut for TlsSession {
     }
 }
 
-pub fn build_client_config() -> ClientConfig {
-    let mut config = ClientConfig::new();
-    config
-        .root_store
-        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    config.versions = vec![ProtocolVersion::TLSv1_3];
-    config.key_log = Arc::new(KeyLogFile::new());
-    config
-}
-
 pub fn build_server_config() -> ServerConfig {
-    let mut config = ServerConfig::new(NoClientAuth::new());
-    config.key_log = Arc::new(KeyLogFile::new());
-    config
+    ServerConfig::new(NoClientAuth::new())
 }
 
 fn to_vec(side: Side, params: &TransportParameters) -> Vec<u8> {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -23,7 +23,6 @@ extern crate slog;
 #[cfg(test)]
 extern crate untrusted;
 extern crate webpki;
-extern crate webpki_roots;
 
 use std::fmt;
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -10,10 +10,16 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 
+[package.metadata.docs.rs]
+all-features = true
+
 [badges]
 codecov = { repository = "djc/quinn" }
 maintenance = { status = "experimental" }
 travis-ci = { repository = "djc/quinn" }
+
+[features]
+dangerous_configuration = ["quinn-proto/dangerous_configuration"]
 
 [dependencies]
 bytes = "0.4.7"
@@ -30,6 +36,7 @@ tokio-io = "0.1"
 tokio-timer = "0.2.1"
 untrusted = "0.6.2"
 webpki = "0.18"
+webpki-roots = "0.15"
 
 [dev-dependencies]
 slog-term = "2"
@@ -37,3 +44,14 @@ structopt = "0.2.7"
 tokio = "0.1.6"
 tokio-current-thread = "0.1"
 url = "1.7"
+
+[[example]]
+name = "server"
+
+[[example]]
+name = "interop"
+required-features = ["dangerous_configuration"]
+
+[[example]]
+name = "client"
+required-features = ["dangerous_configuration"]

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -38,11 +38,11 @@ struct Opt {
 
     #[structopt(parse(from_os_str), long = "ca")]
     ca: Option<PathBuf>,
-    /*
+
     /// whether to accept invalid (e.g. self-signed) TLS certificates
     #[structopt(long = "accept-insecure-certs")]
     accept_insecure_certs: bool,
-
+    /*
     /// file to read/write session tickets to
     #[structopt(long = "session-cache", parse(from_os_str))]
     session_cache: Option<PathBuf>,
@@ -91,14 +91,20 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     */
 
     let mut builder = quinn::Endpoint::new();
+    let mut client_config = quinn::ClientConfigBuilder::new();
     builder.set_protocols(&[quinn::ALPN_QUIC_HTTP]);
     builder.logger(log.clone());
     if options.keylog {
-        builder.enable_keylog();
+        client_config.enable_keylog();
     }
     if let Some(ca_path) = options.ca {
-        builder.add_certificate_authority(&fs::read(&ca_path)?)?;
+        client_config.add_certificate_authority(&fs::read(&ca_path)?)?;
     }
+    if options.accept_insecure_certs {
+        client_config.accept_insecure_certs();
+    }
+
+    let client_config = client_config.build();
 
     let (endpoint, driver, _) = builder.bind("[::]:0")?;
     let mut runtime = Runtime::new()?;
@@ -108,7 +114,8 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     let start = Instant::now();
     runtime.block_on(
         endpoint
-            .connect(
+            .connect_with(
+                &client_config,
                 &remote,
                 url.host_str().ok_or(format_err!("URL missing host"))?,
             )?.map_err(|e| format_err!("failed to connect: {}", e))

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -105,14 +105,14 @@ fn run(log: Logger, options: Opt) -> Result<()> {
 
     let mut runtime = Runtime::new()?;
 
-    let mut builder = quinn::Endpoint::new();
+    let mut builder = quinn::EndpointBuilder::from_config(quinn::Config {
+        max_remote_bi_streams: 64,
+        ..Default::default()
+    });
     builder
         .set_protocols(&[quinn::ALPN_QUIC_HTTP])
         .logger(log.clone())
-        .config(quinn::Config {
-            max_remote_bi_streams: 64,
-            ..Default::default()
-        }).listen();
+        .listen();
 
     if options.keylog {
         builder.enable_keylog();


### PR DESCRIPTION
- Allow configuration of individual clients within an endpoint
- Implement feature-gated config helper for untrusted connections
- Don't enable keylogging by default
- Test rejection of invalid certs

Candidate to address #35.