### PR TITLE
Clientside stateless resets

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1567,7 +1567,7 @@ impl Connection {
                         self.io.retired_cids.push(old);
                     }
                 }
-                Frame::NewConnectionId { .. } => {
+                Frame::NewConnectionId(frame) => {
                     if self.rem_cid.is_empty() {
                         debug!(
                             self.log,
@@ -1575,7 +1575,14 @@ impl Connection {
                         );
                         return Err(TransportError::PROTOCOL_VIOLATION);
                     }
-                    trace!(self.log, "ignoring NEW_CONNECTION_ID (unimplemented)");
+                    if self.params.stateless_reset_token.is_none() {
+                        // We're a server using the initial remote CID for the client, so let's
+                        // switch immediately to enable clientside stateless resets.
+                        debug_assert!(self.side.is_server());
+                        self.update_rem_cid(frame);
+                    } else {
+                        trace!(self.log, "ignoring NEW_CONNECTION_ID (unimplemented)");
+                    }
                 }
                 Frame::NewToken { .. } => {
                     trace!(self.log, "got new token");
@@ -1584,6 +1591,17 @@ impl Connection {
             }
         }
         Ok(false)
+    }
+
+    fn update_rem_cid(&mut self, new: frame::NewConnectionId) {
+        trace!(
+            self.log,
+            "switching to remote CID {sequence}: {connection_id}",
+            sequence = new.sequence,
+            connection_id = new.id
+        );
+        self.rem_cid = new.id;
+        self.params.stateless_reset_token = Some(new.reset_token);
     }
 
     fn next_packet(&mut self, now: u64) -> Option<Box<[u8]>> {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -21,7 +21,7 @@ use crate::stream::{self, ReadError, Stream, WriteError};
 use crate::transport_parameters::{self, TransportParameters};
 use crate::{
     frame, Directionality, Frame, Side, StreamId, TransportError, MIN_INITIAL_SIZE, MIN_MTU,
-    VERSION,
+    RESET_TOKEN_SIZE, VERSION,
 };
 use rustls::internal::msgs::enums::AlertDescription;
 
@@ -961,7 +961,8 @@ impl Connection {
         let was_closed = self.state.is_closed();
 
         let stateless_reset = self.params.stateless_reset_token.map_or(false, |token| {
-            packet.payload.len() >= 16 && packet.payload[packet.payload.len() - 16..] == token
+            packet.payload.len() >= RESET_TOKEN_SIZE
+                && packet.payload[packet.payload.len() - RESET_TOKEN_SIZE..] == token
         });
 
         let result = match self.decrypt_packet(was_handshake, &mut packet) {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2062,6 +2062,13 @@ impl Connection {
         Some(id)
     }
 
+    /// Ping the remote endpoint
+    ///
+    /// Useful for preventing an otherwise idle connection from timing out.
+    pub fn ping(&mut self) {
+        self.pending.ping = true;
+    }
+
     /// Discard state for a stream if it's fully closed.
     ///
     /// Called when one side of a stream transitions to a closed state
@@ -2517,17 +2524,17 @@ impl Streams {
 
 #[derive(Debug, Clone)]
 pub struct Retransmits {
-    pub max_data: bool,
-    pub max_uni_stream_id: bool,
-    pub max_bi_stream_id: bool,
-    pub ping: bool,
-    pub new_connection_id: Option<ConnectionId>,
-    pub stream: VecDeque<frame::Stream>,
+    max_data: bool,
+    max_uni_stream_id: bool,
+    max_bi_stream_id: bool,
+    ping: bool,
+    new_connection_id: Option<ConnectionId>,
+    stream: VecDeque<frame::Stream>,
     /// packet number, token
-    pub path_response: Option<(u64, u64)>,
-    pub rst_stream: Vec<(StreamId, u16)>,
-    pub stop_sending: Vec<(StreamId, u16)>,
-    pub max_stream_data: FnvHashSet<StreamId>,
+    path_response: Option<(u64, u64)>,
+    rst_stream: Vec<(StreamId, u16)>,
+    stop_sending: Vec<(StreamId, u16)>,
+    max_stream_data: FnvHashSet<StreamId>,
     crypto: VecDeque<frame::Crypto>,
 }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -671,7 +671,7 @@ impl Endpoint {
     ///
     /// Useful for preventing an otherwise idle connection from timing out.
     pub fn ping(&mut self, conn: ConnectionHandle) {
-        self.connections[conn.0].pending.ping = true;
+        self.connections[conn.0].ping();
         self.dirty_conns.insert(conn);
     }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -303,7 +303,7 @@ impl Endpoint {
         dst_cid: &ConnectionId,
     ) {
         /// Minimum amount of padding for the stateless reset to look like a short-header packet
-        const MIN_PADDING_LEN: usize = 20;
+        const MIN_PADDING_LEN: usize = 23;
         /// Minimum total length for a stateless reset packet
         const MIN_LEN: usize = 1 + MIN_PADDING_LEN + RESET_TOKEN_SIZE;
 
@@ -321,9 +321,9 @@ impl Endpoint {
             inciting_dgram_len - (MIN_LEN - MIN_PADDING_LEN),
         );
         buf.reserve_exact(1 + padding_len + RESET_TOKEN_SIZE);
-        buf.resize(1 + padding_len, 0);
-        buf[0] = 0b00110000; // Changes in draft 17
-        self.rng.fill_bytes(&mut buf[1..padding_len + 1]);
+        buf.resize(padding_len, 0);
+        self.rng.fill_bytes(&mut buf[0..padding_len]);
+        buf[0] = 0b01000000 | buf[0] >> 2;
         buf.extend(&reset_token_for(&self.config.reset_key, dst_cid));
 
         debug_assert!(buf.len() < inciting_dgram_len);

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -524,6 +524,7 @@ impl Endpoint {
             }
             Err(e) => {
                 debug!(self.log, "handshake failed"; "reason" => %e);
+                self.forget(conn);
                 self.io.push_back(Io::Transmit {
                     destination: remote,
                     ecn: None,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -155,11 +155,7 @@ pub enum Frame {
         directionality: Directionality,
         limit: u64,
     },
-    NewConnectionId {
-        sequence: u64,
-        id: ConnectionId,
-        reset_token: [u8; 16],
-    },
+    NewConnectionId(NewConnectionId),
     RetireConnectionId {
         sequence: u64,
     },
@@ -608,11 +604,11 @@ impl Iter {
                 }
                 let mut reset_token = [0; RESET_TOKEN_SIZE];
                 self.bytes.copy_to_slice(&mut reset_token);
-                Frame::NewConnectionId {
+                Frame::NewConnectionId(NewConnectionId {
                     sequence,
                     id,
                     reset_token,
-                }
+                })
             }
             Type::CRYPTO => Frame::Crypto(Crypto {
                 offset: self.bytes.get_var()?,
@@ -722,6 +718,13 @@ impl ResetStream {
         out.write(self.error_code); // 2 bytes
         out.write_var(self.final_offset); // <= 8 bytes
     }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct NewConnectionId {
+    pub sequence: u64,
+    pub id: ConnectionId,
+    pub reset_token: [u8; 16],
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -737,6 +737,9 @@ impl NewConnectionId {
     }
 }
 
+/// Smallest number of bytes this type of frame is guaranteed to fit within.
+pub const RETIRE_CONNECTION_ID_SIZE_BOUND: usize = 9;
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -727,6 +727,16 @@ pub struct NewConnectionId {
     pub reset_token: [u8; 16],
 }
 
+impl NewConnectionId {
+    pub fn encode<W: BufMut>(&self, out: &mut W) {
+        out.write(Type::NEW_CONNECTION_ID);
+        out.write_var(self.sequence);
+        out.write(self.id.len() as u8);
+        out.put_slice(&self.id);
+        out.put_slice(&self.reset_token);
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -493,7 +493,9 @@ fn stateless_reset() {
         Some(pair_listen_keys),
     )
     .unwrap();
-    pair.client.ping(client_conn);
+    // Send something big enough to allow room for a smaller stateless reset.
+    pair.client
+        .close(pair.time, client_conn, 42, (&[0xab; 128][..]).into());
     info!(pair.log, "resetting");
     pair.drive();
     assert_matches!(pair.client.poll(), Some((conn, Event::ConnectionLost { reason: ConnectionError::Reset })) if conn == client_conn);

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -488,7 +488,7 @@ fn stateless_reset() {
     let mut pair = Pair::new(server, Default::default(), listen_key);
     let (client_conn, _) = pair.connect();
     pair.server.endpoint = Endpoint::new(
-        pair.log.new(o!("peer" => "server")),
+        pair.log.new(o!("side" => "Server")),
         Config::default(),
         Some(pair_listen_keys),
     )

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -138,7 +138,7 @@ fn handle_connection(root: &PathBuf, log: &Logger, conn: quinn::NewConnection) {
         incoming,
         connection,
     } = conn;
-    let log = log.new(o!("local_id" => format!("{}", connection.local_id())));
+    let log = log.clone();
     info!(log, "got connection";
           "remote_id" => %connection.remote_id(),
           "address" => %connection.remote_address(),

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -1030,16 +1030,19 @@ impl Connection {
             .into()
     }
 
-    /// The `ConnectionId` used for `conn` locally.
-    pub fn local_id(&self) -> ConnectionId {
+    /// The `ConnectionId`s defined for `conn` locally.
+    pub fn local_ids(&self) -> impl Iterator<Item = ConnectionId> {
         self.0
             .endpoint
             .borrow()
             .inner
             .connection(self.0.conn)
-            .loc_cid()
+            .loc_cids()
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
     }
-    /// The `ConnectionId` used for `conn` by the peer.
+    /// The `ConnectionId` defined for `conn` by the peer.
     pub fn remote_id(&self) -> ConnectionId {
         self.0
             .endpoint


### PR DESCRIPTION
This adds support for clients performing stateless resets by transmitting `NEW_CONNECTION_ID` immediately after handshake to establish a reset token, and fixes several bugs encountered along the way.