### PR TITLE
Cache keys

### DIFF
--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -392,11 +392,6 @@ impl CryptoState {
     }
 }
 
-pub struct ZeroRttCrypto {
-    state: CryptoState,
-    cipher: &'static aead::Algorithm,
-}
-
 pub struct CryptoContext {
     local: CryptoState,
     sealing_key: aead::SealingKey,

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -100,7 +100,6 @@ pub fn reset_token_for(key: &SigningKey, id: &ConnectionId) -> [u8; RESET_TOKEN_
 }
 
 pub enum Crypto {
-    // ZeroRtt(ZeroRttCrypto),
     Initial(CryptoContext),
     OneRtt(CryptoContext),
 }
@@ -157,15 +156,6 @@ impl Crypto {
         Self::generate_1rtt(digest, cipher, local_secret, remote_secret)
     }
 
-    /*
-    pub fn is_0rtt(&self) -> bool {
-        match *self {
-            Crypto::ZeroRtt(_) => true,
-            _ => false,
-        }
-    }
-    */
-
     pub fn is_initial(&self) -> bool {
         match *self {
             Crypto::Initial(_) => true,
@@ -210,7 +200,6 @@ impl Crypto {
     }
 
     pub fn encrypt(&self, packet: u64, buf: &mut Vec<u8>, header_len: usize) {
-        // FIXME: retain crypter
         let (cipher, iv, key) = match *self {
             Crypto::Initial(ref crypto) => (
                 crypto.sealing_key.algorithm(),
@@ -331,6 +320,7 @@ impl Crypto {
         (key, iv, PacketNumberKey::from_aead(cipher, &secret_key))
     }
 }
+
 /*
 pub struct CookieFactory {
     mac_key: [u8; 64],
@@ -599,5 +589,3 @@ mod test {
         );
     }
 }
-
-//pub type SessionTicketBuffer = Arc<Mutex<Vec<Result<SslSession, ()>>>>;


### PR DESCRIPTION
I've rebased and squashed the commits from #94:

```
commit 722fe7ac2b6e9b818c448600c02dfe9329140ea9 (HEAD -> cache-keys, origin/cache-keys, cryptog)
Author: stammw <begue.jc@gmail.com>
Date:   Wed Nov 28 22:11:39 2018 +0100

    Get rid of Crypto as an enum and work directly with CryptoContext

commit 8dd8ffd834887c0449b2873d99093f11e00cb439
Author: stammw <begue.jc@gmail.com>
Date:   Wed Nov 28 20:29:38 2018 +0100

    Remove commented code in crypto

commit a8a56eac4e0bcdd6fa846c2d7f802abeed60ae64
Author: stammw <begue.jc@gmail.com>
Date:   Wed Nov 28 07:59:01 2018 +0100

    Do not use CryptoState in Initial and OneRtt Crypto

commit d9bd6854d41a7fa3a2136451048cad58b91ef3c3
Author: Dirkjan Ochtman <dirkjan@ochtman.nl>
Date:   Thu Nov 29 10:07:54 2018 +0100

    Remove unused ZeroRttCrypto type

commit 6e35d438921d42448e684b6f95ead7de56acf3da
Author: stammw <begue.jc@gmail.com>
Date:   Thu Nov 22 14:00:16 2018 +0100

    Retain sealing and opening key in CryptoContext
```

In the middle, there's an explicit commit dropping the unused `ZeroRttCrypto` type -- this was previously a bit hidden in your changes and caused warnings at one of the intermediate commits.