### PR TITLE
Handshake robustness

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1825,7 +1825,8 @@ impl Connection {
                 })?
         };
         let probe = !close && self.io.probes != 0;
-        if space_id == SpaceId::Data && !probe && self.congestion_blocked() {
+        let mut ack_only = self.space(space_id).pending.is_empty();
+        if space_id == SpaceId::Data && !probe && !ack_only && self.congestion_blocked() {
             return None;
         }
 
@@ -1885,7 +1886,6 @@ impl Connection {
         };
         let mut buf = Vec::new();
         let partial_encode = header.encode(&mut buf);
-        let mut ack_only = space.pending.is_empty();
         let header_len = buf.len();
 
         let sent = if close {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -25,7 +25,6 @@ use crate::{
     frame, Directionality, Frame, Side, StreamId, TransportError, MIN_INITIAL_SIZE, MIN_MTU,
     RESET_TOKEN_SIZE, TIMER_GRANULARITY, VERSION,
 };
-use rustls::internal::msgs::enums::AlertDescription;
 
 pub struct Connection {
     log: Logger,
@@ -2748,11 +2747,6 @@ mod state {
     impl From<frame::ApplicationClose> for CloseReason {
         fn from(x: frame::ApplicationClose) -> Self {
             CloseReason::Application(x)
-        }
-    }
-    impl From<AlertDescription> for CloseReason {
-        fn from(x: AlertDescription) -> Self {
-            TransportError::crypto(x).into()
         }
     }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -350,14 +350,14 @@ impl HeaderKey {
         use self::HeaderKey::*;
         match self {
             AesEcb128(key) => {
-                let mut cipher = Ecb::<Aes128, ZeroPadding>::new_var(key, &[]).unwrap();
+                let cipher = Ecb::<Aes128, ZeroPadding>::new_var(key, &[]).unwrap();
                 let mut buf = [0; 16];
                 buf.copy_from_slice(sample);
                 cipher.encrypt(&mut buf, 16).unwrap();
                 [buf[0], buf[1], buf[2], buf[3], buf[4]]
             }
             AesEcb256(key) => {
-                let mut cipher = Ecb::<Aes256, ZeroPadding>::new_var(key, &[]).unwrap();
+                let cipher = Ecb::<Aes256, ZeroPadding>::new_var(key, &[]).unwrap();
                 let mut buf = [0; 16];
                 buf.copy_from_slice(sample);
                 cipher.encrypt(&mut buf, 16).unwrap();

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -411,6 +411,9 @@ impl Endpoint {
             }
         };
 
+        let remote_validated = self.server_config.as_ref().map_or(false, |cfg| {
+            cfg.use_stateless_retry && client_config.is_none()
+        });
         let conn = self.connections.insert(Connection::new(
             self.log.new(o!("connection" => local_id)),
             Arc::clone(&self.config),
@@ -420,6 +423,7 @@ impl Endpoint {
             remote,
             client_config,
             tls,
+            remote_validated,
         ));
         let conn = ConnectionHandle(conn);
 

--- a/quinn-proto/src/stream.rs
+++ b/quinn-proto/src/stream.rs
@@ -319,7 +319,7 @@ impl Assembler {
         }
     }
 
-    /// Whether `peek` will return at least one nonempty slice
+    /// Whether `read` will return nonzero
     pub fn blocked(&self) -> bool {
         let mask = !0 >> self.written_offset;
         self.written.front().map_or(true, |x| x & mask == mask)

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -934,6 +934,16 @@ fn server_hs_retransmit() {
         pair.client.inbound.len() - 1
     );
     pair.client.inbound.drain(1..);
+    // Client's Initial ACK buys a lot of budget, so keep dropping...
+    for _ in 0..3 {
+        pair.step();
+        info!(
+            pair.log,
+            "dropping {} server handshake packets",
+            pair.client.inbound.len()
+        );
+        pair.client.inbound.drain(..);
+    }
     pair.drive();
     assert_matches!(pair.client.poll(), Some((conn, Event::Connected { .. })) if conn == client_conn);
 }

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -918,3 +918,22 @@ fn server_busy() {
     );
     assert_matches!(pair.server.poll(), None);
 }
+
+#[test]
+fn server_hs_retransmit() {
+    let mut pair = Pair::default();
+    let client_conn = pair
+        .client
+        .connect(pair.server.addr, &client_config(), "localhost")
+        .unwrap();
+    pair.step();
+    assert!(pair.client.inbound.len() > 1); // Initial + Handshakes
+    info!(
+        pair.log,
+        "dropping {} server handshake packets",
+        pair.client.inbound.len() - 1
+    );
+    pair.client.inbound.drain(1..);
+    pair.drive();
+    assert_matches!(pair.client.poll(), Some((conn, Event::Connected { .. })) if conn == client_conn);
+}

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -1039,7 +1039,6 @@ impl Connection {
             .inner
             .connection(self.0.conn)
             .remote()
-            .into()
     }
 
     /// The `ConnectionId`s defined for `conn` locally.


### PR DESCRIPTION
This adds both the draft-mandated anti-amplification measures, and the clientside changes needed to remain well-behaved in the face of packet loss under those measures.