### PR TITLE
Assorted cleanup, panic fix

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -901,6 +901,10 @@ impl Connection {
             );
             return None;
         }
+        if partial_decode.is_0rtt() {
+            debug!(self.log, "dropping 0-RTT packet (currently unimplemented)");
+            return None;
+        }
         let header_crypto = if let Some(space) = partial_decode.space() {
             if let Some(ref space) = self.spaces[space as usize] {
                 Some(&space.header_crypto)
@@ -1187,10 +1191,7 @@ impl Connection {
                     Header::Long {
                         ty: LongType::ZeroRtt,
                         ..
-                    } => {
-                        debug!(self.log, "dropping 0-RTT packet (currently unimplemented)");
-                        Ok(())
-                    }
+                    } => unreachable!("0-RTT is dropped in handle_decode"),
                     Header::VersionNegotiate { .. } => {
                         let mut payload = io::Cursor::new(&packet.payload[..]);
                         if packet.payload.len() % 4 != 0 {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -792,11 +792,11 @@ impl Connection {
         packet: Packet,
     ) -> Result<(), TransportError> {
         let len = packet.header_data.len() + packet.payload.len();
+        self.on_packet_authenticated(now, SpaceId::Initial, ecn, Some(packet_number), false, len);
         self.process_early_payload(now, packet)?;
         if self.state.is_closed() {
             return Ok(());
         }
-        self.on_packet_authenticated(now, SpaceId::Initial, ecn, Some(packet_number), false, len);
         let params = TransportParameters::read(
             Side::Server,
             &mut io::Cursor::new(self.tls.get_quic_transport_parameters().unwrap()),

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1957,11 +1957,8 @@ impl Connection {
 
         let space = self.spaces[space_id as usize].as_mut().unwrap();
         let mut padded = false;
-        if self.side.is_client()
-            && (space_id == SpaceId::Initial || (probe && space_id == SpaceId::Handshake))
-        {
-            // Either this is an initial packet, or the server might be blocked by
-            // anti-amplification measures and need some bytes to continue
+        if self.side.is_client() && space_id == SpaceId::Initial {
+            // Initial-only packets MUST be padded
             buf.resize(MIN_INITIAL_SIZE - space.crypto.tag_len(), 0);
             padded = true;
         }

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1057,7 +1057,7 @@ impl Connection {
                             // match the Destination Connection ID from its Initial packet.
                             return Ok(());
                         }
-                        trace!(self.log, "retrying");
+                        trace!(self.log, "retrying with CID {rem_cid}", rem_cid = rem_cid);
                         self.orig_rem_cid = Some(self.rem_cid);
                         self.rem_cid = rem_cid;
                         self.on_packet_acked(SpaceId::Initial, 0);
@@ -1132,6 +1132,11 @@ impl Connection {
                         src_cid: rem_cid, ..
                     } => {
                         if !state.rem_cid_set {
+                            trace!(
+                                self.log,
+                                "switching remote CID to {rem_cid}",
+                                rem_cid = rem_cid
+                            );
                             let mut state = state.clone();
                             self.rem_cid = rem_cid;
                             state.rem_cid_set = true;
@@ -1429,7 +1434,11 @@ impl Connection {
                 }
                 Frame::MaxStreamData { id, offset } => {
                     if id.initiator() != self.side && id.directionality() == Directionality::Uni {
-                        debug!(self.log, "got MAX_STREAM_DATA on recv-only stream");
+                        debug!(
+                            self.log,
+                            "got MAX_STREAM_DATA on recv-only {stream}",
+                            stream = id
+                        );
                         return Err(TransportError::PROTOCOL_VIOLATION);
                     }
                     if let Some(ss) = self.streams.get_send_mut(id) {
@@ -1442,7 +1451,11 @@ impl Connection {
                             ss.max_data = offset;
                         }
                     } else {
-                        debug!(self.log, "got MAX_STREAM_DATA on unopened stream");
+                        debug!(
+                            self.log,
+                            "got MAX_STREAM_DATA on unopened {stream}",
+                            stream = id
+                        );
                         return Err(TransportError::PROTOCOL_VIOLATION);
                     }
                 }

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1014,6 +1014,7 @@ impl Connection {
                         self.io.timer_stop(Timer::LossDetection);
                         self.io.timer_stop(Timer::Close);
                         self.io.timer_stop(Timer::Idle);
+                        self.io.timer_stop(Timer::KeyDiscard);
                     }
                     State::Drained
                 }
@@ -2042,6 +2043,8 @@ impl Connection {
     fn close_common(&mut self, now: u64) {
         trace!(self.log, "connection closed");
         self.io.timer_stop(Timer::LossDetection);
+        self.io.timer_stop(Timer::Idle);
+        self.io.timer_stop(Timer::KeyDiscard);
         self.io.timer_start(Timer::Close, now + 3 * self.pto());
     }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -7,7 +7,7 @@ use std::{io, str};
 use aes::{Aes128, Aes256};
 use block_modes::block_padding::ZeroPadding;
 use block_modes::{BlockMode, Ecb};
-use bytes::{BigEndian, Buf, BufMut, ByteOrder, BytesMut};
+use bytes::{Buf, BufMut, ByteOrder, BytesMut, LittleEndian};
 use orion::hazardous::stream::chacha20;
 use ring::aead;
 use ring::digest;
@@ -365,7 +365,7 @@ impl HeaderKey {
             }
             ChaCha20(key) => {
                 let mut buf = [0; 5];
-                let counter = BigEndian::read_u32(&sample[..4]);
+                let counter = LittleEndian::read_u32(&sample[..4]);
                 let nonce =
                     chacha20::Nonce::from_slice(&sample[4..]).expect("failed to generate nonce");
                 chacha20::decrypt(key, &nonce, counter, &[0; 5], &mut buf).unwrap();

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -54,12 +54,26 @@ impl PartialDecode {
                 version: VERSION,
                 first,
                 ..
-            } => match LongHeaderType::from_byte(first) {
-                Ok(LongHeaderType::Initial) => Some(SpaceId::Initial),
-                Ok(LongHeaderType::Standard(LongType::Handshake)) => Some(SpaceId::Handshake),
-                _ => None,
+            } => match LongHeaderType::from_byte(first).ok()? {
+                LongHeaderType::Retry => None,
+                LongHeaderType::Initial => Some(SpaceId::Initial),
+                LongHeaderType::Standard(LongType::Handshake) => Some(SpaceId::Handshake),
+                LongHeaderType::Standard(LongType::ZeroRtt) => Some(SpaceId::Data),
             },
             _ => None,
+        }
+    }
+
+    pub fn is_0rtt(&self) -> bool {
+        match self.invariant_header {
+            InvariantHeader::Long {
+                version: VERSION,
+                first,
+                ..
+            } => {
+                LongHeaderType::from_byte(first) == Ok(LongHeaderType::Standard(LongType::ZeroRtt))
+            }
+            _ => false,
         }
     }
 


### PR DESCRIPTION
0-RTT packets weren't being assigned a packet space, which meant no header crypto was selected for them, which lead to a panic in `PartialDecode::finish` which correctly assumed that all standard-form long-header packets have encrypted headers. This corrects the omission and drops 0-RTT packets prior to decryption since rustls isn't giving us 0-RTT keys yet anyway.