### PR TITLE
Draft 17 handshake crypto

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1"
 orion = "0.11"
 rand = "0.6"
 ring = "0.13"
-rustls = { git = "https://github.com/Ralith/rustls.git", rev = "044b5f10a57ec385157fae0cad46b462208ff257", features = ["quic"] }
+rustls = { git = "https://github.com/Ralith/rustls.git", rev = "ebbed84658cb55c20798bdad65e2b462c04757e6", features = ["quic"] }
 slab = "0.4"
 slog = "2.2"
 webpki = "0.18"

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -40,7 +40,7 @@ pub struct Connection {
     loc_cids: HashMap<u64, ConnectionId>,
     rem_cid: ConnectionId,
     rem_cid_seq: u64,
-    pub(crate) remote: SocketAddrV6,
+    remote: SocketAddrV6,
     state: State,
     side: Side,
     mtu: u16,
@@ -748,7 +748,7 @@ impl Connection {
         }
     }
 
-    pub fn reset_idle_timeout(&mut self, now: u64) {
+    fn reset_idle_timeout(&mut self, now: u64) {
         let dt = if self.config.idle_timeout == 0 || self.params.idle_timeout == 0 {
             cmp::max(self.config.idle_timeout, self.params.idle_timeout)
         } else {
@@ -2491,7 +2491,7 @@ impl Streams {
 }
 
 #[derive(Debug, Clone)]
-pub struct Retransmits {
+struct Retransmits {
     max_data: bool,
     max_uni_stream_id: bool,
     max_bi_stream_id: bool,
@@ -2523,7 +2523,7 @@ impl Retransmits {
             && self.retire_cids.is_empty()
     }
 
-    pub fn path_challenge(&mut self, packet: u64, token: u64) {
+    fn path_challenge(&mut self, packet: u64, token: u64) {
         match self.path_response {
             None => {
                 self.path_response = Some((packet, token));
@@ -2698,7 +2698,7 @@ impl State {
     }
 }
 
-pub mod state {
+mod state {
     use super::*;
 
     #[derive(Clone)]
@@ -2748,22 +2748,22 @@ pub struct ClientConfig {
 
 /// Represents one or more packets subject to retransmission
 #[derive(Debug, Clone)]
-pub struct SentPacket {
+struct SentPacket {
     /// The time the packet was sent.
-    pub time_sent: u64,
+    time_sent: u64,
     /// The number of bytes sent in the packet, not including UDP or IP overhead, but including QUIC
     /// framing overhead.
-    pub size: u16,
+    size: u16,
     /// Whether an acknowledgement is expected directly in response to this packet.
-    pub ack_eliciting: bool,
+    ack_eliciting: bool,
     /// Whether the packet contains cryptographic handshake messages critical to the completion of
     /// the QUIC handshake.
     // FIXME: Implied by retransmits + space
-    pub is_crypto_packet: bool,
+    is_crypto_packet: bool,
     /// Whether the packet counts towards bytes in flight
-    pub in_flight: bool,
-    pub acks: RangeSet,
-    pub retransmits: Retransmits,
+    in_flight: bool,
+    acks: RangeSet,
+    retransmits: Retransmits,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -2799,7 +2799,7 @@ pub enum Io {
 
 /// Encoding of I/O operations to emit on upcoming `poll_io` calls
 #[derive(Debug)]
-pub struct IoQueue {
+struct IoQueue {
     /// Number of probe packets to transmit
     probes: u8,
     /// Whether to transmit a close packet
@@ -2813,7 +2813,7 @@ pub struct IoQueue {
 }
 
 impl IoQueue {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             probes: 0,
             close: false,

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1792,7 +1792,7 @@ impl Connection {
         }
 
         // STREAM
-        while buf.len() + frame::Stream::<Bytes>::SIZE_BOUND < max_size {
+        while buf.len() + frame::Stream::SIZE_BOUND < max_size {
             let mut stream = if let Some(x) = space.pending.stream.pop_front() {
                 x
             } else {
@@ -1808,7 +1808,7 @@ impl Connection {
             }
             let len = cmp::min(
                 stream.data.len(),
-                max_size as usize - buf.len() - frame::Stream::<Bytes>::SIZE_BOUND,
+                max_size as usize - buf.len() - frame::Stream::SIZE_BOUND,
             );
             let data = stream.data.split_to(len);
             let fin = stream.fin && stream.data.is_empty();

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2405,7 +2405,7 @@ impl Connection {
     }
 }
 
-pub fn handshake_close<R>(
+pub fn initial_close<R>(
     crypto: &Crypto,
     header_crypto: &HeaderCrypto,
     remote_id: &ConnectionId,
@@ -2417,11 +2417,11 @@ where
     R: Into<state::CloseReason>,
 {
     let number = PacketNumber::U8(packet_number);
-    let header = Header::Long {
-        ty: LongType::Handshake,
+    let header = Header::Initial {
         dst_cid: *remote_id,
         src_cid: *local_id,
         number,
+        token: Bytes::new(),
     };
 
     let mut buf = Vec::<u8>::new();

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1646,7 +1646,7 @@ impl Connection {
                 number: PacketNumber::new(number, space.largest_acked_packet),
             },
             SpaceId::Initial => Header::Initial {
-                src_cid: *self.loc_cids.values().next().unwrap(),
+                src_cid: *self.loc_cids.get(&0).unwrap(),
                 dst_cid: self.rem_cid,
                 token: match self.state {
                     State::Handshake(ref state) => state.token.clone().unwrap_or_else(Bytes::new),
@@ -2370,9 +2370,12 @@ impl Connection {
         self.state.is_handshake()
     }
 
-    /// Whether the connection has the keys to transmit application data and isn't closed.
-    pub fn can_send(&self) -> bool {
-        !self.state.is_closed() && self.spaces[SpaceId::OneRtt as usize].is_some()
+    pub fn is_closed(&self) -> bool {
+        self.state.is_closed()
+    }
+
+    pub fn has_1rtt(&self) -> bool {
+        self.spaces[SpaceId::OneRtt as usize].is_some()
     }
 
     pub fn is_drained(&self) -> bool {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -118,6 +118,8 @@ pub struct Connection {
     /// count towards bytes_in_flight to ensure congestion control does not impede congestion
     /// feedback.
     bytes_in_flight: u64,
+    /// Number of unacknowledged Initial or Handshake packets bearing CRYPTO frames
+    crypto_in_flight: u64,
     /// Maximum number of bytes in flight that may be sent.
     congestion_window: u64,
     /// The time when QUIC first detects a loss, causing it to enter recovery. When a packet sent
@@ -137,12 +139,6 @@ pub struct Connection {
     /// Whether the most recently received packet had an ECN codepoint set
     receiving_ecn: bool,
 
-    /// Number of unacknowledged Initial or Handshake packets bearing CRYPTO frames
-    crypto_in_flight: u64,
-
-    //
-    // Stream states
-    //
     streams: Streams,
 }
 
@@ -230,6 +226,7 @@ impl Connection {
             time_of_last_sent_crypto_packet: 0,
 
             bytes_in_flight: 0,
+            crypto_in_flight: 0,
             congestion_window: config.initial_window,
             recovery_start_time: 0,
             ssthresh: u64::max_value(),
@@ -237,8 +234,6 @@ impl Connection {
             ecn_feedback: frame::EcnCounts::ZERO,
             sending_ecn: true,
             receiving_ecn: false,
-
-            crypto_in_flight: 0,
 
             streams: Streams {
                 streams,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -570,7 +570,7 @@ impl Endpoint {
             }
         }
         self.connection_remotes
-            .remove(&self.connections[conn.0].remote);
+            .remove(&self.connections[conn.0].remote());
         self.dirty_conns.remove(&conn);
         self.eventful_conns.remove(&conn);
         self.connections.remove(conn.0);

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -221,7 +221,7 @@ impl Endpoint {
                     self.incoming_handshakes -= 1;
                     self.incoming.push_back(conn_id);
                 }
-                if self.config.local_cid_len != 0 {
+                if self.config.local_cid_len != 0 && self.connections[conn_id.0].can_send() {
                     /// Draft 17 §5.1.1: endpoints SHOULD provide and maintain at least eight
                     /// connection IDs
                     const LOCAL_CID_COUNT: usize = 8;
@@ -264,7 +264,7 @@ impl Endpoint {
 
                 let crypto = Crypto::new_initial(&partial_decode.dst_cid(), Side::Server);
                 let header_crypto = crypto.header_crypto();
-                return match partial_decode.finish(&header_crypto) {
+                return match partial_decode.finish(Some(&header_crypto)) {
                     Ok((packet, rest)) => {
                         self.handle_initial(now, remote, ecn, packet, &crypto, &header_crypto);
                         rest

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -440,9 +440,9 @@ impl Endpoint {
             Header::Initial {
                 src_cid,
                 dst_cid,
-                token,
+                ref token,
                 number,
-            } => (src_cid, dst_cid, token, number),
+            } => (src_cid, dst_cid, token.clone(), number),
             _ => panic!("non-initial packet in handle_initial()"),
         };
         let packet_number = packet_number.expand(0);
@@ -539,12 +539,7 @@ impl Endpoint {
             )
             .unwrap();
         self.connection_ids_initial.insert(dst_cid, conn);
-        match self.connections[conn.0].handle_initial(
-            now,
-            ecn,
-            packet_number as u64,
-            packet.payload.freeze(),
-        ) {
+        match self.connections[conn.0].handle_initial(now, ecn, packet_number as u64, packet) {
             Ok(()) => {
                 self.incoming_handshakes += 1;
                 self.dirty_conns.insert(conn);

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -14,7 +14,7 @@ use slog::{self, Logger};
 
 use crate::coding::BufMutExt;
 use crate::connection::{
-    self, handshake_close, ClientConfig, Connection, ConnectionError, ConnectionHandle, TimerUpdate,
+    self, initial_close, ClientConfig, Connection, ConnectionError, ConnectionHandle, TimerUpdate,
 };
 use crate::crypto::{
     self, reset_token_for, ConnectError, Crypto, HeaderCrypto, TlsSession, TokenKey,
@@ -469,7 +469,7 @@ impl Endpoint {
             self.io.push_back(Io::Transmit {
                 destination: remote,
                 ecn: None,
-                packet: handshake_close(
+                packet: initial_close(
                     crypto,
                     header_crypto,
                     &src_cid,
@@ -553,7 +553,7 @@ impl Endpoint {
                 self.io.push_back(Io::Transmit {
                     destination: remote,
                     ecn: None,
-                    packet: handshake_close(crypto, header_crypto, &src_cid, &temp_loc_cid, 0, e),
+                    packet: initial_close(crypto, header_crypto, &src_cid, &temp_loc_cid, 0, e),
                 });
             }
         }

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -811,7 +811,6 @@ fn key_update() {
 }
 
 #[test]
-#[should_panic] // TODO: Spec design flaw fixed in draft 17
 fn key_update_reordered() {
     let mut pair = Pair::default();
     let (client_conn, server_conn) = pair.connect();
@@ -820,7 +819,7 @@ fn key_update_reordered() {
         .open(client_conn, Directionality::Bi)
         .expect("couldn't open first stream");
 
-    const MSG1: &[u8] = b"one";
+    const MSG1: &[u8] = b"1";
     pair.client.write(client_conn, s, MSG1).unwrap();
     pair.client.drive(&pair.log, pair.time, pair.server.addr);
     assert!(!pair.client.outbound.is_empty());
@@ -840,7 +839,7 @@ fn key_update_reordered() {
     assert_matches!(pair.server.poll(), None);
     assert_matches!(
         pair.server.read_unordered(server_conn, s),
-        Ok((ref data, 3)) if data == MSG2
+        Ok((ref data, 1)) if data == MSG2
     );
     assert_matches!(
         pair.server.read_unordered(server_conn, s),

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -29,7 +29,7 @@ fnv = "1.0.6"
 futures = "0.1.21"
 quinn-proto = { path = "../quinn-proto", version = "0.1.0" }
 rand = "0.6"
-rustls = { git = "https://github.com/Ralith/rustls.git", rev = "044b5f10a57ec385157fae0cad46b462208ff257", features = ["quic"] }
+rustls = { git = "https://github.com/Ralith/rustls.git", rev = "ebbed84658cb55c20798bdad65e2b462c04757e6", features = ["quic"] }
 slog = "2.1"
 tokio-reactor = "0.1.1"
 tokio-udp = "0.1"


### PR DESCRIPTION
This introduces the notion of discrete packet number spaces and the associated crypto and retransmit management. Currently non-functional due to, at minimum, bugs in the rustls `QuicExt::get_handshake_secrets` implementation, which I'll continue to investigate tomorrow.