### PR TITLE
[WIP] Refactor TransportParameters to separate client/server types

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "experimental" }
 dangerous_configuration = ["rustls/dangerous_configuration"]
 
 [dependencies]
+aes-ctr = "0.2"
 blake2 = "0.8"
 byteorder = "1.1"
 bytes = "0.4.7"

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -774,20 +774,6 @@ impl Connection {
         self.set_loss_detection_alarm(config);
     }
 
-    pub fn update_keys(
-        &mut self,
-        packet: u64,
-        header: &[u8],
-        payload: &mut BytesMut,
-    ) -> Result<(), ()> {
-        let new = self.crypto.as_mut().unwrap().update(self.side);
-        new.decrypt(packet, header, payload)?;
-        let old = mem::replace(self.crypto.as_mut().unwrap(), new);
-        self.prev_crypto = Some((packet, old));
-        self.key_phase = !self.key_phase;
-        Ok(())
-    }
-
     pub fn transmit_handshake(&mut self, messages: &[u8]) {
         let offset = {
             let ss = self
@@ -2408,15 +2394,19 @@ impl Connection {
                 // Illegal key update
                 return Err(Some(TransportError::PROTOCOL_VIOLATION));
             }
-            if self
-                .update_keys(number, &packet.header_data, &mut packet.payload)
-                .is_ok()
-            {
-                Ok((packet.payload.to_vec(), number))
-            } else {
-                // Invalid key update
-                Err(None)
+
+            let new = self.crypto.as_mut().unwrap().update(self.side);
+            match new.decrypt(number, &packet.header_data, &mut packet.payload) {
+                Ok(()) => {}
+                Err(_) => {
+                    return Err(None);
+                }
             }
+
+            let old = mem::replace(self.crypto.as_mut().unwrap(), new);
+            self.prev_crypto = Some((number, old));
+            self.key_phase = !self.key_phase;
+            Ok((packet.payload.to_vec(), number))
         } else {
             let crypto = match (handshake, &self.prev_crypto) {
                 (true, _) => &self.handshake_crypto,

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -14,7 +14,8 @@ use crypto::{
 };
 use endpoint::{Config, Context, Event, Io, Timer};
 use packet::{
-    set_payload_length, ConnectionId, Header, LongType, Packet, PacketNumber, AEAD_TAG_SIZE,
+    set_payload_length, ConnectionId, Header, LongType, Packet, PacketNumber, PartialDecode,
+    AEAD_TAG_SIZE,
 };
 use range_set::RangeSet;
 use stream::{self, Stream};
@@ -989,13 +990,26 @@ impl Connection {
         tls.read_tls(&mut io::Cursor::new(&buf[..num])).unwrap();
     }
 
-    pub fn handle_connected(
+    pub fn handle_decode(
         &mut self,
         ctx: &mut Context,
         now: u64,
         remote: SocketAddrV6,
-        packet: Packet,
-    ) {
+        partial_decode: PartialDecode,
+    ) -> Option<BytesMut> {
+        match partial_decode.finish() {
+            Ok((packet, rest)) => {
+                self.handle_packet(ctx, now, remote, packet);
+                rest
+            }
+            Err(e) => {
+                trace!(ctx.log, "unable to complete packet decoding"; "reason" => %e);
+                None
+            }
+        }
+    }
+
+    fn handle_packet(&mut self, ctx: &mut Context, now: u64, remote: SocketAddrV6, packet: Packet) {
         if let Some(token) = self.params.stateless_reset_token {
             if packet.payload.len() >= 16 && packet.payload[packet.payload.len() - 16..] == token {
                 if !self.state.as_ref().unwrap().is_drained() {
@@ -1033,6 +1047,7 @@ impl Connection {
             State::Handshake(_) => true,
             _ => false,
         };
+
         let state = match self.handle_connected_inner(ctx, now, remote, packet, prev_state) {
             Ok(state) => state,
             Err(conn_err) => {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -14,7 +14,7 @@ use crypto::{
 };
 use endpoint::{Config, Context, Event, Io, Timer};
 use packet::{
-    set_payload_length, types, ConnectionId, Header, Packet, PacketNumber, AEAD_TAG_SIZE,
+    set_payload_length, ConnectionId, Header, LongType, Packet, PacketNumber, AEAD_TAG_SIZE,
 };
 use range_set::RangeSet;
 use stream::{self, Stream};
@@ -947,7 +947,7 @@ impl Connection {
             State::Handshake(mut state) => {
                 match packet.header {
                     Header::Long {
-                        ty: types::RETRY,
+                        ty: LongType::Retry,
                         number,
                         destination_id: conn_id,
                         source_id: remote_id,
@@ -1014,7 +1014,7 @@ impl Connection {
                         }
                     }
                     Header::Long {
-                        ty: types::HANDSHAKE,
+                        ty: LongType::Handshake,
                         destination_id: id,
                         source_id: remote_id,
                         number,
@@ -1150,7 +1150,8 @@ impl Connection {
                         }
                     }
                     Header::Long {
-                        ty: types::INITIAL, ..
+                        ty: LongType::Initial,
+                        ..
                     }
                         if self.side == Side::Server =>
                     {
@@ -1203,7 +1204,7 @@ impl Connection {
                         }
                     }*/
                     Header::Long { ty, .. } => {
-                        debug!(ctx.log, "unexpected packet type"; "type" => format!("{:02X}", ty));
+                        debug!(ctx.log, "unexpected packet type"; "type" => format!("{:?}", ty));
                         Err(TransportError::PROTOCOL_VIOLATION.into())
                     }
                     Header::VersionNegotiate {
@@ -1671,10 +1672,10 @@ impl Connection {
                         }
                     }
                     is_initial = true;
-                    types::INITIAL
+                    LongType::Initial
                 } else {
                     is_initial = false;
-                    types::HANDSHAKE
+                    LongType::Handshake
                 };
                 Header::Long {
                     ty,

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -278,7 +278,7 @@ impl Connection {
         config: &Config,
         handle: ConnectionHandle,
     ) -> Self {
-        let handshake_crypto = Crypto::new_handshake(&initial_id, side);
+        let handshake_crypto = Crypto::new_initial(&initial_id, side);
         let mut streams = FnvHashMap::default();
         for i in 0..config.max_remote_uni_streams {
             streams.insert(
@@ -1875,7 +1875,7 @@ impl Connection {
                 set_payload_length(&mut buf, header_len as usize);
             }
             crypto.encrypt(number, &mut buf, header_len as usize);
-            handshake = crypto.is_handshake();
+            handshake = crypto.is_initial();
         }
 
         // If we sent any acks, don't immediately resend them.  Setting this even if ack_only is false needlessly

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1135,7 +1135,7 @@ impl Connection {
         ctx: &mut Context,
         now: u64,
         remote: SocketAddrV6,
-        mut packet: Packet,
+        packet: Packet,
         state: State,
     ) -> Result<State, ConnectionError> {
         match state {
@@ -1190,20 +1190,16 @@ impl Connection {
                             self.rem_cid = rem_cid;
                             state.rem_cid_set = true;
                         }
-                        if self
-                            .decrypt(
-                                true,
-                                number as u64,
-                                &packet.header_data,
-                                &mut packet.payload,
-                            ).is_err()
-                        {
-                            debug!(ctx.log, "failed to authenticate handshake packet");
-                            return Ok(State::Handshake(state));
+                        let payload = match self.decrypt_packet(true, packet) {
+                            Ok((payload, _)) => payload,
+                            Err(_) => {
+                                debug!(ctx.log, "failed to authenticate handshake packet");
+                                return Ok(State::Handshake(state));
+                            }
                         };
                         self.on_packet_authenticated(ctx, now, number as u64);
                         // Complete handshake (and ultimately send Finished)
-                        for frame in frame::Iter::new(packet.payload.into()) {
+                        for frame in frame::Iter::new(payload.into()) {
                             match frame {
                                 Frame::Ack(_) => {}
                                 _ => {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -429,14 +429,14 @@ impl Connection {
         ctx.incoming_handshakes += 1;
     }
 
-    pub fn get_tx_number(&mut self) -> u64 {
+    fn get_tx_number(&mut self) -> u64 {
         self.largest_sent_packet = self.largest_sent_packet.overflowing_add(1).0;
         // TODO: Handle packet number overflow gracefully
         assert!(self.largest_sent_packet < 2u64.pow(62));
         self.largest_sent_packet
     }
 
-    pub fn on_packet_sent(
+    fn on_packet_sent(
         &mut self,
         config: &Config,
         now: u64,
@@ -460,7 +460,7 @@ impl Connection {
         }
     }
 
-    pub fn on_ack_received(&mut self, ctx: &mut Context, now: u64, ack: frame::Ack) {
+    fn on_ack_received(&mut self, ctx: &mut Context, now: u64, ack: frame::Ack) {
         trace!(ctx.log, "got ack"; "ranges" => ?ack.iter().collect::<Vec<_>>());
         let was_blocked = self.blocked();
         self.largest_acked_packet = cmp::max(self.largest_acked_packet, ack.largest); // TODO: Validate
@@ -490,7 +490,7 @@ impl Connection {
         }
     }
 
-    pub fn update_rtt(&mut self, ack_delay: u64, ack_only: bool) {
+    fn update_rtt(&mut self, ack_delay: u64, ack_only: bool) {
         self.min_rtt = cmp::min(self.min_rtt, self.latest_rtt);
         if self.latest_rtt - self.min_rtt > ack_delay {
             self.latest_rtt -= ack_delay;
@@ -509,7 +509,7 @@ impl Connection {
     }
 
     // Not timing-aware, so it's safe to call this for inferred acks, such as arise from high-latency handshakes
-    pub fn on_packet_acked(&mut self, config: &Config, packet: u64) {
+    fn on_packet_acked(&mut self, config: &Config, packet: u64) {
         let info = if let Some(x) = self.sent_packets.remove(&packet) {
             x
         } else {
@@ -630,7 +630,7 @@ impl Connection {
         ctx.dirty_conns.insert(self.handle);
     }
 
-    pub fn detect_lost_packets(&mut self, config: &Config, now: u64, largest_acked: u64) {
+    fn detect_lost_packets(&mut self, config: &Config, now: u64, largest_acked: u64) {
         self.loss_time = 0;
         let mut lost_packets = Vec::<u64>::new();
         let delay_until_lost;
@@ -681,11 +681,11 @@ impl Connection {
         }
     }
 
-    pub fn in_recovery(&self, packet: u64) -> bool {
+    fn in_recovery(&self, packet: u64) -> bool {
         packet <= self.end_of_recovery
     }
 
-    pub fn set_loss_detection_alarm(&mut self, config: &Config) {
+    fn set_loss_detection_alarm(&mut self, config: &Config) {
         if self.bytes_in_flight == 0 {
             self.set_loss_detection = Some(None);
             return;
@@ -728,12 +728,12 @@ impl Connection {
     }
 
     /// Retransmit time-out
-    pub fn rto(&self, config: &Config) -> u64 {
+    fn rto(&self, config: &Config) -> u64 {
         let computed = self.smoothed_rtt + 4 * self.rttvar + self.max_ack_delay;
         cmp::max(computed, config.min_rto_timeout) * 2u64.pow(self.rto_count)
     }
 
-    pub fn on_packet_authenticated(&mut self, ctx: &mut Context, now: u64, packet: u64) {
+    fn on_packet_authenticated(&mut self, ctx: &mut Context, now: u64, packet: u64) {
         trace!(ctx.log, "packet authenticated"; "connection" => %self.loc_cid, "pn" => packet);
         self.reset_idle_timeout(&ctx.config, now);
         self.pending_acks.insert_one(packet);
@@ -756,7 +756,7 @@ impl Connection {
     }
 
     /// Consider all previously transmitted handshake packets to be delivered. Called when we receive a new handshake packet.
-    pub fn handshake_cleanup(&mut self, config: &Config) {
+    fn handshake_cleanup(&mut self, config: &Config) {
         if !self.awaiting_handshake {
             return;
         }
@@ -774,7 +774,7 @@ impl Connection {
         self.set_loss_detection_alarm(config);
     }
 
-    pub fn transmit_handshake(&mut self, messages: &[u8]) {
+    fn transmit_handshake(&mut self, messages: &[u8]) {
         let offset = {
             let ss = self
                 .streams
@@ -796,7 +796,7 @@ impl Connection {
         self.awaiting_handshake = true;
     }
 
-    pub fn transmit(&mut self, stream: StreamId, data: Bytes) {
+    fn transmit(&mut self, stream: StreamId, data: Bytes) {
         let ss = self.streams.get_mut(&stream).unwrap().send_mut().unwrap();
         assert_eq!(ss.state, stream::SendState::Ready);
         let offset = ss.offset;
@@ -843,11 +843,7 @@ impl Connection {
         ctx.dirty_conns.insert(self.handle);
     }
 
-    pub fn drive_tls(
-        &mut self,
-        ctx: &mut Context,
-        tls: &mut TlsSession,
-    ) -> Result<(), TransportError> {
+    fn drive_tls(&mut self, ctx: &mut Context, tls: &mut TlsSession) -> Result<(), TransportError> {
         trace!(ctx.log, "processed stream 0 bytes");
         /* Process any new session tickets that might have been delivered
         {
@@ -1137,7 +1133,7 @@ impl Connection {
         ctx.dirty_conns.insert(self.handle);
     }
 
-    pub fn handle_connected_inner(
+    fn handle_connected_inner(
         &mut self,
         ctx: &mut Context,
         now: u64,
@@ -1439,7 +1435,7 @@ impl Connection {
         }
     }
 
-    pub fn process_payload(
+    fn process_payload(
         &mut self,
         ctx: &mut Context,
         now: u64,
@@ -2065,7 +2061,7 @@ impl Connection {
     }
 
     // TLP/RTO transmit
-    pub fn force_transmit(&mut self, config: &Config, now: u64) -> Box<[u8]> {
+    fn force_transmit(&mut self, config: &Config, now: u64) -> Box<[u8]> {
         let number = self.get_tx_number();
         let mut buf = Vec::new();
         Header::Short {
@@ -2094,7 +2090,7 @@ impl Connection {
         buf.into()
     }
 
-    pub fn make_close(&mut self, reason: &state::CloseReason) -> Box<[u8]> {
+    fn make_close(&mut self, reason: &state::CloseReason) -> Box<[u8]> {
         let number = self.get_tx_number();
         let mut buf = Vec::new();
         Header::Short {
@@ -2157,7 +2153,7 @@ impl Connection {
         });
     }
 
-    pub fn set_params(&mut self, params: TransportParameters) {
+    fn set_params(&mut self, params: TransportParameters) {
         self.max_bi_streams = params.initial_max_bidi_streams as u64;
         if self.side == Side::Client {
             self.max_bi_streams += 1;
@@ -2368,15 +2364,15 @@ impl Connection {
         }
     }
 
-    pub fn congestion_blocked(&self) -> bool {
+    fn congestion_blocked(&self) -> bool {
         self.congestion_window.saturating_sub(self.bytes_in_flight) < self.mtu as u64
     }
 
-    pub fn blocked(&self) -> bool {
+    fn blocked(&self) -> bool {
         self.data_sent >= self.max_data || self.congestion_blocked()
     }
 
-    pub fn decrypt_packet(
+    fn decrypt_packet(
         &mut self,
         handshake: bool,
         packet: &mut Packet,
@@ -2473,7 +2469,7 @@ impl Connection {
         r
     }
 
-    pub fn write_inner(
+    fn write_inner(
         &mut self,
         config: &Config,
         stream: StreamId,
@@ -2525,7 +2521,7 @@ impl Connection {
 }
 
 /// Extract stream 0 data from an Initial or Retry packet payload
-pub fn parse_initial(log: &Logger, payload: Bytes) -> Result<Option<frame::Stream>, ()> {
+fn parse_initial(log: &Logger, payload: Bytes) -> Result<Option<frame::Stream>, ()> {
     let mut result = None;
     for frame in frame::Iter::new(payload) {
         match frame {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -965,7 +965,12 @@ impl Connection {
         remote: SocketAddrV6,
         partial_decode: PartialDecode,
     ) -> Option<BytesMut> {
-        match partial_decode.finish() {
+        let pn_key = if partial_decode.is_handshake() {
+            &self.handshake_crypto.pn_key
+        } else {
+            &self.crypto.as_ref().unwrap().pn_key
+        };
+        match partial_decode.finish(pn_key) {
             Ok((packet, rest)) => {
                 self.handle_packet(ctx, now, remote, packet);
                 rest

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1107,7 +1107,7 @@ impl Connection {
         ctx: &mut Context,
         now: u64,
         remote: SocketAddrV6,
-        packet: Packet,
+        mut packet: Packet,
         state: State,
     ) -> Result<State, ConnectionError> {
         match state {
@@ -1154,7 +1154,6 @@ impl Connection {
                         ty: LongType::Handshake,
                         dst_cid: id,
                         src_cid: rem_cid,
-                        number,
                         ..
                     } => {
                         if !state.rem_cid_set {
@@ -1162,8 +1161,8 @@ impl Connection {
                             self.rem_cid = rem_cid;
                             state.rem_cid_set = true;
                         }
-                        let payload = match self.decrypt_packet(true, packet) {
-                            Ok((payload, _)) => payload,
+                        let number = match self.decrypt_packet(true, &mut packet) {
+                            Ok(number) => number,
                             Err(_) => {
                                 debug!(ctx.log, "failed to authenticate handshake packet");
                                 return Ok(State::Handshake(state));
@@ -1171,7 +1170,7 @@ impl Connection {
                         };
                         self.on_packet_authenticated(ctx, now, number as u64);
                         // Complete handshake (and ultimately send Finished)
-                        for frame in frame::Iter::new(payload.into()) {
+                        for frame in frame::Iter::new(packet.payload.into()) {
                             match frame {
                                 Frame::Ack(_) => {}
                                 _ => {
@@ -1370,7 +1369,7 @@ impl Connection {
                     trace!(ctx.log, "discarding unprotected packet"; "connection" => %id);
                     return Ok(State::Established(state));
                 }
-                let (payload, number) = match self.decrypt_packet(false, packet) {
+                let number = match self.decrypt_packet(false, &mut packet) {
                     Ok(x) => x,
                     Err(None) => {
                         trace!(ctx.log, "failed to authenticate packet"; "connection" => %id);
@@ -1392,7 +1391,7 @@ impl Connection {
                     self.handshake_cleanup(&ctx.config);
                 }
                 let closed =
-                    self.process_payload(ctx, now, number, payload.into(), &mut state.tls)?;
+                    self.process_payload(ctx, now, number, packet.payload.into(), &mut state.tls)?;
                 self.drive_tls(ctx, &mut state.tls)?;
                 Ok(if closed {
                     State::Draining
@@ -1401,8 +1400,8 @@ impl Connection {
                 })
             }
             State::HandshakeFailed(state) => {
-                if let Ok((payload, _)) = self.decrypt_packet(true, packet) {
-                    for frame in frame::Iter::new(payload.into()) {
+                if self.decrypt_packet(true, &mut packet).is_ok() {
+                    for frame in frame::Iter::new(packet.payload.into()) {
                         match frame {
                             Frame::ConnectionClose(_) | Frame::ApplicationClose(_) => {
                                 trace!(ctx.log, "draining");
@@ -1415,8 +1414,8 @@ impl Connection {
                 Ok(State::HandshakeFailed(state))
             }
             State::Closed(state) => {
-                if let Ok((payload, _)) = self.decrypt_packet(false, packet) {
-                    for frame in frame::Iter::new(payload.into()) {
+                if self.decrypt_packet(false, &mut packet).is_ok() {
+                    for frame in frame::Iter::new(packet.payload.into()) {
                         match frame {
                             Frame::ConnectionClose(_) | Frame::ApplicationClose(_) => {
                                 trace!(ctx.log, "draining");
@@ -2373,8 +2372,8 @@ impl Connection {
     pub fn decrypt_packet(
         &mut self,
         handshake: bool,
-        mut packet: Packet,
-    ) -> Result<(Vec<u8>, u64), Option<TransportError>> {
+        packet: &mut Packet,
+    ) -> Result<u64, Option<TransportError>> {
         let (key_phase, number) = match packet.header {
             Header::Short {
                 key_phase, number, ..
@@ -2406,7 +2405,7 @@ impl Connection {
             let old = mem::replace(self.crypto.as_mut().unwrap(), new);
             self.prev_crypto = Some((number, old));
             self.key_phase = !self.key_phase;
-            Ok((packet.payload.to_vec(), number))
+            Ok(number)
         } else {
             let crypto = match (handshake, &self.prev_crypto) {
                 (true, _) => &self.handshake_crypto,
@@ -2414,7 +2413,7 @@ impl Connection {
                 _ => self.crypto.as_ref().unwrap(),
             };
             match crypto.decrypt(number, &packet.header_data, &mut packet.payload) {
-                Ok(()) => Ok((packet.payload.to_vec(), number)),
+                Ok(()) => Ok(number),
                 Err(()) => Err(None),
             }
         }

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -577,6 +577,58 @@ impl Connection {
         self.pending_acks.subtract(&info.acks);
     }
 
+    pub fn check_packet_loss(&mut self, ctx: &mut Context, now: u64) {
+        if self.awaiting_handshake {
+            trace!(ctx.log, "retransmitting handshake packets"; "connection" => %self.loc_cid);
+            let packets = self
+                .sent_packets
+                .iter()
+                .filter_map(|(&packet, info)| if info.handshake { Some(packet) } else { None })
+                .collect::<Vec<_>>();
+            for number in packets {
+                let mut info = self.sent_packets.remove(&number).unwrap();
+                self.handshake_pending += info.retransmits;
+                self.bytes_in_flight -= info.bytes as u64;
+            }
+            self.handshake_count += 1;
+        } else if self.loss_time != 0 {
+            // Early retransmit or Time Loss Detection
+            let largest = self.largest_acked_packet;
+            self.detect_lost_packets(&ctx.config, now, largest);
+        } else if self.tlp_count < ctx.config.max_tlps {
+            trace!(ctx.log, "sending TLP {number} in {pn}",
+                           number=self.tlp_count,
+                           pn=self.largest_sent_packet + 1;
+                           "outstanding" => ?self.sent_packets.keys().collect::<Vec<_>>(),
+                           "in flight" => self.bytes_in_flight);
+            // Tail Loss Probe.
+            ctx.io.push_back(Io::Transmit {
+                destination: self.remote,
+                packet: self.force_transmit(&ctx.config, now),
+            });
+            self.reset_idle_timeout(&ctx.config, now);
+            self.tlp_count += 1;
+        } else {
+            trace!(ctx.log, "RTO fired, retransmitting"; "pn" => self.largest_sent_packet + 1,
+                           "outstanding" => ?self.sent_packets.keys().collect::<Vec<_>>(),
+                           "in flight" => self.bytes_in_flight);
+            // RTO
+            if self.rto_count == 0 {
+                self.largest_sent_before_rto = self.largest_sent_packet;
+            }
+            for _ in 0..2 {
+                ctx.io.push_back(Io::Transmit {
+                    destination: self.remote,
+                    packet: self.force_transmit(&ctx.config, now),
+                });
+            }
+            self.reset_idle_timeout(&ctx.config, now);
+            self.rto_count += 1;
+        }
+        self.set_loss_detection_alarm(&ctx.config);
+        ctx.dirty_conns.insert(self.handle);
+    }
+
     pub fn detect_lost_packets(&mut self, config: &Config, now: u64, largest_acked: u64) {
         self.loss_time = 0;
         let mut lost_packets = Vec::<u64>::new();

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2043,11 +2043,11 @@ impl Connection {
     }
 
     pub fn set_params(&mut self, params: TransportParameters) {
-        self.max_bi_streams = params.initial_max_streams_bidi as u64;
+        self.max_bi_streams = params.initial_max_bidi_streams as u64;
         if self.side == Side::Client {
             self.max_bi_streams += 1;
         } // Account for TLS stream
-        self.max_uni_streams = params.initial_max_streams_uni as u64;
+        self.max_uni_streams = params.initial_max_uni_streams as u64;
         self.max_data = params.initial_max_data as u64;
         for i in 0..self.max_remote_bi_streams {
             let id = StreamId::new(!self.side, Directionality::Bi, i as u64);
@@ -2056,7 +2056,7 @@ impl Connection {
                 .unwrap()
                 .send_mut()
                 .unwrap()
-                .max_data = params.initial_max_stream_data as u64;
+                .max_data = params.initial_max_stream_data_bidi_local as u64;
         }
         self.params = params;
     }
@@ -2081,7 +2081,10 @@ impl Connection {
                 return None;
             } // TODO: Queue STREAM_ID_BLOCKED
         };
-        stream.send_mut().unwrap().max_data = self.params.initial_max_stream_data as u64;
+        stream.send_mut().unwrap().max_data = match direction {
+            Directionality::Uni => self.params.initial_max_stream_data_uni,
+            Directionality::Bi => self.params.initial_max_stream_data_bidi_remote,
+        } as u64;
         let old = self.streams.insert(id, stream);
         assert!(old.is_none());
         Some(id)

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -788,20 +788,6 @@ impl Connection {
         Ok(())
     }
 
-    pub fn decrypt(
-        &self,
-        handshake: bool,
-        packet: u64,
-        header: &[u8],
-        payload: &mut BytesMut,
-    ) -> Result<(), ()> {
-        match (handshake, &self.prev_crypto) {
-            (true, _) => &self.handshake_crypto,
-            (false, &Some((boundary, ref prev))) if packet < boundary => prev,
-            _ => self.crypto.as_ref().unwrap(),
-        }.decrypt(packet, header, payload)
-    }
-
     pub fn transmit_handshake(&mut self, messages: &[u8]) {
         let offset = {
             let ss = self
@@ -2431,14 +2417,16 @@ impl Connection {
                 // Invalid key update
                 Err(None)
             }
-        } else if self
-            .decrypt(handshake, number, &packet.header_data, &mut packet.payload)
-            .is_ok()
-        {
-            Ok((packet.payload.to_vec(), number))
         } else {
-            // Unable to authenticate
-            Err(None)
+            let crypto = match (handshake, &self.prev_crypto) {
+                (true, _) => &self.handshake_crypto,
+                (false, &Some((boundary, ref prev))) if number < boundary => prev,
+                _ => self.crypto.as_ref().unwrap(),
+            };
+            match crypto.decrypt(number, &packet.header_data, &mut packet.payload) {
+                Ok(()) => Ok((packet.payload.to_vec(), number)),
+                Err(()) => Err(None),
+            }
         }
     }
 

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2432,6 +2432,45 @@ pub fn parse_initial(log: &Logger, payload: Bytes) -> Result<Option<frame::Strea
     Ok(result)
 }
 
+pub fn handshake_close<R>(
+    crypto: &Crypto,
+    remote_id: &ConnectionId,
+    local_id: &ConnectionId,
+    packet_number: u32,
+    reason: R,
+    tls_alert: Option<&[u8]>,
+) -> Box<[u8]>
+where
+    R: Into<state::CloseReason>,
+{
+    let mut buf = Vec::<u8>::new();
+    Header::Long {
+        ty: LongType::Handshake,
+        dst_cid: *remote_id,
+        src_cid: *local_id,
+        number: packet_number,
+    }.encode(&mut buf);
+    let header_len = buf.len();
+    let max_len = MIN_MTU - header_len as u16 - AEAD_TAG_SIZE as u16;
+    match reason.into() {
+        state::CloseReason::Application(ref x) => x.encode(&mut buf, max_len),
+        state::CloseReason::Connection(ref x) => x.encode(&mut buf, max_len),
+    }
+    if let Some(data) = tls_alert {
+        if !data.is_empty() {
+            frame::Stream {
+                id: StreamId(0),
+                fin: false,
+                offset: 0,
+                data,
+            }.encode(false, &mut buf);
+        }
+    }
+    set_payload_length(&mut buf, header_len);
+    crypto.encrypt(packet_number as u64, &mut buf, header_len);
+    buf.into()
+}
+
 /// Reasons why a connection might be lost.
 #[derive(Debug, Clone, Fail)]
 pub enum ConnectionError {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -989,6 +989,104 @@ impl Connection {
         tls.read_tls(&mut io::Cursor::new(&buf[..num])).unwrap();
     }
 
+    pub fn handle_connected(
+        &mut self,
+        ctx: &mut Context,
+        now: u64,
+        remote: SocketAddrV6,
+        packet: Packet,
+    ) {
+        trace!(ctx.log, "connection got packet"; "connection" => %self.loc_cid, "len" => packet.payload.len());
+        let was_closed = self.state.as_ref().unwrap().is_closed();
+
+        // State transitions
+        let prev_state = self.state.take().unwrap();
+        let was_handshake = match prev_state {
+            State::Handshake(_) => true,
+            _ => false,
+        };
+        let state = match self.handle_connected_inner(ctx, now, remote, packet, prev_state) {
+            Ok(state) => state,
+            Err(conn_err) => {
+                ctx.events.push_back((
+                    self.handle,
+                    Event::ConnectionLost {
+                        reason: conn_err.clone(),
+                    },
+                ));
+
+                match conn_err {
+                    ConnectionError::ApplicationClosed { reason } => {
+                        if was_handshake {
+                            State::handshake_failed(reason, None)
+                        } else {
+                            State::closed(reason)
+                        }
+                    }
+                    ConnectionError::ConnectionClosed { reason } => {
+                        if was_handshake {
+                            State::handshake_failed(reason, None)
+                        } else {
+                            State::closed(reason)
+                        }
+                    }
+                    ConnectionError::Reset => {
+                        debug!(ctx.log, "unexpected connection reset error received"; "err" => %conn_err, "initial_conn_id" => %self.init_cid);
+                        panic!("unexpected connection reset error received");
+                    }
+                    ConnectionError::TimedOut => {
+                        debug!(ctx.log, "unexpected connection timed out error received"; "err" => %conn_err, "initial_conn_id" => %self.init_cid);
+                        panic!("unexpected connection timed out error received");
+                    }
+                    ConnectionError::TransportError { error_code } => {
+                        if was_handshake {
+                            State::handshake_failed(error_code, None)
+                        } else {
+                            State::closed(error_code)
+                        }
+                    }
+                    ConnectionError::VersionMismatch => State::Draining,
+                }
+            }
+        };
+
+        if !was_closed && state.is_closed() {
+            self.close_common(ctx, now);
+        }
+
+        // Transmit CONNECTION_CLOSE if necessary
+        match state {
+            State::HandshakeFailed(ref state) => {
+                if !was_closed && self.side == Side::Server {
+                    ctx.incoming_handshakes -= 1;
+                }
+                let n = self.get_tx_number();
+                ctx.io.push_back(Io::Transmit {
+                    destination: remote,
+                    packet: handshake_close(
+                        &self.handshake_crypto,
+                        &self.rem_cid,
+                        &self.loc_cid,
+                        n as u32,
+                        state.reason.clone(),
+                        state.alert.as_ref().map(|x| &x[..]),
+                    ),
+                });
+                self.reset_idle_timeout(&ctx.config, now);
+            }
+            State::Closed(ref state) => {
+                ctx.io.push_back(Io::Transmit {
+                    destination: remote,
+                    packet: self.make_close(&state.reason),
+                });
+                self.reset_idle_timeout(&ctx.config, now);
+            }
+            _ => {}
+        }
+        self.state = Some(state);
+        ctx.dirty_conns.insert(self.handle);
+    }
+
     pub fn handle_connected_inner(
         &mut self,
         ctx: &mut Context,

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -3,6 +3,9 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::{io, str};
 
+use aes_ctr::stream_cipher::generic_array::GenericArray;
+use aes_ctr::stream_cipher::{NewFixStreamCipher, StreamCipherCore};
+use aes_ctr::Aes128Ctr;
 use blake2::{
     digest::{Input, VariableOutput},
     VarBlake2b,
@@ -327,6 +330,7 @@ pub struct CryptoState {
     secret: Vec<u8>,
     key: Vec<u8>,
     iv: Vec<u8>,
+    pn: Vec<u8>,
 }
 
 impl CryptoState {
@@ -340,7 +344,15 @@ impl CryptoState {
         qhkdf_expand(&secret_key, b"key", &mut key);
         let mut iv = vec![0; cipher.nonce_len()];
         qhkdf_expand(&secret_key, b"iv", &mut iv);
-        Self { secret, key, iv }
+        let pne_alg = PacketNumberEncryptionAlgorithm::from_aead(cipher);
+        let mut pn = vec![0; pne_alg.key_len()];
+        qhkdf_expand(&secret_key, b"pn", &mut pn);
+        Self {
+            secret,
+            key,
+            iv,
+            pn,
+        }
     }
 
     fn update(
@@ -389,6 +401,59 @@ pub enum ConnectError {
 impl From<TLSError> for ConnectError {
     fn from(x: TLSError) -> Self {
         ConnectError::Tls(x)
+    }
+}
+
+enum PacketNumberEncryptionAlgorithm {
+    AesCtr128,
+    ChaCha20,
+}
+
+impl PacketNumberEncryptionAlgorithm {
+    fn from_aead(alg: &aead::Algorithm) -> Self {
+        use self::PacketNumberEncryptionAlgorithm::*;
+        if alg == &aead::AES_128_GCM {
+            AesCtr128
+        } else if alg == &aead::CHACHA20_POLY1305 {
+            ChaCha20
+        } else {
+            unimplemented!()
+        }
+    }
+
+    fn key_len(&self) -> usize {
+        use self::PacketNumberEncryptionAlgorithm::*;
+        match *self {
+            AesCtr128 => 16,
+            ChaCha20 => 32,
+        }
+    }
+
+    fn sample_size(&self) -> usize {
+        use self::PacketNumberEncryptionAlgorithm::*;
+        match *self {
+            AesCtr128 | ChaCha20 => 16,
+        }
+    }
+
+    fn decrypt(&self, key: &[u8], sample: &[u8], in_out: &mut [u8]) {
+        use self::PacketNumberEncryptionAlgorithm::*;
+        let key = GenericArray::from_slice(key);
+        let nonce = GenericArray::from_slice(sample);
+        match *self {
+            AesCtr128 => Aes128Ctr::new(key, nonce).apply_keystream(in_out),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn encrypt(&self, key: &[u8], sample: &[u8], in_out: &mut [u8]) {
+        use self::PacketNumberEncryptionAlgorithm::*;
+        let key = GenericArray::from_slice(key);
+        let nonce = GenericArray::from_slice(sample);
+        match *self {
+            AesCtr128 => Aes128Ctr::new(key, nonce).apply_keystream(in_out),
+            _ => unimplemented!(),
+        }
     }
 }
 
@@ -481,6 +546,13 @@ mod test {
             &client_state.iv[..],
             [0xab, 0x95, 0x0b, 0x01, 0x98, 0x63, 0x79, 0x78, 0xcf, 0x44, 0xaa, 0xb9,]
         );
+        assert_eq!(
+            &client_state.pn[..],
+            [
+                0x68, 0xc3, 0xf6, 0x4e, 0x2d, 0x66, 0x34, 0x41, 0x2b, 0x8e, 0x32, 0x94, 0x62, 0x8d,
+                0x76, 0xf1
+            ]
+        );
 
         let server_secret = expanded_initial_secret(&initial_secret, b"server in");
         assert_eq!(
@@ -503,6 +575,36 @@ mod test {
             &server_state.iv[..],
             [0x32, 0x05, 0x03, 0x5a, 0x3c, 0x93, 0x7c, 0x90, 0x2e, 0xe4, 0xf4, 0xd6,]
         );
+        assert_eq!(
+            &server_state.pn[..],
+            [
+                0xa3, 0x13, 0xc8, 0x6d, 0x13, 0x73, 0xec, 0xbc, 0xcb, 0x32, 0x94, 0xb1, 0x49, 0x74,
+                0x22, 0x6c
+            ]
+        );
+    }
+
+    // https://github.com/quicwg/base-drafts/wiki/Test-vector-for-AES-packet-number-encryption
+    #[test]
+    fn pne_test_vectors() {
+        let key = [
+            0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf,
+            0x4f, 0x3c,
+        ];
+        let mut received = [
+            0x30, 0x80, 0x6d, 0xbb, 0xb5, 0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9,
+            0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a, 0x20, 0x3f, 0xbe, 0x2e, 0x32, 0x17, 0xfc,
+            0x5b, 0x88, 0x55,
+        ];
+        let alg = PacketNumberEncryptionAlgorithm::AesCtr128;
+        // Cheating a little bit here...
+        let sample_offset = 5;
+        let (header, payload) = received.split_at_mut(sample_offset);
+        let sample = &payload[..alg.sample_size()];
+        alg.decrypt(&key, sample, &mut header[1..]);
+        assert_eq!(&header[1..], [0xba, 0xba, 0xc0, 0x01]);
+        alg.encrypt(&key, sample, &mut header[1..]);
+        assert_eq!(&header[1..], [0x80, 0x6d, 0xbb, 0xb5]);
     }
 }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -16,7 +16,7 @@ use connection::{
 };
 use crypto::{self, reset_token_for, ClientConfig, ConnectError, Crypto, ServerConfig};
 use packet::{
-    set_payload_length, types, ConnectionId, Header, HeaderError, Packet, PacketNumber,
+    set_payload_length, ConnectionId, Header, HeaderError, LongType, Packet, PacketNumber,
     AEAD_TAG_SIZE,
 };
 use {
@@ -383,7 +383,7 @@ impl Endpoint {
         } = header
         {
             match ty {
-                types::INITIAL => {
+                LongType::Initial => {
                     if datagram_len >= MIN_INITIAL_SIZE {
                         self.handle_initial(
                             now,
@@ -413,7 +413,7 @@ impl Endpoint {
                     return;
                 }*/
                 _ => {
-                    debug!(self.ctx.log, "ignoring packet for unknown connection {connection} with unexpected type {type:02x}",
+                    debug!(self.ctx.log, "ignoring packet for unknown connection {connection} with unexpected type {type:?}",
                            connection=destination_id, type=ty);
                     return;
                 }
@@ -1102,7 +1102,7 @@ where
 {
     let mut buf = Vec::<u8>::new();
     Header::Long {
-        ty: types::HANDSHAKE,
+        ty: LongType::Handshake,
         destination_id: *remote_id,
         source_id: *local_id,
         number: packet_number,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -837,22 +837,7 @@ impl Endpoint {
         stream: StreamId,
         data: &[u8],
     ) -> Result<usize, WriteError> {
-        let r = self.connections[conn.0].write(&self.ctx.config, stream, data);
-        match r {
-            Ok(n) => {
-                self.ctx.dirty_conns.insert(conn);
-                trace!(self.ctx.log, "write"; "connection" => %self.connections[conn.0].loc_cid, "stream" => stream.0, "len" => n)
-            }
-            Err(WriteError::Blocked) => {
-                if self.connections[conn.0].congestion_blocked() {
-                    trace!(self.ctx.log, "write blocked by congestion"; "connection" => %self.connections[conn.0].loc_cid);
-                } else {
-                    trace!(self.ctx.log, "write blocked by flow control"; "connection" => %self.connections[conn.0].loc_cid, "stream" => stream.0);
-                }
-            }
-            _ => {}
-        }
-        r
+        self.connections[conn.0].write(&mut self.ctx, stream, data)
     }
 
     /// Indicate that no more data will be sent on a stream

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -12,15 +12,14 @@ use slog::{self, Logger};
 
 use coding::BufMutExt;
 use connection::{
-    state, Connection, ConnectionError, ConnectionHandle, ReadError, State, WriteError,
+    handshake_close, Connection, ConnectionError, ConnectionHandle, ReadError, State, WriteError,
 };
 use crypto::{self, reset_token_for, ClientConfig, ConnectError, Crypto, ServerConfig};
 use packet::{
     set_payload_length, ConnectionId, Header, HeaderError, LongType, Packet, PacketNumber,
-    AEAD_TAG_SIZE,
 };
 use {
-    frame, Directionality, Side, StreamId, TransportError, MAX_CID_SIZE, MIN_INITIAL_SIZE, MIN_MTU,
+    Directionality, Side, StreamId, TransportError, MAX_CID_SIZE, MIN_INITIAL_SIZE,
     RESET_TOKEN_SIZE, VERSION,
 };
 
@@ -1019,43 +1018,4 @@ impl slog::Value for Timer {
     ) -> slog::Result {
         serializer.emit_arguments(key, &format_args!("{:?}", self))
     }
-}
-
-fn handshake_close<R>(
-    crypto: &Crypto,
-    remote_id: &ConnectionId,
-    local_id: &ConnectionId,
-    packet_number: u32,
-    reason: R,
-    tls_alert: Option<&[u8]>,
-) -> Box<[u8]>
-where
-    R: Into<state::CloseReason>,
-{
-    let mut buf = Vec::<u8>::new();
-    Header::Long {
-        ty: LongType::Handshake,
-        dst_cid: *remote_id,
-        src_cid: *local_id,
-        number: packet_number,
-    }.encode(&mut buf);
-    let header_len = buf.len();
-    let max_len = MIN_MTU - header_len as u16 - AEAD_TAG_SIZE as u16;
-    match reason.into() {
-        state::CloseReason::Application(ref x) => x.encode(&mut buf, max_len),
-        state::CloseReason::Connection(ref x) => x.encode(&mut buf, max_len),
-    }
-    if let Some(data) = tls_alert {
-        if !data.is_empty() {
-            frame::Stream {
-                id: StreamId(0),
-                fin: false,
-                offset: 0,
-                data,
-            }.encode(false, &mut buf);
-        }
-    }
-    set_payload_length(&mut buf, header_len);
-    crypto.encrypt(packet_number as u64, &mut buf, header_len);
-    buf.into()
 }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -515,7 +515,7 @@ impl Endpoint {
         header: &[u8],
         mut payload: BytesMut,
     ) {
-        let crypto = Crypto::new_handshake(&dest_id, Side::Server);
+        let crypto = Crypto::new_initial(&dest_id, Side::Server);
         if crypto
             .decrypt(packet_number as u64, header, &mut payload)
             .is_err()

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -767,60 +767,7 @@ impl Endpoint {
                 self.ctx.dirty_conns.insert(conn); // Ensure the loss detection timer cancellation goes through
             }
             Timer::LossDetection => {
-                if self.connections[conn.0].awaiting_handshake {
-                    trace!(self.ctx.log, "retransmitting handshake packets"; "connection" => %self.connections[conn.0].loc_cid);
-                    let packets = self.connections[conn.0]
-                        .sent_packets
-                        .iter()
-                        .filter_map(
-                            |(&packet, info)| if info.handshake { Some(packet) } else { None },
-                        ).collect::<Vec<_>>();
-                    for number in packets {
-                        let mut info = self.connections[conn.0]
-                            .sent_packets
-                            .remove(&number)
-                            .unwrap();
-                        self.connections[conn.0].handshake_pending += info.retransmits;
-                        self.connections[conn.0].bytes_in_flight -= info.bytes as u64;
-                    }
-                    self.connections[conn.0].handshake_count += 1;
-                } else if self.connections[conn.0].loss_time != 0 {
-                    // Early retransmit or Time Loss Detection
-                    let largest = self.connections[conn.0].largest_acked_packet;
-                    self.connections[conn.0].detect_lost_packets(&self.ctx.config, now, largest);
-                } else if self.connections[conn.0].tlp_count < self.ctx.config.max_tlps {
-                    trace!(self.ctx.log, "sending TLP {number} in {pn}",
-                           number=self.connections[conn.0].tlp_count,
-                           pn=self.connections[conn.0].largest_sent_packet + 1;
-                           "outstanding" => ?self.connections[conn.0].sent_packets.keys().collect::<Vec<_>>(),
-                           "in flight" => self.connections[conn.0].bytes_in_flight);
-                    // Tail Loss Probe.
-                    self.ctx.io.push_back(Io::Transmit {
-                        destination: self.connections[conn.0].remote,
-                        packet: self.connections[conn.0].force_transmit(&self.ctx.config, now),
-                    });
-                    self.connections[conn.0].reset_idle_timeout(&self.ctx.config, now);
-                    self.connections[conn.0].tlp_count += 1;
-                } else {
-                    trace!(self.ctx.log, "RTO fired, retransmitting"; "pn" => self.connections[conn.0].largest_sent_packet + 1,
-                           "outstanding" => ?self.connections[conn.0].sent_packets.keys().collect::<Vec<_>>(),
-                           "in flight" => self.connections[conn.0].bytes_in_flight);
-                    // RTO
-                    if self.connections[conn.0].rto_count == 0 {
-                        self.connections[conn.0].largest_sent_before_rto =
-                            self.connections[conn.0].largest_sent_packet;
-                    }
-                    for _ in 0..2 {
-                        self.ctx.io.push_back(Io::Transmit {
-                            destination: self.connections[conn.0].remote,
-                            packet: self.connections[conn.0].force_transmit(&self.ctx.config, now),
-                        });
-                    }
-                    self.connections[conn.0].reset_idle_timeout(&self.ctx.config, now);
-                    self.connections[conn.0].rto_count += 1;
-                }
-                self.connections[conn.0].set_loss_detection_alarm(&self.ctx.config);
-                self.ctx.dirty_conns.insert(conn);
+                self.connections[conn.0].check_packet_loss(&mut self.ctx, now);
             }
         }
     }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -15,7 +15,7 @@ use connection::{
     handshake_close, Connection, ConnectionError, ConnectionHandle, ReadError, State, WriteError,
 };
 use crypto::{self, reset_token_for, ClientConfig, ConnectError, Crypto, ServerConfig};
-use packet::{ConnectionId, Header, HeaderError, Packet, PacketNumber, PartialDecode};
+use packet::{ConnectionId, Header, Packet, PacketDecodeError, PacketNumber, PartialDecode};
 use {
     Directionality, Side, StreamId, TransportError, LOCAL_ID_LEN, MAX_CID_SIZE, MIN_INITIAL_SIZE,
     RESET_TOKEN_SIZE, VERSION,
@@ -275,7 +275,7 @@ impl Endpoint {
                         }
                     }
                 }
-                Err(HeaderError::UnsupportedVersion {
+                Err(PacketDecodeError::UnsupportedVersion {
                     source,
                     destination,
                 }) => {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -474,7 +474,7 @@ impl Endpoint {
             mut payload,
         } = packet;
         let (src_cid, dst_cid, packet_number) = match header {
-            Header::Long {
+            Header::Initial {
                 src_cid,
                 dst_cid,
                 number,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -17,7 +17,7 @@ use connection::{
 use crypto::{self, reset_token_for, ClientConfig, ConnectError, Crypto, ServerConfig};
 use packet::{ConnectionId, Header, HeaderError, LongType, Packet, PacketNumber};
 use {
-    Directionality, Side, StreamId, TransportError, MAX_CID_SIZE, MIN_INITIAL_SIZE,
+    Directionality, Side, StreamId, TransportError, LOCAL_ID_LEN, MAX_CID_SIZE, MIN_INITIAL_SIZE,
     RESET_TOKEN_SIZE, VERSION,
 };
 
@@ -143,8 +143,6 @@ impl Context {
     }
 }
 
-const LOCAL_ID_LEN: usize = 8;
-
 /// Information that should be preserved between restarts for server endpoints.
 ///
 /// Keeping this around allows better behavior by clients that communicated with a previous instance of the same
@@ -266,7 +264,7 @@ impl Endpoint {
     pub fn handle(&mut self, now: u64, remote: SocketAddrV6, mut data: BytesMut) {
         let datagram_len = data.len();
         while !data.is_empty() {
-            let (packet, rest) = match Packet::decode(data, LOCAL_ID_LEN) {
+            let (packet, rest) = match Packet::decode(data) {
                 Ok(x) => x,
                 Err(HeaderError::UnsupportedVersion {
                     source,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -283,7 +283,6 @@ impl Endpoint {
                     // Negotiate versions
                     let mut buf = Vec::<u8>::new();
                     Header::VersionNegotiate {
-                        ty: self.ctx.rng.gen(),
                         source_id: destination,
                         destination_id: source,
                     }.encode(&mut buf);

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate aes_ctr;
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -172,6 +172,7 @@ impl coding::Codec for StreamId {
 // Useful internal constants
 //
 
+const LOCAL_ID_LEN: usize = 8;
 const RESET_TOKEN_SIZE: usize = 16;
 const MAX_CID_SIZE: usize = 18;
 const MIN_CID_SIZE: usize = 4;

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -36,34 +36,34 @@ impl Packet {
 pub enum Header {
     Long {
         ty: LongType,
-        source_id: ConnectionId,
-        destination_id: ConnectionId,
+        src_cid: ConnectionId,
+        dst_cid: ConnectionId,
         number: u32,
     },
     Retry {
-        source_id: ConnectionId,
-        destination_id: ConnectionId,
+        src_cid: ConnectionId,
+        dst_cid: ConnectionId,
         orig_dst_cid: ConnectionId,
     },
     Short {
-        id: ConnectionId,
+        dst_cid: ConnectionId,
         number: PacketNumber,
         key_phase: bool,
     },
     VersionNegotiate {
-        source_id: ConnectionId,
-        destination_id: ConnectionId,
+        src_cid: ConnectionId,
+        dst_cid: ConnectionId,
     },
 }
 
 impl Header {
-    pub fn destination_id(&self) -> ConnectionId {
+    pub fn dst_cid(&self) -> ConnectionId {
         use self::Header::*;
         match self {
-            Long { destination_id, .. } => *destination_id,
-            Retry { destination_id, .. } => *destination_id,
-            Short { id, .. } => *id,
-            VersionNegotiate { destination_id, .. } => *destination_id,
+            Long { dst_cid, .. } => *dst_cid,
+            Retry { dst_cid, .. } => *dst_cid,
+            Short { dst_cid, .. } => *dst_cid,
+            VersionNegotiate { dst_cid, .. } => *dst_cid,
         }
     }
 
@@ -89,7 +89,7 @@ impl Header {
                 ));
             }
             buf.copy_to_slice(&mut cid_stage[..dest_id_len]);
-            let id = ConnectionId::new(&cid_stage[..dest_id_len]);
+            let dst_cid = ConnectionId::new(&cid_stage[..dest_id_len]);
             let key_phase = first & KEY_PHASE_BIT != 0;
             let number = match first & 0b11 {
                 0x0 => PacketNumber::U8(buf.get()?),
@@ -103,7 +103,7 @@ impl Header {
                 buf.position() as usize,
                 packet.len() - buf.position() as usize,
                 Header::Short {
-                    id,
+                    dst_cid,
                     number,
                     key_phase,
                 },
@@ -127,23 +127,20 @@ impl Header {
         }
 
         buf.copy_to_slice(&mut cid_stage[0..dcil as usize]);
-        let destination_id = ConnectionId::new(&cid_stage[..dcil as usize]);
+        let dst_cid = ConnectionId::new(&cid_stage[..dcil as usize]);
         buf.copy_to_slice(&mut cid_stage[0..scil as usize]);
-        let source_id = ConnectionId::new(&cid_stage[..scil as usize]);
+        let src_cid = ConnectionId::new(&cid_stage[..scil as usize]);
 
         if version == 0 {
             return Ok((
                 buf.position() as usize,
                 packet.len() - buf.position() as usize,
-                Header::VersionNegotiate {
-                    source_id,
-                    destination_id,
-                },
+                Header::VersionNegotiate { src_cid, dst_cid },
             ));
         } else if version != VERSION {
             return Err(HeaderError::UnsupportedVersion {
-                source: source_id,
-                destination: destination_id,
+                source: src_cid,
+                destination: dst_cid,
             });
         }
 
@@ -157,8 +154,8 @@ impl Header {
                 buf.position() as usize,
                 packet.len() - buf.position() as usize,
                 Header::Retry {
-                    source_id,
-                    destination_id,
+                    src_cid,
+                    dst_cid,
                     orig_dst_cid,
                 },
             ));
@@ -176,8 +173,8 @@ impl Header {
             len as usize,
             Header::Long {
                 ty,
-                source_id,
-                destination_id,
+                src_cid,
+                dst_cid,
                 number,
             },
         ))
@@ -188,60 +185,60 @@ impl Header {
         match *self {
             Long {
                 ty,
-                ref source_id,
-                ref destination_id,
+                ref src_cid,
+                ref dst_cid,
                 number,
             } => {
                 w.write(u8::from(ty));
                 w.write(VERSION);
-                Self::encode_cids(w, destination_id, source_id);
+                Self::encode_cids(w, dst_cid, src_cid);
                 w.write::<u16>(0); // Placeholder for payload length; see `set_payload_length`
                 w.write(number);
             }
             Retry {
-                ref source_id,
-                ref destination_id,
+                ref src_cid,
+                ref dst_cid,
                 ref orig_dst_cid,
             } => {
                 w.write(u8::from(LongType::Retry));
                 w.write(VERSION);
-                Self::encode_cids(w, destination_id, source_id);
+                Self::encode_cids(w, dst_cid, src_cid);
                 w.write(orig_dst_cid.len() as u8);
                 w.put_slice(orig_dst_cid);
             }
             Short {
-                ref id,
+                ref dst_cid,
                 number,
                 key_phase,
             } => {
                 let ty = number.ty() | 0x30 | if key_phase { KEY_PHASE_BIT } else { 0 };
                 w.write(ty);
-                w.put_slice(id);
+                w.put_slice(dst_cid);
                 number.encode(w);
             }
             VersionNegotiate {
-                ref source_id,
-                ref destination_id,
+                ref src_cid,
+                ref dst_cid,
             } => {
                 w.write(0x80u8);
                 w.write::<u32>(0);
-                Self::encode_cids(w, destination_id, source_id);
+                Self::encode_cids(w, dst_cid, src_cid);
             }
         }
     }
 
-    fn encode_cids<W: BufMut>(w: &mut W, destination_id: &ConnectionId, source_id: &ConnectionId) {
-        let mut dcil = destination_id.len() as u8;
+    fn encode_cids<W: BufMut>(w: &mut W, dst_cid: &ConnectionId, src_cid: &ConnectionId) {
+        let mut dcil = dst_cid.len() as u8;
         if dcil > 0 {
             dcil -= 3;
         }
-        let mut scil = source_id.len() as u8;
+        let mut scil = src_cid.len() as u8;
         if scil > 0 {
             scil -= 3;
         }
         w.write(dcil << 4 | scil);
-        w.put_slice(destination_id);
-        w.put_slice(source_id);
+        w.put_slice(dst_cid);
+        w.put_slice(src_cid);
     }
 }
 

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use slog;
 
 use coding::{self, BufExt, BufMutExt};
-use {MAX_CID_SIZE, MIN_CID_SIZE, VERSION};
+use {LOCAL_ID_LEN, MAX_CID_SIZE, MIN_CID_SIZE, VERSION};
 
 pub struct Packet {
     pub header: Header,
@@ -14,11 +14,8 @@ pub struct Packet {
 }
 
 impl Packet {
-    pub fn decode(
-        mut packet: BytesMut,
-        dest_id_len: usize,
-    ) -> Result<(Self, BytesMut), HeaderError> {
-        let (header_len, payload_len, header) = Header::decode(&mut packet, dest_id_len)?;
+    pub fn decode(mut packet: BytesMut) -> Result<(Self, BytesMut), HeaderError> {
+        let (header_len, payload_len, header) = Header::decode(&mut packet)?;
         let header_data = packet.split_to(header_len).freeze();
         let payload = packet.split_to(payload_len);
         Ok((
@@ -74,22 +71,19 @@ impl Header {
         }
     }
 
-    fn decode(
-        packet: &mut BytesMut,
-        dest_id_len: usize,
-    ) -> Result<(usize, usize, Self), HeaderError> {
+    fn decode(packet: &mut BytesMut) -> Result<(usize, usize, Self), HeaderError> {
         let mut buf = io::Cursor::new(&packet[..]);
         let first = buf.get::<u8>()?;
         let mut cid_stage = [0; MAX_CID_SIZE];
 
         if first & LONG_HEADER_FORM == 0 {
-            if buf.remaining() < dest_id_len {
+            if buf.remaining() < LOCAL_ID_LEN {
                 return Err(HeaderError::InvalidHeader(
                     "destination connection ID longer than packet",
                 ));
             }
-            buf.copy_to_slice(&mut cid_stage[..dest_id_len]);
-            let dst_cid = ConnectionId::new(&cid_stage[..dest_id_len]);
+            buf.copy_to_slice(&mut cid_stage[..LOCAL_ID_LEN]);
+            let dst_cid = ConnectionId::new(&cid_stage[..LOCAL_ID_LEN]);
             let key_phase = first & KEY_PHASE_BIT != 0;
             let number = match first & 0b11 {
                 0x0 => PacketNumber::U8(buf.get()?),

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -46,7 +46,6 @@ pub enum Header {
         key_phase: bool,
     },
     VersionNegotiate {
-        ty: u8,
         source_id: ConnectionId,
         destination_id: ConnectionId,
     },
@@ -103,7 +102,6 @@ impl Header {
                     buf.position() as usize,
                     packet.len() - buf.position() as usize,
                     Header::VersionNegotiate {
-                        ty,
                         source_id,
                         destination_id,
                     },
@@ -198,11 +196,10 @@ impl Header {
                 number.encode(w);
             }
             VersionNegotiate {
-                ty,
                 ref source_id,
                 ref destination_id,
             } => {
-                w.write(0x80 | ty);
+                w.write(0x80u8);
                 w.write::<u32>(0);
                 let mut dcil = destination_id.len() as u8;
                 if dcil > 0 {

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -7,26 +7,154 @@ use slog;
 use coding::{self, BufExt, BufMutExt};
 use {LOCAL_ID_LEN, MAX_CID_SIZE, MIN_CID_SIZE, VERSION};
 
-pub struct Packet {
-    pub header: Header,
-    pub header_data: Bytes,
-    pub payload: BytesMut,
+// Due to packet number encryption, it is impossible to fully decode a header
+// (which includes a variable-length packet number) without crypto context.
+// The crypto context (represented by the `Crypto` type in Quinn) is usually
+// part of the `Connection`, or can be derived from the destination CID for
+// Initial packets.
+//
+// To cope with this, we decode the invariant header (which should be stable
+// across QUIC versions), which gives us the destination CID and allows us
+// to inspect the version and packet type (which depends on the version).
+// This information allows us to fully decode and decrypt the packet.
+pub struct PartialDecode {
+    invariant_header: InvariantHeader,
+    buf: io::Cursor<BytesMut>,
 }
 
-impl Packet {
-    pub fn decode(mut packet: BytesMut) -> Result<(Self, BytesMut), HeaderError> {
-        let (header_len, payload_len, header) = Header::decode(&mut packet)?;
-        let header_data = packet.split_to(header_len).freeze();
-        let payload = packet.split_to(payload_len);
+impl PartialDecode {
+    pub fn new(bytes: BytesMut) -> Result<Self, HeaderError> {
+        let mut buf = io::Cursor::new(bytes);
+        let invariant_header = InvariantHeader::decode(&mut buf)?;
+        Ok(Self {
+            invariant_header,
+            buf,
+        })
+    }
+
+    pub fn has_long_header(&self) -> bool {
+        use self::InvariantHeader::*;
+        match self.invariant_header {
+            Long { .. } => true,
+            Short { .. } => false,
+        }
+    }
+
+    pub fn is_initial(&self) -> bool {
+        use self::InvariantHeader::*;
+        match self.invariant_header {
+            Long {
+                version: VERSION,
+                first,
+                ..
+            } => LongType::from_byte(first) == Ok(LongType::Initial),
+            Long { .. } | Short { .. } => false,
+        }
+    }
+
+    pub fn dst_cid(&self) -> ConnectionId {
+        self.invariant_header.dst_cid()
+    }
+
+    pub fn finish(self) -> Result<(Packet, Option<BytesMut>), HeaderError> {
+        let Self {
+            invariant_header,
+            mut buf,
+        } = self;
+        let (header_len, payload_len, header, allow_coalesced) = match invariant_header {
+            InvariantHeader::Short { first, dst_cid } => {
+                let key_phase = first & KEY_PHASE_BIT != 0;
+                let number = match first & 0b11 {
+                    0x0 => PacketNumber::U8(buf.get()?),
+                    0x1 => PacketNumber::U16(buf.get()?),
+                    0x2 => PacketNumber::U32(buf.get()?),
+                    _ => {
+                        return Err(HeaderError::InvalidHeader("unknown packet type"));
+                    }
+                };
+                (
+                    buf.position() as usize,
+                    buf.remaining(),
+                    Header::Short {
+                        dst_cid,
+                        number,
+                        key_phase,
+                    },
+                    false,
+                )
+            }
+            InvariantHeader::Long {
+                first,
+                version,
+                dst_cid,
+                src_cid,
+            } => {
+                if version == 0 {
+                    (
+                        buf.position() as usize,
+                        buf.remaining(),
+                        Header::VersionNegotiate { src_cid, dst_cid },
+                        false,
+                    )
+                } else {
+                    debug_assert_eq!(version, VERSION);
+                    let ty = LongType::from_byte(first)?;
+                    if let LongType::Retry = ty {
+                        let odcil = buf.get::<u8>()? as usize;
+                        let mut odci_stage = [0; 18];
+                        buf.copy_to_slice(&mut odci_stage[0..odcil]);
+                        let orig_dst_cid = ConnectionId::new(&odci_stage[..odcil]);
+                        (
+                            buf.position() as usize,
+                            buf.remaining(),
+                            Header::Retry {
+                                src_cid,
+                                dst_cid,
+                                orig_dst_cid,
+                            },
+                            false,
+                        )
+                    } else {
+                        let len = buf.get_var()?;
+                        let number = buf.get()?;
+                        let header_len = buf.position() as usize;
+                        if len > buf.remaining() as u64 {
+                            return Err(HeaderError::InvalidHeader("payload longer than packet"));
+                        }
+                        (
+                            header_len,
+                            len as usize,
+                            Header::Long {
+                                ty,
+                                src_cid,
+                                dst_cid,
+                                number,
+                            },
+                            true,
+                        )
+                    }
+                }
+            }
+        };
+
+        let mut bytes = buf.into_inner();
+        let header_data = bytes.split_to(header_len).freeze();
+        let payload = bytes.split_to(payload_len);
         Ok((
             Packet {
                 header,
                 header_data,
                 payload,
             },
-            packet,
+            if allow_coalesced { Some(bytes) } else { None },
         ))
     }
+}
+
+pub struct Packet {
+    pub header: Header,
+    pub header_data: Bytes,
+    pub payload: BytesMut,
 }
 
 #[derive(Debug, Clone)]
@@ -54,126 +182,6 @@ pub enum Header {
 }
 
 impl Header {
-    pub fn dst_cid(&self) -> ConnectionId {
-        use self::Header::*;
-        match self {
-            Long { dst_cid, .. } => *dst_cid,
-            Retry { dst_cid, .. } => *dst_cid,
-            Short { dst_cid, .. } => *dst_cid,
-            VersionNegotiate { dst_cid, .. } => *dst_cid,
-        }
-    }
-
-    pub fn key_phase(&self) -> bool {
-        match *self {
-            Header::Short { key_phase, .. } => key_phase,
-            _ => false,
-        }
-    }
-
-    fn decode(packet: &mut BytesMut) -> Result<(usize, usize, Self), HeaderError> {
-        let mut buf = io::Cursor::new(&packet[..]);
-        let first = buf.get::<u8>()?;
-        let mut cid_stage = [0; MAX_CID_SIZE];
-
-        if first & LONG_HEADER_FORM == 0 {
-            if buf.remaining() < LOCAL_ID_LEN {
-                return Err(HeaderError::InvalidHeader(
-                    "destination connection ID longer than packet",
-                ));
-            }
-            buf.copy_to_slice(&mut cid_stage[..LOCAL_ID_LEN]);
-            let dst_cid = ConnectionId::new(&cid_stage[..LOCAL_ID_LEN]);
-            let key_phase = first & KEY_PHASE_BIT != 0;
-            let number = match first & 0b11 {
-                0x0 => PacketNumber::U8(buf.get()?),
-                0x1 => PacketNumber::U16(buf.get()?),
-                0x2 => PacketNumber::U32(buf.get()?),
-                _ => {
-                    return Err(HeaderError::InvalidHeader("unknown packet type"));
-                }
-            };
-            return Ok((
-                buf.position() as usize,
-                packet.len() - buf.position() as usize,
-                Header::Short {
-                    dst_cid,
-                    number,
-                    key_phase,
-                },
-            ));
-        }
-
-        let version = buf.get::<u32>()?;
-        let ci_lengths = buf.get::<u8>()?;
-        let mut dcil = ci_lengths >> 4;
-        if dcil > 0 {
-            dcil += 3
-        };
-        let mut scil = ci_lengths & 0xF;
-        if scil > 0 {
-            scil += 3
-        };
-        if buf.remaining() < (dcil + scil) as usize {
-            return Err(HeaderError::InvalidHeader(
-                "connection IDs longer than packet",
-            ));
-        }
-
-        buf.copy_to_slice(&mut cid_stage[0..dcil as usize]);
-        let dst_cid = ConnectionId::new(&cid_stage[..dcil as usize]);
-        buf.copy_to_slice(&mut cid_stage[0..scil as usize]);
-        let src_cid = ConnectionId::new(&cid_stage[..scil as usize]);
-
-        if version == 0 {
-            return Ok((
-                buf.position() as usize,
-                packet.len() - buf.position() as usize,
-                Header::VersionNegotiate { src_cid, dst_cid },
-            ));
-        } else if version != VERSION {
-            return Err(HeaderError::UnsupportedVersion {
-                source: src_cid,
-                destination: dst_cid,
-            });
-        }
-
-        let ty = LongType::from_byte(first)?;
-        if let LongType::Retry = ty {
-            let odcil = buf.get::<u8>()? as usize;
-            let mut odci_stage = [0; 18];
-            buf.copy_to_slice(&mut odci_stage[0..odcil]);
-            let orig_dst_cid = ConnectionId::new(&cid_stage[..odcil]);
-            return Ok((
-                buf.position() as usize,
-                packet.len() - buf.position() as usize,
-                Header::Retry {
-                    src_cid,
-                    dst_cid,
-                    orig_dst_cid,
-                },
-            ));
-        }
-
-        let len = buf.get_var()?;
-        let number = buf.get()?;
-        let header_len = buf.position() as usize;
-        if buf.position() + len > packet.len() as u64 {
-            return Err(HeaderError::InvalidHeader("payload longer than packet"));
-        }
-
-        Ok((
-            header_len,
-            len as usize,
-            Header::Long {
-                ty,
-                src_cid,
-                dst_cid,
-                number,
-            },
-        ))
-    }
-
     pub fn encode<W: BufMut>(&self, w: &mut W) {
         use self::Header::*;
         match *self {
@@ -233,6 +241,80 @@ impl Header {
         w.write(dcil << 4 | scil);
         w.put_slice(dst_cid);
         w.put_slice(src_cid);
+    }
+}
+
+pub enum InvariantHeader {
+    Long {
+        first: u8,
+        version: u32,
+        dst_cid: ConnectionId,
+        src_cid: ConnectionId,
+    },
+    Short {
+        first: u8,
+        dst_cid: ConnectionId,
+    },
+}
+
+impl InvariantHeader {
+    fn dst_cid(&self) -> ConnectionId {
+        use self::InvariantHeader::*;
+        match self {
+            Long { dst_cid, .. } => *dst_cid,
+            Short { dst_cid, .. } => *dst_cid,
+        }
+    }
+
+    fn decode<R: Buf>(buf: &mut R) -> Result<Self, HeaderError> {
+        let first = buf.get::<u8>()?;
+        let mut cid_stage = [0; MAX_CID_SIZE];
+
+        if first & LONG_HEADER_FORM == 0 {
+            if buf.remaining() < LOCAL_ID_LEN {
+                return Err(HeaderError::InvalidHeader(
+                    "destination connection ID longer than packet",
+                ));
+            }
+            buf.copy_to_slice(&mut cid_stage[..LOCAL_ID_LEN]);
+            let dst_cid = ConnectionId::new(&cid_stage[..LOCAL_ID_LEN]);
+            Ok(InvariantHeader::Short { first, dst_cid })
+        } else {
+            let version = buf.get::<u32>()?;
+            let ci_lengths = buf.get::<u8>()?;
+            let mut dcil = ci_lengths >> 4;
+            if dcil > 0 {
+                dcil += 3
+            };
+            let mut scil = ci_lengths & 0xF;
+            if scil > 0 {
+                scil += 3
+            };
+            if buf.remaining() < (dcil + scil) as usize {
+                return Err(HeaderError::InvalidHeader(
+                    "connection IDs longer than packet",
+                ));
+            }
+
+            buf.copy_to_slice(&mut cid_stage[0..dcil as usize]);
+            let dst_cid = ConnectionId::new(&cid_stage[..dcil as usize]);
+            buf.copy_to_slice(&mut cid_stage[0..scil as usize]);
+            let src_cid = ConnectionId::new(&cid_stage[..scil as usize]);
+
+            if version > 0 && version != VERSION {
+                return Err(HeaderError::UnsupportedVersion {
+                    source: src_cid,
+                    destination: dst_cid,
+                });
+            }
+
+            Ok(InvariantHeader::Long {
+                first,
+                version,
+                dst_cid,
+                src_cid,
+            })
+        }
     }
 }
 
@@ -301,7 +383,7 @@ impl PacketNumber {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LongType {
     Initial,
     Retry,

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -172,17 +172,7 @@ impl Header {
             } => {
                 w.write(u8::from(ty));
                 w.write(VERSION);
-                let mut dcil = destination_id.len() as u8;
-                if dcil > 0 {
-                    dcil -= 3;
-                }
-                let mut scil = source_id.len() as u8;
-                if scil > 0 {
-                    scil -= 3;
-                }
-                w.write(dcil << 4 | scil);
-                w.put_slice(destination_id);
-                w.put_slice(source_id);
+                Self::encode_cids(w, destination_id, source_id);
                 w.write::<u16>(0); // Placeholder for payload length; see `set_payload_length`
                 w.write(number);
             }
@@ -202,19 +192,23 @@ impl Header {
             } => {
                 w.write(0x80u8);
                 w.write::<u32>(0);
-                let mut dcil = destination_id.len() as u8;
-                if dcil > 0 {
-                    dcil -= 3;
-                }
-                let mut scil = source_id.len() as u8;
-                if scil > 0 {
-                    scil -= 3;
-                }
-                w.write(dcil << 4 | scil);
-                w.put_slice(destination_id);
-                w.put_slice(source_id);
+                Self::encode_cids(w, destination_id, source_id);
             }
         }
+    }
+
+    fn encode_cids<W: BufMut>(w: &mut W, destination_id: &ConnectionId, source_id: &ConnectionId) {
+        let mut dcil = destination_id.len() as u8;
+        if dcil > 0 {
+            dcil -= 3;
+        }
+        let mut scil = source_id.len() as u8;
+        if scil > 0 {
+            scil -= 3;
+        }
+        w.write(dcil << 4 | scil);
+        w.put_slice(destination_id);
+        w.put_slice(source_id);
     }
 }
 

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -35,7 +35,7 @@ impl Packet {
 #[derive(Debug, Clone)]
 pub enum Header {
     Long {
-        ty: u8,
+        ty: LongType,
         source_id: ConnectionId,
         destination_id: ConnectionId,
         number: u32,
@@ -73,9 +73,8 @@ impl Header {
         dest_id_len: usize,
     ) -> Result<(usize, usize, Self), HeaderError> {
         let mut buf = io::Cursor::new(&packet[..]);
-        let ty = buf.get::<u8>()?;
-        let long = ty & 0x80 != 0;
-        let ty = ty & !0x80;
+        let first = buf.get::<u8>()?;
+        let long = first & LONG_HEADER_FORM != 0;
         let mut cid_stage = [0; MAX_CID_SIZE];
         if long {
             let version = buf.get::<u32>()?;
@@ -107,6 +106,7 @@ impl Header {
                     },
                 )),
                 VERSION => {
+                    let ty = LongType::from_byte(first)?;
                     let len = buf.get_var()?;
                     let number = buf.get()?;
                     let header_len = buf.position() as usize;
@@ -139,8 +139,8 @@ impl Header {
             }
             buf.copy_to_slice(&mut cid_stage[..dest_id_len]);
             let id = ConnectionId::new(&cid_stage[..dest_id_len]);
-            let key_phase = ty & KEY_PHASE_BIT != 0;
-            let number = match ty & 0b11 {
+            let key_phase = first & KEY_PHASE_BIT != 0;
+            let number = match first & 0b11 {
                 0x0 => PacketNumber::U8(buf.get()?),
                 0x1 => PacketNumber::U16(buf.get()?),
                 0x2 => PacketNumber::U32(buf.get()?),
@@ -169,7 +169,7 @@ impl Header {
                 ref destination_id,
                 number,
             } => {
-                w.write(0b1000_0000 | ty);
+                w.write(u8::from(ty));
                 w.write(VERSION);
                 let mut dcil = destination_id.len() as u8;
                 if dcil > 0 {
@@ -282,6 +282,51 @@ impl PacketNumber {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum LongType {
+    Initial,
+    Retry,
+    Handshake,
+    ZeroRtt,
+}
+
+impl LongType {
+    fn from_byte(b: u8) -> Result<Self, HeaderError> {
+        use self::LongType::*;
+        debug_assert_eq!(b & LONG_HEADER_FORM, LONG_HEADER_FORM);
+        match b ^ LONG_HEADER_FORM {
+            0x7f => Ok(Initial),
+            0x7e => Ok(Retry),
+            0x7d => Ok(Handshake),
+            0x7c => Ok(ZeroRtt),
+            _ => Err(HeaderError::InvalidLongHeaderType(b)),
+        }
+    }
+}
+
+impl From<LongType> for u8 {
+    fn from(ty: LongType) -> u8 {
+        use self::LongType::*;
+        LONG_HEADER_FORM | match ty {
+            Initial => 0x7f,
+            Retry => 0x7e,
+            Handshake => 0x7d,
+            ZeroRtt => 0x7c,
+        }
+    }
+}
+
+impl slog::Value for LongType {
+    fn serialize(
+        &self,
+        _: &slog::Record,
+        key: slog::Key,
+        serializer: &mut slog::Serializer,
+    ) -> slog::Result {
+        serializer.emit_arguments(key, &format_args!("{:?}", self))
+    }
+}
+
 #[derive(Debug, Fail, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum HeaderError {
     #[fail(display = "unsupported version")]
@@ -291,6 +336,8 @@ pub enum HeaderError {
     },
     #[fail(display = "invalid header: {}", _0)]
     InvalidHeader(&'static str),
+    #[fail(display = "invalid long header type: {:02x}", _0)]
+    InvalidLongHeaderType(u8),
 }
 
 impl From<coding::UnexpectedEnd> for HeaderError {
@@ -374,11 +421,5 @@ pub fn set_payload_length(packet: &mut [u8], header_len: usize) {
 }
 
 pub const AEAD_TAG_SIZE: usize = 16;
+const LONG_HEADER_FORM: u8 = 0x80;
 const KEY_PHASE_BIT: u8 = 0x40;
-
-pub mod types {
-    pub const INITIAL: u8 = 0x7F;
-    pub const RETRY: u8 = 0x7E;
-    //pub const ZERO_RTT: u8 = 0x7C;
-    pub const HANDSHAKE: u8 = 0x7D;
-}

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -7,191 +7,10 @@ use slog;
 use coding::{self, BufExt, BufMutExt};
 use {MAX_CID_SIZE, MIN_CID_SIZE, VERSION};
 
-#[derive(Debug, Clone)]
-pub enum Header {
-    Long {
-        ty: u8,
-        source_id: ConnectionId,
-        destination_id: ConnectionId,
-        number: u32,
-    },
-    Short {
-        id: ConnectionId,
-        number: PacketNumber,
-        key_phase: bool,
-    },
-    VersionNegotiate {
-        ty: u8,
-        source_id: ConnectionId,
-        destination_id: ConnectionId,
-    },
-}
-
-impl Header {
-    pub fn destination_id(&self) -> ConnectionId {
-        use self::Header::*;
-        match self {
-            Long { destination_id, .. } => *destination_id,
-            Short { id, .. } => *id,
-            VersionNegotiate { destination_id, .. } => *destination_id,
-        }
-    }
-
-    pub fn key_phase(&self) -> bool {
-        match *self {
-            Header::Short { key_phase, .. } => key_phase,
-            _ => false,
-        }
-    }
-}
-
-// An encoded packet number
-#[derive(Debug, Copy, Clone)]
-pub enum PacketNumber {
-    U8(u8),
-    U16(u16),
-    U32(u32),
-}
-
-impl PacketNumber {
-    pub fn new(n: u64, largest_acked: u64) -> Self {
-        if largest_acked == 0 {
-            return PacketNumber::U32(n as u32);
-        }
-        let range = (n - largest_acked) / 2;
-        if range < 1 << 8 {
-            PacketNumber::U8(n as u8)
-        } else if range < 1 << 16 {
-            PacketNumber::U16(n as u16)
-        } else if range < 1 << 32 {
-            PacketNumber::U32(n as u32)
-        } else {
-            panic!("packet number too large to encode")
-        }
-    }
-
-    fn ty(self) -> u8 {
-        use self::PacketNumber::*;
-        match self {
-            U8(_) => 0x00,
-            U16(_) => 0x01,
-            U32(_) => 0x02,
-        }
-    }
-
-    pub fn encode<W: BufMut>(self, w: &mut W) {
-        use self::PacketNumber::*;
-        match self {
-            U8(x) => w.write(x),
-            U16(x) => w.write(x),
-            U32(x) => w.write(x),
-        }
-    }
-
-    pub fn expand(self, prev: u64) -> u64 {
-        use self::PacketNumber::*;
-        let t = prev + 1;
-        // Compute missing bits that minimize the difference from expected
-        let d = match self {
-            U8(_) => 1 << 8,
-            U16(_) => 1 << 16,
-            U32(_) => 1 << 32,
-        };
-        let x = match self {
-            U8(x) => x as u64,
-            U16(x) => x as u64,
-            U32(x) => x as u64,
-        };
-        if t > d / 2 {
-            x + d * ((t + d / 2 - x) / d)
-        } else {
-            x % d
-        }
-    }
-}
-
-const KEY_PHASE_BIT: u8 = 0x40;
-
-impl Header {
-    pub fn encode<W: BufMut>(&self, w: &mut W) {
-        use self::Header::*;
-        match *self {
-            Long {
-                ty,
-                ref source_id,
-                ref destination_id,
-                number,
-            } => {
-                w.write(0b1000_0000 | ty);
-                w.write(VERSION);
-                let mut dcil = destination_id.len() as u8;
-                if dcil > 0 {
-                    dcil -= 3;
-                }
-                let mut scil = source_id.len() as u8;
-                if scil > 0 {
-                    scil -= 3;
-                }
-                w.write(dcil << 4 | scil);
-                w.put_slice(destination_id);
-                w.put_slice(source_id);
-                w.write::<u16>(0); // Placeholder for payload length; see `set_payload_length`
-                w.write(number);
-            }
-            Short {
-                ref id,
-                number,
-                key_phase,
-            } => {
-                let ty = number.ty() | 0x30 | if key_phase { KEY_PHASE_BIT } else { 0 };
-                w.write(ty);
-                w.put_slice(id);
-                number.encode(w);
-            }
-            VersionNegotiate {
-                ty,
-                ref source_id,
-                ref destination_id,
-            } => {
-                w.write(0x80 | ty);
-                w.write::<u32>(0);
-                let mut dcil = destination_id.len() as u8;
-                if dcil > 0 {
-                    dcil -= 3;
-                }
-                let mut scil = source_id.len() as u8;
-                if scil > 0 {
-                    scil -= 3;
-                }
-                w.write(dcil << 4 | scil);
-                w.put_slice(destination_id);
-                w.put_slice(source_id);
-            }
-        }
-    }
-}
-
 pub struct Packet {
     pub header: Header,
     pub header_data: Bytes,
     pub payload: BytesMut,
-}
-
-#[derive(Debug, Fail, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum HeaderError {
-    #[fail(display = "unsupported version")]
-    UnsupportedVersion {
-        source: ConnectionId,
-        destination: ConnectionId,
-    },
-    #[fail(display = "invalid header: {}", _0)]
-    InvalidHeader(&'static str),
-}
-
-impl From<coding::UnexpectedEnd> for HeaderError {
-    fn from(_: coding::UnexpectedEnd) -> Self {
-        HeaderError::InvalidHeader("unexpected end of packet")
-    }
 }
 
 impl Packet {
@@ -301,6 +120,183 @@ impl Packet {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum Header {
+    Long {
+        ty: u8,
+        source_id: ConnectionId,
+        destination_id: ConnectionId,
+        number: u32,
+    },
+    Short {
+        id: ConnectionId,
+        number: PacketNumber,
+        key_phase: bool,
+    },
+    VersionNegotiate {
+        ty: u8,
+        source_id: ConnectionId,
+        destination_id: ConnectionId,
+    },
+}
+
+impl Header {
+    pub fn destination_id(&self) -> ConnectionId {
+        use self::Header::*;
+        match self {
+            Long { destination_id, .. } => *destination_id,
+            Short { id, .. } => *id,
+            VersionNegotiate { destination_id, .. } => *destination_id,
+        }
+    }
+
+    pub fn key_phase(&self) -> bool {
+        match *self {
+            Header::Short { key_phase, .. } => key_phase,
+            _ => false,
+        }
+    }
+
+    pub fn encode<W: BufMut>(&self, w: &mut W) {
+        use self::Header::*;
+        match *self {
+            Long {
+                ty,
+                ref source_id,
+                ref destination_id,
+                number,
+            } => {
+                w.write(0b1000_0000 | ty);
+                w.write(VERSION);
+                let mut dcil = destination_id.len() as u8;
+                if dcil > 0 {
+                    dcil -= 3;
+                }
+                let mut scil = source_id.len() as u8;
+                if scil > 0 {
+                    scil -= 3;
+                }
+                w.write(dcil << 4 | scil);
+                w.put_slice(destination_id);
+                w.put_slice(source_id);
+                w.write::<u16>(0); // Placeholder for payload length; see `set_payload_length`
+                w.write(number);
+            }
+            Short {
+                ref id,
+                number,
+                key_phase,
+            } => {
+                let ty = number.ty() | 0x30 | if key_phase { KEY_PHASE_BIT } else { 0 };
+                w.write(ty);
+                w.put_slice(id);
+                number.encode(w);
+            }
+            VersionNegotiate {
+                ty,
+                ref source_id,
+                ref destination_id,
+            } => {
+                w.write(0x80 | ty);
+                w.write::<u32>(0);
+                let mut dcil = destination_id.len() as u8;
+                if dcil > 0 {
+                    dcil -= 3;
+                }
+                let mut scil = source_id.len() as u8;
+                if scil > 0 {
+                    scil -= 3;
+                }
+                w.write(dcil << 4 | scil);
+                w.put_slice(destination_id);
+                w.put_slice(source_id);
+            }
+        }
+    }
+}
+
+// An encoded packet number
+#[derive(Debug, Copy, Clone)]
+pub enum PacketNumber {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+}
+
+impl PacketNumber {
+    pub fn new(n: u64, largest_acked: u64) -> Self {
+        if largest_acked == 0 {
+            return PacketNumber::U32(n as u32);
+        }
+        let range = (n - largest_acked) / 2;
+        if range < 1 << 8 {
+            PacketNumber::U8(n as u8)
+        } else if range < 1 << 16 {
+            PacketNumber::U16(n as u16)
+        } else if range < 1 << 32 {
+            PacketNumber::U32(n as u32)
+        } else {
+            panic!("packet number too large to encode")
+        }
+    }
+
+    fn ty(self) -> u8 {
+        use self::PacketNumber::*;
+        match self {
+            U8(_) => 0x00,
+            U16(_) => 0x01,
+            U32(_) => 0x02,
+        }
+    }
+
+    pub fn encode<W: BufMut>(self, w: &mut W) {
+        use self::PacketNumber::*;
+        match self {
+            U8(x) => w.write(x),
+            U16(x) => w.write(x),
+            U32(x) => w.write(x),
+        }
+    }
+
+    pub fn expand(self, prev: u64) -> u64 {
+        use self::PacketNumber::*;
+        let t = prev + 1;
+        // Compute missing bits that minimize the difference from expected
+        let d = match self {
+            U8(_) => 1 << 8,
+            U16(_) => 1 << 16,
+            U32(_) => 1 << 32,
+        };
+        let x = match self {
+            U8(x) => x as u64,
+            U16(x) => x as u64,
+            U32(x) => x as u64,
+        };
+        if t > d / 2 {
+            x + d * ((t + d / 2 - x) / d)
+        } else {
+            x % d
+        }
+    }
+}
+
+#[derive(Debug, Fail, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum HeaderError {
+    #[fail(display = "unsupported version")]
+    UnsupportedVersion {
+        source: ConnectionId,
+        destination: ConnectionId,
+    },
+    #[fail(display = "invalid header: {}", _0)]
+    InvalidHeader(&'static str),
+}
+
+impl From<coding::UnexpectedEnd> for HeaderError {
+    fn from(_: coding::UnexpectedEnd) -> Self {
+        HeaderError::InvalidHeader("unexpected end of packet")
+    }
+}
+
 /// Protocol-level identifier for a connection.
 ///
 /// Mainly useful for identifying this connection's packets on the wire with tools like Wireshark.
@@ -308,19 +304,6 @@ impl Packet {
 pub struct ConnectionId {
     pub len: u8,
     pub bytes: [u8; MAX_CID_SIZE],
-}
-
-impl ::std::ops::Deref for ConnectionId {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        &self.bytes[0..self.len as usize]
-    }
-}
-
-impl ::std::ops::DerefMut for ConnectionId {
-    fn deref_mut(&mut self) -> &mut [u8] {
-        &mut self.bytes[0..self.len as usize]
-    }
 }
 
 impl ConnectionId {
@@ -346,6 +329,19 @@ impl ConnectionId {
         rng.fill_bytes(&mut rng_bytes);
         res.bytes[..len as usize].clone_from_slice(&rng_bytes[..len as usize]);
         res
+    }
+}
+
+impl ::std::ops::Deref for ConnectionId {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.bytes[0..self.len as usize]
+    }
+}
+
+impl ::std::ops::DerefMut for ConnectionId {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes[0..self.len as usize]
     }
 }
 
@@ -376,6 +372,7 @@ pub fn set_payload_length(packet: &mut [u8], header_len: usize) {
 }
 
 pub const AEAD_TAG_SIZE: usize = 16;
+const KEY_PHASE_BIT: u8 = 0x40;
 
 pub mod types {
     pub const INITIAL: u8 = 0x7F;

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -396,7 +396,7 @@ fn version_negotiate() {
     assert_matches!(io, Some(Io::Transmit { .. }));
     if let Some(Io::Transmit { packet, .. }) = io {
         assert!(packet[0] | 0x80 != 0);
-        assert!(&packet[1..14] == hex!("00000000 11 00000000 00000000"));
+        assert_eq!(&packet[1..14], hex!("00000000 11 00000000 00000000"));
         assert!(
             packet[14..]
                 .chunks(4)


### PR DESCRIPTION
Sorry about the slow progress (and the messy state of the code so far). The month ended up seeing way more action than I like and this task turned out to require a bit more planning than I first expected. Still not quite sure how to best do the parameter parsing for `read()`, since the "common" and server-specific params may be in any order. Maybe something around a mutable TransportParameters that tries to parse & set a single field per call?

(eventually)
Closes #30 