### PR TITLE
Move TLS out of state enum

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -12,9 +12,10 @@ use slog::{self, Logger};
 
 use coding::BufMutExt;
 use connection::{
-    state, Connection, ConnectionError, ConnectionHandle, ReadError, State, WriteError,
+    make_tls, state, ClientConfig, Connection, ConnectionError, ConnectionHandle, ReadError, State,
+    WriteError,
 };
-use crypto::{self, reset_token_for, ClientConfig, ConnectError, Crypto, ServerConfig};
+use crypto::{self, reset_token_for, ConnectError, Crypto, ServerConfig};
 use packet::{
     set_payload_length, types, ConnectionId, Header, HeaderError, Packet, PacketNumber,
     AEAD_TAG_SIZE,
@@ -464,14 +465,22 @@ impl Endpoint {
     pub fn connect(
         &mut self,
         remote: SocketAddrV6,
-        config: &Arc<ClientConfig>,
+        config: &Arc<crypto::ClientConfig>,
         server_name: &str,
     ) -> Result<ConnectionHandle, ConnectError> {
         let local_id = ConnectionId::random(&mut self.ctx.rng, LOCAL_ID_LEN as u8);
         let remote_id = ConnectionId::random(&mut self.ctx.rng, MAX_CID_SIZE as u8);
         trace!(self.ctx.log, "initial dcid"; "value" => %remote_id);
-        let conn = self.add_connection(remote_id, local_id, remote_id, remote, Side::Client);
-        self.connections[conn.0].connect(&self.ctx, config, server_name)?;
+        let conn = self.add_connection(
+            remote_id,
+            local_id,
+            remote_id,
+            remote,
+            Some(ClientConfig {
+                tls_config: config.clone(),
+                server_name: server_name.into(),
+            }),
+        );
         self.ctx.dirty_conns.insert(conn);
         Ok(conn)
     }
@@ -482,21 +491,24 @@ impl Endpoint {
         local_id: ConnectionId,
         remote_id: ConnectionId,
         remote: SocketAddrV6,
-        side: Side,
+        client_config: Option<ClientConfig>,
     ) -> ConnectionHandle {
         debug_assert!(!local_id.is_empty());
         let packet_num = self.ctx.gen_initial_packet_num();
         let conn = {
             let entry = self.connections.vacant_entry();
             let conn = ConnectionHandle(entry.key());
+            let tls = make_tls(&self.ctx, &local_id, client_config.as_ref());
+
             entry.insert(Connection::new(
                 initial_id,
                 local_id,
                 remote_id,
                 remote,
                 packet_num.into(),
-                side,
-                &self.ctx.config,
+                client_config,
+                tls,
+                &mut self.ctx,
                 conn,
             ));
             conn
@@ -548,7 +560,7 @@ impl Endpoint {
             return;
         }
 
-        let conn = self.add_connection(dest_id, local_id, source_id, remote, Side::Server);
+        let conn = self.add_connection(dest_id, local_id, source_id, remote, None);
         self.connection_ids_initial.insert(dest_id, conn);
         match self.connections[conn.0].handle_initial(
             &mut self.ctx,
@@ -977,11 +989,10 @@ impl Endpoint {
         &self.connections[conn.0].remote
     }
     pub fn get_protocol(&self, conn: ConnectionHandle) -> Option<&[u8]> {
-        if let State::Established(ref state) = *self.connections[conn.0].state.as_ref().unwrap() {
-            state.tls.get_alpn_protocol().map(|p| p.as_bytes())
-        } else {
-            None
-        }
+        self.connections[conn.0]
+            .tls
+            .get_alpn_protocol()
+            .map(|p| p.as_bytes())
     }
     /// The number of bytes of packets containing retransmittable frames that have not been acknowleded or declared lost
     pub fn get_bytes_in_flight(&self, conn: ConnectionHandle) -> u64 {
@@ -998,11 +1009,7 @@ impl Endpoint {
     ///
     /// None if no name was supplied or if this connection was locally-initiated.
     pub fn get_server_name(&self, conn: ConnectionHandle) -> Option<&str> {
-        match *self.connections[conn.0].state.as_ref().unwrap() {
-            State::Handshake(ref state) => state.tls.get_sni_hostname(),
-            State::Established(ref state) => state.tls.get_sni_hostname(),
-            _ => None,
-        }
+        self.connections[conn.0].tls.get_sni_hostname()
     }
 
     /// Whether a previous session was successfully resumed by `conn`.

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -7,7 +7,6 @@ extern crate slog;
 extern crate futures;
 extern crate rustls;
 extern crate slog_term;
-#[macro_use]
 extern crate structopt;
 extern crate url;
 

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -7,9 +7,9 @@ extern crate slog;
 extern crate futures;
 extern crate rustls;
 extern crate slog_term;
-extern crate url;
 #[macro_use]
 extern crate structopt;
+extern crate url;
 
 use std::fs;
 use std::io::{self, Write};

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -7,7 +7,6 @@ extern crate slog;
 extern crate futures;
 extern crate rustls;
 extern crate slog_term;
-#[macro_use]
 extern crate structopt;
 extern crate tokio_current_thread;
 

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -188,14 +188,19 @@ fn handle_request(root: &PathBuf, log: &Logger, stream: quinn::NewStream) {
                 // Execute the request
                 let resp = process_get(&root, &req).unwrap_or_else(move |e| {
                     error!(log, "failed to process request"; "reason" => %e.pretty());
-                    format!("failed to process request: {}\n", e.pretty()).into_bytes().into()
+                    format!("failed to process request: {}\n", e.pretty())
+                        .into_bytes()
+                        .into()
                 });
                 // Write the response
-                tokio::io::write_all(stream, resp).map_err(|e| format_err!("failed to send response: {}", e))
+                tokio::io::write_all(stream, resp)
+                    .map_err(|e| format_err!("failed to send response: {}", e))
             })
             // Gracefully terminate the stream
-            .and_then(|(stream, _)| tokio::io::shutdown(stream).map_err(|e| format_err!("failed to shutdown stream: {}", e)))
-            .map(move |_| info!(log3, "request complete"))
+            .and_then(|(stream, _)| {
+                tokio::io::shutdown(stream)
+                    .map_err(|e| format_err!("failed to shutdown stream: {}", e))
+            }).map(move |_| info!(log3, "request complete"))
             .map_err(move |e| error!(log2, "request failed"; "reason" => %e.pretty())),
     )
 }


### PR DESCRIPTION
Simplifies many signatures.

A lot of things are still a bit awkward about construction, but I think this is a step in the right direction.