### PR TITLE
Draft 17 transport parameters

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2013,8 +2013,8 @@ impl Connection {
         }
 
         // Apply
-        self.streams.max_bi = params.initial_max_bidi_streams as u64;
-        self.streams.max_uni = params.initial_max_uni_streams as u64;
+        self.streams.max_bi = params.initial_max_streams_bidi;
+        self.streams.max_uni = params.initial_max_streams_uni;
         self.max_data = params.initial_max_data as u64;
         for i in 0..self.streams.max_remote_bi {
             let id = StreamId::new(!self.side, Directionality::Bi, i as u64);

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -186,13 +186,13 @@ impl Connection {
             crypto: Crypto::new_initial(&init_cid, side),
         });
         let mut streams = FnvHashMap::default();
-        for i in 0..config.max_remote_uni_streams {
+        for i in 0..config.max_remote_streams_uni {
             streams.insert(
                 StreamId::new(!side, Directionality::Uni, u64::from(i)),
                 stream::Recv::new(u64::from(config.stream_receive_window)).into(),
             );
         }
-        for i in 0..config.max_remote_bi_streams {
+        for i in 0..config.max_remote_streams_bidi {
             streams.insert(
                 StreamId::new(!side, Directionality::Bi, i as u64),
                 Stream::new_bi(config.stream_receive_window as u64),
@@ -277,8 +277,8 @@ impl Connection {
                 next_bi: 0,
                 max_uni: 0,
                 max_bi: 0,
-                max_remote_uni: config.max_remote_uni_streams as u64,
-                max_remote_bi: config.max_remote_bi_streams as u64,
+                max_remote_uni: config.max_remote_streams_uni as u64,
+                max_remote_bi: config.max_remote_streams_bidi as u64,
                 finished: Vec::new(),
             },
             config,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -696,14 +696,14 @@ impl Endpoint {
 /// Parameters governing the core QUIC state machine.
 pub struct Config {
     /// Maximum number of peer-initiated bidirectional streams that may exist at one time.
-    pub max_remote_bi_streams: u16,
+    pub max_remote_bi_streams: u64,
     /// Maximum number of peer-initiated  unidirectional streams that may exist at one time.
-    pub max_remote_uni_streams: u16,
+    pub max_remote_uni_streams: u64,
     /// Maximum duration of inactivity to accept before timing out the connection (s).
     ///
     /// Maximum value is 600 seconds. The actual value used is the minimum of this and the peer's
     /// own idle timeout. 0 for none.
-    pub idle_timeout: u16,
+    pub idle_timeout: u64,
     /// Maximum number of bytes the peer may transmit on any one stream before becoming blocked.
     ///
     /// This should be set to at least the expected connection latency multiplied by the maximum
@@ -711,14 +711,14 @@ pub struct Config {
     /// stream doesn't monopolize receive buffers, which may otherwise occur if the application
     /// chooses not to read from a large stream for a time while still requiring data on other
     /// streams.
-    pub stream_receive_window: u32,
+    pub stream_receive_window: u64,
     /// Maximum number of bytes the peer may transmit across all streams of a connection before
     /// becoming blocked.
     ///
     /// This should be set to at least the expected connection latency multiplied by the maximum
     /// desired throughput. Larger values can be useful to allow maximum throughput within a
     /// stream while another is blocked.
-    pub receive_window: u32,
+    pub receive_window: u64,
 
     /// Maximum number of tail loss probes before an RTO fires.
     pub max_tlps: u32,
@@ -758,11 +758,11 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        const EXPECTED_RTT: u32 = 100; // ms
-        const MAX_STREAM_BANDWIDTH: u32 = 12500 * 1000; // bytes/s
+        const EXPECTED_RTT: u64 = 100; // ms
+        const MAX_STREAM_BANDWIDTH: u64 = 12500 * 1000; // bytes/s
                                                         // Window size needed to avoid pipeline
                                                         // stalls
-        const STREAM_RWND: u32 = MAX_STREAM_BANDWIDTH / 1000 * EXPECTED_RTT;
+        const STREAM_RWND: u64 = MAX_STREAM_BANDWIDTH / 1000 * EXPECTED_RTT;
         Self {
             max_remote_bi_streams: 0,
             max_remote_uni_streams: 0,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -696,9 +696,9 @@ impl Endpoint {
 /// Parameters governing the core QUIC state machine.
 pub struct Config {
     /// Maximum number of peer-initiated bidirectional streams that may exist at one time.
-    pub max_remote_bi_streams: u64,
+    pub max_remote_streams_bidi: u64,
     /// Maximum number of peer-initiated  unidirectional streams that may exist at one time.
-    pub max_remote_uni_streams: u64,
+    pub max_remote_streams_uni: u64,
     /// Maximum duration of inactivity to accept before timing out the connection (s).
     ///
     /// Maximum value is 600 seconds. The actual value used is the minimum of this and the peer's
@@ -764,8 +764,8 @@ impl Default for Config {
                                                         // stalls
         const STREAM_RWND: u64 = MAX_STREAM_BANDWIDTH / 1000 * EXPECTED_RTT;
         Self {
-            max_remote_bi_streams: 0,
-            max_remote_uni_streams: 0,
+            max_remote_streams_bidi: 0,
+            max_remote_streams_uni: 0,
             idle_timeout: 10,
             stream_receive_window: STREAM_RWND,
             receive_window: 8 * STREAM_RWND,

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -71,8 +71,8 @@ struct Pair {
 impl Default for Pair {
     fn default() -> Self {
         let mut server = Config::default();
-        server.max_remote_uni_streams = 32;
-        server.max_remote_bi_streams = 32;
+        server.max_remote_streams_uni = 32;
+        server.max_remote_streams_bidi = 32;
         Pair::new(server, Default::default(), server_config())
     }
 }
@@ -464,8 +464,8 @@ fn stateless_retry() {
 #[test]
 fn stateless_reset() {
     let mut server = Config::default();
-    server.max_remote_uni_streams = 32;
-    server.max_remote_bi_streams = 32;
+    server.max_remote_streams_uni = 32;
+    server.max_remote_streams_bidi = 32;
 
     let mut token_value = [0; 64];
     let mut reset_value = [0; 64];
@@ -689,7 +689,7 @@ fn close_during_handshake() {
 #[test]
 fn stream_id_backpressure() {
     let server = Config {
-        max_remote_uni_streams: 1,
+        max_remote_streams_uni: 1,
         ..Config::default()
     };
     let mut pair = Pair::new(server, Default::default(), server_config());

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -70,8 +70,8 @@ apply_params!(make_struct);
 impl TransportParameters {
     pub fn new(config: &Config) -> Self {
         TransportParameters {
-            initial_max_streams_bidi: config.max_remote_bi_streams,
-            initial_max_streams_uni: config.max_remote_uni_streams,
+            initial_max_streams_bidi: config.max_remote_streams_bidi,
+            initial_max_streams_uni: config.max_remote_streams_uni,
             initial_max_data: config.receive_window,
             initial_max_stream_data_bidi_local: config.stream_receive_window,
             initial_max_stream_data_bidi_remote: config.stream_receive_window,

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -96,7 +96,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     let mut runtime = Runtime::new()?;
 
     let mut endpoint = quinn::EndpointBuilder::new(quinn::Config {
-        max_remote_bi_streams: 64,
+        max_remote_streams_bidi: 64,
         ..Default::default()
     });
     endpoint.logger(log.clone());


### PR DESCRIPTION
Integer parameters were moved to varint encoding, and everything was renumbered.