### PR TITLE
Derive Clone for high-level Connection and Endpoint

### DIFF
--- a/quinn/examples/interop.rs
+++ b/quinn/examples/interop.rs
@@ -84,7 +84,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
                 stream
                     .map_err(|e| format_err!("failed to open stream: {}", e))
                     .and_then(move |stream| get(stream))
-                    .and_then(|data| {
+                    .and_then(move |data| {
                         println!("read {} bytes, closing", data.len());
                         stream_data = true;
                         conn.close(0, b"done").map_err(|_| unreachable!())


### PR DESCRIPTION
This makes it easier to construct multiple futures that interact with the same connection.