### PR TITLE
Use libc from crates.io

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -38,7 +38,7 @@ tokio-timer = "0.2.1"
 untrusted = "0.6.2"
 webpki = "0.18"
 webpki-roots = "0.15"
-libc = { git = "https://github.com/rust-lang/libc.git", rev = "8ee27008ffb0dec2e79360e8e65d96446ac54dff" }
+libc = "0.2.46"
 mio = "0.6"
 
 [dev-dependencies]


### PR DESCRIPTION
The git commit that libc had been pinned
to earlier has been part of a release since.