### PR TITLE
Ipv4 fixes

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1,5 +1,5 @@
 use std::collections::{hash_map, BTreeMap, HashMap, VecDeque};
-use std::net::SocketAddrV6;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::{cmp, io, mem};
 
@@ -37,7 +37,7 @@ pub struct Connection {
     loc_cids: HashMap<u64, ConnectionId>,
     rem_cid: ConnectionId,
     rem_cid_seq: u64,
-    remote: SocketAddrV6,
+    remote: SocketAddr,
     state: State,
     side: Side,
     mtu: u16,
@@ -140,7 +140,7 @@ impl Connection {
         init_cid: ConnectionId,
         loc_cid: ConnectionId,
         rem_cid: ConnectionId,
-        remote: SocketAddrV6,
+        remote: SocketAddr,
         client_config: Option<ClientConfig>,
         tls: TlsSession,
     ) -> Self {
@@ -900,7 +900,7 @@ impl Connection {
     pub fn handle_decode(
         &mut self,
         now: u64,
-        remote: SocketAddrV6,
+        remote: SocketAddr,
         ecn: Option<EcnCodepoint>,
         partial_decode: PartialDecode,
     ) -> Option<BytesMut> {
@@ -2386,7 +2386,7 @@ impl Connection {
         self.rem_cid
     }
 
-    pub fn remote(&self) -> SocketAddrV6 {
+    pub fn remote(&self) -> SocketAddr {
         self.remote
     }
 
@@ -2819,7 +2819,7 @@ const MAX_ACK_BLOCKS: usize = 64;
 #[derive(Debug)]
 pub enum Io {
     Transmit {
-        destination: SocketAddrV6,
+        destination: SocketAddr,
         /// Explicit congestion notification bits to set on the packet
         ecn: Option<EcnCodepoint>,
         packet: Box<[u8]>,

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -294,12 +294,6 @@ impl HeaderCrypto {
     }
 }
 
-#[derive(Clone)]
-pub struct ConnectionInfo {
-    pub(crate) id: ConnectionId,
-    pub(crate) remote: SocketAddrV6,
-}
-
 #[derive(Debug, Fail)]
 pub enum ConnectError {
     #[fail(display = "invalid DNS name: {}", _0)]

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
-use std::net::{Ipv6Addr, SocketAddrV6, UdpSocket};
+use std::net::{Ipv6Addr, SocketAddr, UdpSocket};
 use std::ops::RangeFrom;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -132,18 +132,13 @@ impl Pair {
         .unwrap();
         let client = Endpoint::new(log.new(o!("side" => "Client")), client_config, None).unwrap();
 
-        let localhost = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
-        let server_addr = SocketAddrV6::new(
-            localhost,
+        let server_addr = SocketAddr::new(
+            Ipv6Addr::LOCALHOST.into(),
             SERVER_PORTS.lock().unwrap().next().unwrap(),
-            0,
-            0,
         );
-        let client_addr = SocketAddrV6::new(
-            localhost,
+        let client_addr = SocketAddr::new(
+            Ipv6Addr::LOCALHOST.into(),
             CLIENT_PORTS.lock().unwrap().next().unwrap(),
-            0,
-            0,
         );
         Self {
             log,
@@ -245,7 +240,7 @@ impl Pair {
 struct TestEndpoint {
     side: Side,
     endpoint: Endpoint,
-    addr: SocketAddrV6,
+    addr: SocketAddr,
     socket: Option<UdpSocket>,
     timers: [u64; 4],
     conn: Option<ConnectionHandle>,
@@ -255,7 +250,7 @@ struct TestEndpoint {
 }
 
 impl TestEndpoint {
-    fn new(side: Side, endpoint: Endpoint, addr: SocketAddrV6) -> Self {
+    fn new(side: Side, endpoint: Endpoint, addr: SocketAddr) -> Self {
         let socket = if env::var_os("SSLKEYLOGFILE").is_some() {
             let socket = UdpSocket::bind(addr).expect("failed to bind UDP socket");
             socket
@@ -278,7 +273,7 @@ impl TestEndpoint {
         }
     }
 
-    fn drive(&mut self, log: &Logger, now: u64, remote: SocketAddrV6) {
+    fn drive(&mut self, log: &Logger, now: u64, remote: SocketAddr) {
         if let Some(ref socket) = self.socket {
             loop {
                 let mut buf = [0; 8192];


### PR DESCRIPTION
Fix #154

I wasn't sure whether to branch based on the type of the destination address or the type of the local address. I opted for the former since it allows the OS to provide its usual error message when an unsupported address is used.

It's interesting to note that an "Address family not supported by protocol" error currently brings down the whole endpoint. Perhaps send errors should be propagated back to their associated connection instead?