### PR TITLE
Makes `write()` return `Err` when stream is closed

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2603,7 +2603,7 @@ impl Connection {
                 .streams
                 .streams
                 .get_mut(&stream)
-                .expect("stream already closed")
+                .ok_or(WriteError::Stopped {error_code: 0})?
                 .send_mut()
                 .unwrap();
             (


### PR DESCRIPTION
...instead of panicking.

Basically, I have a server that accepts a client, opens a stream to it,
sends a message to it, and closes the stream.  By accident I had the
client trying to send a message back on the same stream, which panicked,
on the `write()`, 'cause it was already closed.  This makes the write
return `Err` instead.

This doesn't QUITE work right still, I think it messes up the state
in the server side somehow.  If I run a server, then run a client
the client properly says "that stream is closed" on the write.
But when I run it again without restarting the server then the client
never manages to connect to the server again, and times out.
The server never even sees an incoming connection.

This is still a step up for me, so I'm submitting this PR.  XD

Oh, also, I don't know what error code the error should be.