### PR TITLE
Remove ConnectionDrained event

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -729,7 +729,6 @@ impl Endpoint {
                     timer: Timer::Idle,
                     update: TimerUpdate::Stop,
                 });
-                self.ctx.events.push_back((conn, Event::ConnectionDrained));
                 if self.connections[conn.0].app_closed {
                     self.forget(conn);
                 } else {
@@ -899,8 +898,6 @@ pub enum Event {
     ConnectionLost {
         reason: ConnectionError,
     },
-    /// A closed connection was dropped.
-    ConnectionDrained,
     /// A stream has data or errors waiting to be read
     StreamReadable {
         /// The affected stream
@@ -952,6 +949,7 @@ pub enum Io {
 pub enum Timer {
     LossDetection = 0,
     Idle = 1,
+    /// When the close timer expires, the connection has been gracefully terminated.
     Close = 2,
 }
 

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -445,7 +445,7 @@ fn lifecycle() {
                     Some((_, Event::ConnectionLost { reason: ConnectionError::ApplicationClosed {
                         reason: ApplicationClose { error_code: 42, ref reason }
                     }})) if reason == REASON);
-    assert_matches!(pair.client.poll(), Some((conn, Event::ConnectionDrained)) if conn == client_conn);
+    assert_matches!(pair.client.poll(), None);
 }
 
 #[test]


### PR DESCRIPTION
This event was always emitted exactly when the close timer expires, which is already known to the caller. Making it implicit lets us reduce bookkeeping.

If #127 moves queuing of the `TimedOut` event into the connection, we will be able to do away with `Context::events` entirely.