### PR TITLE
Make the example documentation clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ The example client [currently always verifies][insecure] the server's certificat
 Example certificates are included in the repository for test purposes.
 
 ```sh
-$ cd quinn
 $ cargo run --example server -- --cert ./certs/server.chain --key ./certs/server.rsa ./
 $ cargo run --example client -- --ca ./certs/ca.der https://localhost:4433/Cargo.toml
 ```
 
-The above example will work on localhost and serve the "Cargo.toml" file to the client.  If
-you wish to run across a network you need to update the `certs/openssl.cnf` file and change 
-the `DNS.3` entry to suit the DNS name of the server.
+In the above example, the server will run on localhost and serve the "." folder to the client.
+The client will request the "Cargo.toml" file.  If you wish to run across a network you need 
+to update the `certs/openssl.cnf` file and change the `DNS.3` entry to suit the DNS name of 
+the server, and then regenerate the certificates using the `certs/generate.sh` script.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The client will request the "Cargo.toml" file.
 If you wish to run the client/server across a network for testing only (not production) you 
 need to update the `certs/openssl.cnf` file and change the `DNS.3` entry to suit the DNS name 
 of the server, and then regenerate the certificates using the `certs/generate.sh` script.  This
-method of generating certificates is very limiting. The preferred method when running quinn 
+method of generating certificates is very limiting. The preferred method when running a 
 server on a network would be to use real certs from an actual certificate authority, like 
 Let's Encrypt.
 

--- a/README.md
+++ b/README.md
@@ -45,23 +45,22 @@ Quinn was created and is maintained by Dirkjan Ochtman and Benjamin Saunders.
 
 ## How to start
 
-The example client [currently always verifies][insecure] the server's certificate chain.
-Example certificates are included in the repository for test purposes.
+The example client [currently always verifies][insecure] the server's certificate 
+chain. Example certificates are included in the repository for test purposes.
 
 ```sh
 $ cargo run --example server -- --cert ./certs/server.chain --key ./certs/server.rsa ./
 $ cargo run --example client -- --ca ./certs/ca.der https://localhost:4433/Cargo.toml
 ```
 
-In the above example, the server will run on localhost and serve the "." folder to the client.
-The client will request the "Cargo.toml" file.  
+In the above example, the server will run on localhost and serve the "." folder to
+the client. The client will request the "Cargo.toml" file.  
 
-To run the example client/server across a network you 
-need to update the `certs/openssl.cnf` file and change the `DNS.3` entry to suit the DNS name 
-of the server, and then regenerate the certificates using the `certs/generate.sh` script.  This
-method of generating certificates is very limiting. The preferred method when running a 
-server on a network would be to use real certs from an actual certificate authority, like 
-Let's Encrypt.
+To run the example client/server across a network you need to update the 
+`certs/openssl.cnf` file and change the `DNS.3` entry to suit the DNS name  of the 
+server, and then regenerate the certificates using the `certs/generate.sh` script.  
+For real-world use, a certificate signed by a legitimate CA is recommended when 
+possible.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ Example certificates are included in the repository for test purposes.
 
 ```sh
 $ cd quinn
-$ cargo run --example server -- --cert ../certs/server.chain --key ../certs/server.rsa .
-$ cargo run --example client -- --ca ../certs/ca.der https://localhost:4433/Cargo.toml
+$ cargo run --example server -- --cert ./certs/server.chain --key ./certs/server.rsa ./
+$ cargo run --example client -- --ca ./certs/ca.der https://localhost:4433/Cargo.toml
 ```
+
+The above example will work on localhost and serve the "Cargo.toml" file to the client.  If
+you wish to run across a network you need to update the `certs/openssl.cnf` file and change 
+the `DNS.3` entry to suit the DNS name of the server.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ $ cargo run --example client -- --ca ./certs/ca.der https://localhost:4433/Cargo
 ```
 
 In the above example, the server will run on localhost and serve the "." folder to the client.
-The client will request the "Cargo.toml" file.  If you wish to run across a network you need 
-to update the `certs/openssl.cnf` file and change the `DNS.3` entry to suit the DNS name of 
-the server, and then regenerate the certificates using the `certs/generate.sh` script.
+The client will request the "Cargo.toml" file.  
+
+If you wish to run the client/server across a network for testing only (not production) you 
+need to update the `certs/openssl.cnf` file and change the `DNS.3` entry to suit the DNS name 
+of the server, and then regenerate the certificates using the `certs/generate.sh` script.  This
+method of generating certificates is very limiting. The preferred method when running quinn 
+server on a network would be to use real certs from an actual certificate authority, like 
+Let's Encrypt.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ cargo run --example client -- --ca ./certs/ca.der https://localhost:4433/Cargo
 In the above example, the server will run on localhost and serve the "." folder to the client.
 The client will request the "Cargo.toml" file.  
 
-If you wish to run the client/server across a network for testing only (not production) you 
+To run the example client/server across a network you 
 need to update the `certs/openssl.cnf` file and change the `DNS.3` entry to suit the DNS name 
 of the server, and then regenerate the certificates using the `certs/generate.sh` script.  This
 method of generating certificates is very limiting. The preferred method when running a 


### PR DESCRIPTION
Added comments on updating the certs/openssl.cnf for access across the network.
Changed the path of the certificates folder, since then it will just be copy and paste.
Changed the `.` to a `./` because when I copy-n-pasted I missed the `.` because it's not very visible.