### PR TITLE
IPv4 redux

### DIFF
--- a/quinn/examples/interop.rs
+++ b/quinn/examples/interop.rs
@@ -6,7 +6,6 @@ extern crate failure;
 extern crate slog;
 extern crate futures;
 extern crate slog_term;
-#[macro_use]
 extern crate structopt;
 
 use std::net::ToSocketAddrs;

--- a/quinn/src/platform/cmsg.rs
+++ b/quinn/src/platform/cmsg.rs
@@ -1,70 +1,25 @@
 use std::{mem, ptr};
 
-macro_rules! cmsgs {
-    {$($level:ident { $($name:ident : $ty:ty;)* })*} => {
-        #[allow(non_camel_case_types)]
-        #[derive(Debug, Copy, Clone)]
-        pub enum Cmsg {
-            $($($name($ty),)*)*
-        }
-
-        impl Cmsg {
-            pub fn space(&self) -> usize {
-                let x = match *self {
-                    $($(Cmsg::$name(_) => unsafe { libc::CMSG_SPACE(mem::size_of::<$ty>() as _)},)*)*
-                };
-                x as usize
-            }
-
-            unsafe fn encode(&self, cmsg: &mut libc::cmsghdr) {
-                match *self {
-                    $($(Cmsg::$name(x) => {
-                        cmsg.cmsg_level = libc::$level as _;
-                        cmsg.cmsg_type = libc::$name as _;
-                        cmsg.cmsg_len = libc::CMSG_LEN(mem::size_of::<$ty>() as _) as _;
-                        ptr::write::<$ty>(libc::CMSG_DATA(cmsg) as *mut $ty, x);
-                    })*)*
-                }
-            }
-
-            unsafe fn decode(cmsg: &libc::cmsghdr) -> Option<Self> {
-                Some(match cmsg.cmsg_level {
-                    $(libc::$level => match cmsg.cmsg_type {
-                        $(libc::$name => Cmsg::$name(ptr::read::<$ty>(libc::CMSG_DATA(cmsg) as *const $ty)),)*
-                        _ => { return None; }
-                    },)*
-                    _ => { return None; }
-                })
-            }
-        }
-    }
-}
-
-cmsgs! {
-    IPPROTO_IP {
-        IP_TOS: u8;
-    }
-    IPPROTO_IPV6 {
-        IPV6_TCLASS: libc::c_int;
-    }
-}
-
-pub fn encode(hdr: &mut libc::msghdr, buf: &mut [u8], msgs: &[Cmsg]) {
-    assert!(buf.len() >= msgs.iter().map(|msg| msg.space()).sum());
+pub fn encode<T: Copy + ?Sized>(
+    hdr: &mut libc::msghdr,
+    buf: &mut [u8],
+    level: libc::c_int,
+    ty: libc::c_int,
+    value: T,
+) {
+    let space = unsafe { libc::CMSG_SPACE(mem::size_of_val(&value) as _) as usize };
+    assert!(buf.len() >= space);
     hdr.msg_control = buf.as_mut_ptr() as _;
     hdr.msg_controllen = buf.len() as _;
 
-    let mut len = 0;
-    let mut cursor = unsafe { libc::CMSG_FIRSTHDR(hdr) };
-    for msg in msgs {
-        unsafe {
-            msg.encode(&mut *cursor);
-        }
-        len += msg.space();
-        cursor = unsafe { libc::CMSG_NXTHDR(hdr, cursor) };
+    let mut cmsg = unsafe { &mut *libc::CMSG_FIRSTHDR(hdr) };
+    cmsg.cmsg_level = level;
+    cmsg.cmsg_type = ty;
+    cmsg.cmsg_len = unsafe { libc::CMSG_LEN(mem::size_of_val(&value) as _) } as _;
+    unsafe {
+        ptr::write(libc::CMSG_DATA(cmsg) as *const T as *mut T, value);
     }
-    debug_assert!(len as usize <= buf.len());
-    hdr.msg_controllen = len;
+    hdr.msg_controllen = space as _;
 }
 
 pub struct Iter<'a> {
@@ -86,17 +41,13 @@ impl<'a> Iter<'a> {
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = Cmsg;
-    fn next(&mut self) -> Option<Cmsg> {
-        loop {
-            if self.cmsg.is_null() {
-                return None;
-            }
-            let current = self.cmsg;
-            self.cmsg = unsafe { libc::CMSG_NXTHDR(self.hdr, self.cmsg) };
-            if let Some(x) = unsafe { Cmsg::decode(&*current) } {
-                return Some(x);
-            }
+    type Item = &'a libc::cmsghdr;
+    fn next(&mut self) -> Option<&'a libc::cmsghdr> {
+        if self.cmsg.is_null() {
+            return None;
         }
+        let current = self.cmsg;
+        self.cmsg = unsafe { libc::CMSG_NXTHDR(self.hdr, self.cmsg) };
+        Some(unsafe { &*current })
     }
 }


### PR DESCRIPTION
Where the prior approach broke on even only slightly old Linux, this makes for a simpler, more efficient, more portable, and more robust solution, and the new tests should help avoid any future surprises.

Note that testing dual-stack sockets is a bit dicey since only Linux enables dual-stack mode by default (subject to system configuration), enabling it by hand on the socket takes a bit of effort, and e.g. OpenBSD doesn't support them at all. Still, better than no test at all.