### PR TITLE
Tweak solicited RESET_STREAM error code to match recommendation

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1861,7 +1861,7 @@ impl Connection {
                         ));
                         return Err(TransportError::PROTOCOL_VIOLATION.into());
                     }
-                    self.reset(ctx, id, 0);
+                    self.reset(ctx, id, error_code);
                     self.streams
                         .streams
                         .get_mut(&id)

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -528,7 +528,7 @@ fn stop_stream() {
     assert_matches!(pair.server.read_unordered(server_conn, s), Ok((ref data, 0)) if data == MSG);
     assert_matches!(
         pair.server.read_unordered(server_conn, s),
-        Err(ReadError::Reset { error_code: 0 })
+        Err(ReadError::Reset { error_code: ERROR })
     );
 
     assert_matches!(


### PR DESCRIPTION
>  An endpoint that receives a STOP_SENDING frame MUST send a RESET_STREAM frame for that stream [and] SHOULD copy the error code from the STOP_SENDING frame