### PR TITLE
Retain sealing and opening key

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1898,7 +1898,8 @@ impl Connection {
         let mut sent = Retransmits::default();
 
         let (number, acks, ack_only, handshake) = {
-            let (number, header, crypto, pending) = if (!established || self.awaiting_handshake)
+            let (number, header, crypto, pending, crypto_level) = if (!established
+                || self.awaiting_handshake)
                 && (!self.handshake_pending.is_empty()
                     || (!self.pending_acks.is_empty() && self.permit_ack_only))
             {
@@ -1936,6 +1937,7 @@ impl Connection {
                     header,
                     &self.handshake_crypto,
                     &mut self.handshake_pending,
+                    CryptoLevel::Initial,
                 )
             } else if established {
                 //|| (self.zero_rtt_crypto.is_some() && self.side == Side::Client) {
@@ -1970,6 +1972,7 @@ impl Connection {
                     header,
                     self.crypto.as_ref().unwrap(),
                     &mut self.pending,
+                    CryptoLevel::OneRtt,
                 )
             } else {
                 return None;
@@ -2157,7 +2160,7 @@ impl Connection {
                     );
                 }
             }
-            if !crypto.is_1rtt() {
+            if crypto_level != CryptoLevel::OneRtt {
                 let pn_len = match header {
                     Header::Initial { number, .. } | Header::Long { number, .. } => number.len(),
                     _ => panic!("invalid header for packet payload length"),
@@ -2166,7 +2169,7 @@ impl Connection {
             }
             crypto.encrypt(number, &mut buf, header_len as usize);
             partial_encode.finish(&mut buf, crypto.pn_encrypt_key(), header_len as usize);
-            (number, acks, ack_only, crypto.is_initial())
+            (number, acks, ack_only, crypto_level == CryptoLevel::Initial)
         };
 
         // If we sent any acks, don't immediately resend them. Setting this even if ack_only is
@@ -2664,6 +2667,12 @@ impl Connection {
         }
         None
     }
+}
+
+#[derive(Eq, PartialEq)]
+enum CryptoLevel {
+    Initial,
+    OneRtt,
 }
 
 /// Extract stream 0 data from an Initial or Retry packet payload

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -99,13 +99,7 @@ pub fn reset_token_for(key: &SigningKey, id: &ConnectionId) -> [u8; RESET_TOKEN_
     result
 }
 
-enum CryptoLevel {
-    Initial,
-    OneRtt,
-}
-
 pub struct Crypto {
-    crypto_level: CryptoLevel,
     local_secret: Vec<u8>,
     local_iv: Vec<u8>,
     local_pn_key: PacketNumberKey,
@@ -134,7 +128,6 @@ impl Crypto {
         let (remote_key, remote_iv, remote_pn_key) = Self::get_keys(digest, cipher, &remote_secret);
 
         Self {
-            crypto_level: CryptoLevel::Initial,
             local_secret,
             sealing_key: aead::SealingKey::new(cipher, &local_key).unwrap(),
             local_pn_key,
@@ -168,20 +161,6 @@ impl Crypto {
             .unwrap();
 
         Self::generate_1rtt(digest, cipher, local_secret, remote_secret)
-    }
-
-    pub fn is_initial(&self) -> bool {
-        match self.crypto_level {
-            CryptoLevel::Initial => true,
-            _ => false,
-        }
-    }
-
-    pub fn is_1rtt(&self) -> bool {
-        match self.crypto_level {
-            CryptoLevel::OneRtt => true,
-            _ => false,
-        }
     }
 
     pub fn write_nonce(&self, iv: &[u8], number: u64, out: &mut [u8]) {
@@ -280,7 +259,6 @@ impl Crypto {
         let (remote_key, remote_iv, remote_pn_key) = Self::get_keys(digest, cipher, &remote_secret);
 
         Crypto {
-            crypto_level: CryptoLevel::OneRtt,
             local_secret,
             sealing_key: aead::SealingKey::new(cipher, &local_key).unwrap(),
             local_pn_key,

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -99,7 +99,6 @@ pub fn reset_token_for(key: &SigningKey, id: &ConnectionId) -> [u8; RESET_TOKEN_
     result
 }
 
-#[derive(Clone)]
 pub enum Crypto {
     // ZeroRtt(ZeroRttCrypto),
     Initial(CryptoContext),
@@ -239,9 +238,11 @@ impl Crypto {
         // FIXME: retain crypter
         let (cipher, state, key) = match *self {
             //Crypto::ZeroRtt(ref crypto) => (crypto.cipher, &crypto.state, &crypto.sealing_key),
-            Crypto::Initial(ref crypto) | Crypto::OneRtt(ref crypto) => {
-                (crypto.sealing_key.algorithm(), &crypto.local, &crypto.sealing_key)
-            }
+            Crypto::Initial(ref crypto) | Crypto::OneRtt(ref crypto) => (
+                crypto.sealing_key.algorithm(),
+                &crypto.local,
+                &crypto.sealing_key,
+            ),
         };
 
         let mut nonce_buf = [0u8; aead::MAX_TAG_LEN];
@@ -261,9 +262,11 @@ impl Crypto {
 
         let (cipher, state, key) = match *self {
             //Crypto::ZeroRtt(ref crypto) => (crypto.cipher, &crypto.state, &crypto.opening_key),
-            Crypto::Initial(ref crypto) | Crypto::OneRtt(ref crypto) => {
-                (crypto.opening_key.algorithm(), &crypto.remote, &crypto.opening_key)
-            }
+            Crypto::Initial(ref crypto) | Crypto::OneRtt(ref crypto) => (
+                crypto.opening_key.algorithm(),
+                &crypto.remote,
+                &crypto.opening_key,
+            ),
         };
 
         let mut nonce_buf = [0u8; aead::MAX_TAG_LEN];
@@ -342,7 +345,6 @@ pub struct ConnectionInfo {
     pub(crate) remote: SocketAddrV6,
 }
 
-#[derive(Clone)]
 pub struct CryptoState {
     secret: Vec<u8>,
     key: Vec<u8>,
@@ -390,7 +392,6 @@ impl CryptoState {
     }
 }
 
-#[derive(Clone)]
 pub struct ZeroRttCrypto {
     state: CryptoState,
     cipher: &'static aead::Algorithm,
@@ -402,19 +403,6 @@ pub struct CryptoContext {
     remote: CryptoState,
     opening_key: aead::OpeningKey,
     digest: &'static digest::Algorithm,
-}
-
-impl Clone for CryptoContext {
-    fn clone(&self) -> CryptoContext {
-        let cipher = self.sealing_key.algorithm();
-        Self {
-            local: self.local.clone(),
-            sealing_key: aead::SealingKey::new(cipher, &self.local.key.clone()).unwrap(),
-            remote: self.remote.clone(),
-            opening_key: aead::OpeningKey::new(cipher, &self.remote.key).unwrap(),
-            digest: self.digest,
-        }
-    }
 }
 
 #[derive(Debug, Fail)]

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -106,31 +106,11 @@ pub struct OneRttCrypto {
 }
 
 pub enum Crypto {
-    // ZeroRtt(ZeroRttCrypto),
     Initial(CryptoContext),
     OneRtt(OneRttCrypto),
 }
 
 impl Crypto {
-    /*
-    pub fn new_0rtt(tls: &TlsSide) -> Self {
-        let suite = tls.get_negotiated_ciphersuite().unwrap();
-        let tls_cipher = tls.current_cipher().unwrap();
-        let digest = tls_cipher.handshake_digest().unwrap();
-        let cipher = Cipher::from_nid(tls_cipher.cipher_nid().unwrap()).unwrap();
-
-        const LABEL: &str = "EXPORTER-QUIC 0rtt";
-
-        let mut secret = vec![0; digest.size()];
-        tls.export_keying_material_early(&mut secret, &LABEL, b"")
-            .unwrap();
-        Crypto::ZeroRtt(ZeroRttCrypto {
-            state: CryptoState::new(digest, cipher, secret.into()),
-            cipher,
-        })
-    }
-    */
-
     fn get_keys(
         digest: &'static digest::Algorithm,
         cipher: &'static aead::Algorithm,
@@ -224,15 +204,6 @@ impl Crypto {
         Self::generate_1rtt(digest, cipher, local_secret, remote_secret)
     }
 
-    /*
-    pub fn is_0rtt(&self) -> bool {
-        match *self {
-            Crypto::ZeroRtt(_) => true,
-            _ => false,
-        }
-    }
-    */
-
     pub fn is_initial(&self) -> bool {
         match *self {
             Crypto::Initial(_) => true,
@@ -278,9 +249,7 @@ impl Crypto {
     }
 
     pub fn encrypt(&self, packet: u64, buf: &mut Vec<u8>, header_len: usize) {
-        // FIXME: retain crypter
         let (cipher, iv, key) = match *self {
-            //Crypto::ZeroRtt(ref crypto) => (crypto.cipher, &crypto.state, &crypto.sealing_key),
             Crypto::Initial(ref context) => (
                 context.sealing_key.algorithm(),
                 &context.local_iv,
@@ -309,7 +278,6 @@ impl Crypto {
         }
 
         let (cipher, iv, key) = match *self {
-            //Crypto::ZeroRtt(ref crypto) => (crypto.cipher, &crypto.state, &crypto.opening_key),
             Crypto::Initial(ref context) => (
                 context.opening_key.algorithm(),
                 &context.remote_iv,
@@ -364,6 +332,7 @@ impl Crypto {
         }
     }
 }
+
 /*
 pub struct CookieFactory {
     mac_key: [u8; 64],
@@ -410,13 +379,6 @@ pub struct ConnectionInfo {
     pub(crate) id: ConnectionId,
     pub(crate) remote: SocketAddrV6,
 }
-
-/*
-pub struct ZeroRttCrypto {
-    state: CryptoState,
-    cipher: &'static aead::Algorithm,
-}
-*/
 
 pub struct CryptoContext {
     local_iv: Vec<u8>,
@@ -637,5 +599,3 @@ mod test {
         );
     }
 }
-
-//pub type SessionTicketBuffer = Arc<Mutex<Vec<Result<SslSession, ()>>>>;

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -99,9 +99,22 @@ pub fn reset_token_for(key: &SigningKey, id: &ConnectionId) -> [u8; RESET_TOKEN_
     result
 }
 
-pub enum Crypto {
-    Initial(CryptoContext),
-    OneRtt(CryptoContext),
+enum CryptoLevel {
+    Initial,
+    OneRtt,
+}
+
+pub struct Crypto {
+    crypto_level: CryptoLevel,
+    local_secret: Vec<u8>,
+    local_iv: Vec<u8>,
+    local_pn_key: PacketNumberKey,
+    sealing_key: aead::SealingKey,
+    remote_secret: Vec<u8>,
+    remote_iv: Vec<u8>,
+    remote_pn_key: PacketNumberKey,
+    opening_key: aead::OpeningKey,
+    digest: &'static digest::Algorithm,
 }
 
 impl Crypto {
@@ -120,7 +133,8 @@ impl Crypto {
         let (local_key, local_iv, local_pn_key) = Self::get_keys(digest, cipher, &local_secret);
         let (remote_key, remote_iv, remote_pn_key) = Self::get_keys(digest, cipher, &remote_secret);
 
-        Crypto::Initial(CryptoContext {
+        Self {
+            crypto_level: CryptoLevel::Initial,
             local_secret,
             sealing_key: aead::SealingKey::new(cipher, &local_key).unwrap(),
             local_pn_key,
@@ -130,7 +144,7 @@ impl Crypto {
             remote_pn_key,
             remote_iv,
             digest,
-        })
+        }
     }
 
     pub fn new_1rtt(tls: &TlsSession, side: Side) -> Self {
@@ -157,15 +171,15 @@ impl Crypto {
     }
 
     pub fn is_initial(&self) -> bool {
-        match *self {
-            Crypto::Initial(_) => true,
+        match self.crypto_level {
+            CryptoLevel::Initial => true,
             _ => false,
         }
     }
 
     pub fn is_1rtt(&self) -> bool {
-        match *self {
-            Crypto::OneRtt(_) => true,
+        match self.crypto_level {
+            CryptoLevel::OneRtt => true,
             _ => false,
         }
     }
@@ -185,33 +199,19 @@ impl Crypto {
     }
 
     pub fn pn_decrypt_key(&self) -> &PacketNumberKey {
-        &self.ctx().remote_pn_key
+        &self.remote_pn_key
     }
 
     pub fn pn_encrypt_key(&self) -> &PacketNumberKey {
-        &self.ctx().local_pn_key
-    }
-
-    fn ctx(&self) -> &CryptoContext {
-        use self::Crypto::*;
-        match self {
-            Initial(ctx) | OneRtt(ctx) => ctx,
-        }
+        &self.local_pn_key
     }
 
     pub fn encrypt(&self, packet: u64, buf: &mut Vec<u8>, header_len: usize) {
-        let (cipher, iv, key) = match *self {
-            Crypto::Initial(ref crypto) => (
-                crypto.sealing_key.algorithm(),
-                &crypto.local_iv,
-                &crypto.sealing_key,
-            ),
-            Crypto::OneRtt(ref crypto) => (
-                crypto.sealing_key.algorithm(),
-                &crypto.local_iv,
-                &crypto.sealing_key,
-            ),
-        };
+        let (cipher, iv, key) = (
+            self.sealing_key.algorithm(),
+            &self.local_iv,
+            &self.sealing_key,
+        );
 
         let mut nonce_buf = [0u8; aead::MAX_TAG_LEN];
         let nonce = &mut nonce_buf[..cipher.nonce_len()];
@@ -228,18 +228,11 @@ impl Crypto {
             return Err(());
         }
 
-        let (cipher, iv, key) = match *self {
-            Crypto::Initial(ref crypto) => (
-                crypto.opening_key.algorithm(),
-                &crypto.remote_iv,
-                &crypto.opening_key,
-            ),
-            Crypto::OneRtt(ref crypto) => (
-                crypto.opening_key.algorithm(),
-                &crypto.remote_iv,
-                &crypto.opening_key,
-            ),
-        };
+        let (cipher, iv, key) = (
+            self.opening_key.algorithm(),
+            &self.remote_iv,
+            &self.opening_key,
+        );
 
         let mut nonce_buf = [0u8; aead::MAX_TAG_LEN];
         let nonce = &mut nonce_buf[..cipher.nonce_len()];
@@ -252,35 +245,29 @@ impl Crypto {
     }
 
     pub fn update(&self, side: Side) -> Crypto {
-        match *self {
-            Crypto::OneRtt(ref crypto) => {
-                const SERVER_LABEL: &[u8] = b"server 1rtt";
-                const CLIENT_LABEL: &[u8] = b"client 1rtt";
+        const SERVER_LABEL: &[u8] = b"server 1rtt";
+        const CLIENT_LABEL: &[u8] = b"client 1rtt";
 
-                let (local_label, remote_label) = if side == Side::Client {
-                    (CLIENT_LABEL, SERVER_LABEL)
-                } else {
-                    (SERVER_LABEL, CLIENT_LABEL)
-                };
+        let (local_label, remote_label) = if side == Side::Client {
+            (CLIENT_LABEL, SERVER_LABEL)
+        } else {
+            (SERVER_LABEL, CLIENT_LABEL)
+        };
 
-                let local_secret_key = SigningKey::new(crypto.digest, &crypto.local_secret);
-                let mut new_local_secret = vec![0; crypto.digest.output_len];
-                qhkdf_expand(&local_secret_key, &local_label, &mut new_local_secret);
+        let local_secret_key = SigningKey::new(self.digest, &self.local_secret);
+        let mut new_local_secret = vec![0; self.digest.output_len];
+        qhkdf_expand(&local_secret_key, &local_label, &mut new_local_secret);
 
-                let remote_secret_key =
-                    SigningKey::new(crypto.digest, &crypto.remote_secret);
-                let mut new_remote_secret = vec![0; crypto.digest.output_len];
-                qhkdf_expand(&remote_secret_key, &remote_label, &mut new_remote_secret);
+        let remote_secret_key = SigningKey::new(self.digest, &self.remote_secret);
+        let mut new_remote_secret = vec![0; self.digest.output_len];
+        qhkdf_expand(&remote_secret_key, &remote_label, &mut new_remote_secret);
 
-                Self::generate_1rtt(
-                    crypto.digest,
-                    crypto.opening_key.algorithm(),
-                    new_local_secret,
-                    new_remote_secret,
-                )
-            }
-            _ => unreachable!(),
-        }
+        Self::generate_1rtt(
+            self.digest,
+            self.opening_key.algorithm(),
+            new_local_secret,
+            new_remote_secret,
+        )
     }
 
     fn generate_1rtt(
@@ -292,7 +279,8 @@ impl Crypto {
         let (local_key, local_iv, local_pn_key) = Self::get_keys(digest, cipher, &local_secret);
         let (remote_key, remote_iv, remote_pn_key) = Self::get_keys(digest, cipher, &remote_secret);
 
-        Crypto::OneRtt(CryptoContext {
+        Crypto {
+            crypto_level: CryptoLevel::OneRtt,
             local_secret,
             sealing_key: aead::SealingKey::new(cipher, &local_key).unwrap(),
             local_pn_key,
@@ -302,7 +290,7 @@ impl Crypto {
             remote_pn_key,
             remote_iv,
             digest,
-        })
+        }
     }
 
     fn get_keys(
@@ -320,7 +308,6 @@ impl Crypto {
 
         (key, iv, PacketNumberKey::from_aead(cipher, &secret_key))
     }
-
 }
 
 /*
@@ -368,18 +355,6 @@ impl CookieFactory {
 pub struct ConnectionInfo {
     pub(crate) id: ConnectionId,
     pub(crate) remote: SocketAddrV6,
-}
-
-pub struct CryptoContext {
-    local_secret: Vec<u8>,
-    local_iv: Vec<u8>,
-    local_pn_key: PacketNumberKey,
-    sealing_key: aead::SealingKey,
-    remote_secret: Vec<u8>,
-    remote_iv: Vec<u8>,
-    remote_pn_key: PacketNumberKey,
-    opening_key: aead::OpeningKey,
-    digest: &'static digest::Algorithm,
 }
 
 #[derive(Debug, Fail)]


### PR DESCRIPTION
Here is a pretty trivial solution for #17. Is it what you expected ?

Similarly to #92, built keys and the data used to build them could be constructed wrongly by using a bad `CryptoContext { ... }`. I propose to move key and `CrytpoState` building logic into a `CryptoContext::new()` method to prevent this from happening.

Everything would be easier with all the key types implementing `Clone`. I'll see what can be done on this side. But I wonder why it is not already the case?