### PR TITLE
Remove Blake2 and use SHA512_256 for reset_token instead

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -19,7 +19,6 @@ maintenance = { status = "experimental" }
 dangerous_configuration = ["rustls/dangerous_configuration"]
 
 [dependencies]
-blake2 = "0.8"
 byteorder = "1.1"
 bytes = "0.4.7"
 constant_time_eq = "0.1"

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -221,7 +221,7 @@ pub fn make_tls(
         None => {
             let server_params = TransportParameters {
                 stateless_reset_token: Some(reset_token_for(
-                    &ctx.listen_keys.as_ref().unwrap().reset,
+                    &ctx.listen_keys.as_ref().unwrap().reset_key,
                     &local_id,
                 )),
                 ..TransportParameters::new(&ctx.config)

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -221,7 +221,7 @@ pub fn make_tls(
         None => {
             let server_params = TransportParameters {
                 stateless_reset_token: Some(reset_token_for(
-                    &ctx.listen_keys.as_ref().unwrap().reset_key,
+                    &ctx.listen_keys.as_ref().unwrap().reset,
                     &local_id,
                 )),
                 ..TransportParameters::new(&ctx.config)

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -87,9 +87,8 @@ pub const ACK_DELAY_EXPONENT: u8 = 3;
 /// Magic value used to indicate 0-RTT support in NewSessionTicket
 //pub const TLS_MAX_EARLY_DATA: u32 = 0xffff_ffff;
 
-pub fn reset_token_for(key: &[u8], id: &ConnectionId) -> [u8; RESET_TOKEN_SIZE] {
-    let mac = SigningKey::new(&digest::SHA512_256, key);
-    let signature = hmac::sign(&mac, id);
+pub fn reset_token_for(key: &SigningKey, id: &ConnectionId) -> [u8; RESET_TOKEN_SIZE] {
+    let signature = hmac::sign(key, id);
     // TODO: Server ID??
     let mut result = [0; RESET_TOKEN_SIZE];
     result.copy_from_slice(&signature.as_ref()[..RESET_TOKEN_SIZE]);

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
-extern crate blake2;
 extern crate byteorder;
 extern crate bytes;
 extern crate constant_time_eq;

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -123,7 +123,7 @@ impl Pair {
         let server = Endpoint::new(
             log.new(o!("side" => "Server")),
             server_config,
-            Some(*LISTEN_KEYS),
+            Some(LISTEN_KEYS.clone()),
         ).unwrap();
         let client = Endpoint::new(log.new(o!("side" => "Client")), client_config, None).unwrap();
 
@@ -385,8 +385,11 @@ fn version_negotiate() {
     let log = logger();
     let client_addr = "[::2]:7890".parse().unwrap();
     let config = server_config();
-    let mut server =
-        Endpoint::new(log.new(o!("peer" => "server")), config, Some(*LISTEN_KEYS)).unwrap();
+    let mut server = Endpoint::new(
+        log.new(o!("peer" => "server")),
+        config,
+        Some(LISTEN_KEYS.clone()),
+    ).unwrap();
     server.handle(
         0,
         client_addr,
@@ -451,7 +454,7 @@ fn stateless_reset() {
     pair.server.endpoint = Endpoint::new(
         pair.log.new(o!("peer" => "server")),
         Config::default(),
-        Some(*LISTEN_KEYS),
+        Some(LISTEN_KEYS.clone()),
     ).unwrap();
     pair.client.ping(client_conn);
     info!(pair.log, "resetting");


### PR DESCRIPTION
Creating this pull request to show what I've already done. I don't quite get the part where:

>  it would probably good to store the SigningKey in the ListenKeys and work from that

But I'll work on this now.