### PR TITLE
Implement dynamic stream ID flow control

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -160,13 +160,13 @@ impl Connection {
 
         let initial_space = PacketSpace::new(Crypto::new_initial(&init_cid, side));
         let mut streams = FnvHashMap::default();
-        for i in 0..config.max_remote_streams_uni {
+        for i in 0..config.stream_window_uni {
             streams.insert(
                 StreamId::new(!side, Directionality::Uni, u64::from(i)),
                 stream::Recv::new(u64::from(config.stream_receive_window)).into(),
             );
         }
-        for i in 0..config.max_remote_streams_bidi {
+        for i in 0..config.stream_window_bidi {
             streams.insert(
                 StreamId::new(!side, Directionality::Bi, i as u64),
                 Stream::new_bi(config.stream_receive_window as u64),
@@ -246,8 +246,8 @@ impl Connection {
                 next_bi: 0,
                 max_uni: 0,
                 max_bi: 0,
-                max_remote_uni: config.max_remote_streams_uni as u64,
-                max_remote_bi: config.max_remote_streams_bidi as u64,
+                max_remote_uni: config.stream_window_uni,
+                max_remote_bi: config.stream_window_bidi,
                 finished: Vec::new(),
             },
             config,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -744,6 +744,13 @@ impl Endpoint {
 }
 
 /// Parameters governing the core QUIC state machine
+///
+/// This should be tuned to suit the application. In particular, window sizes for streams, stream
+/// data, and overall connection data should be set differently depending on the expected round trip
+/// time, link capacity, memory availability, and rate of stream creation. The default configuration
+/// is tuned for a 100Mbps link with a 100ms round trip time, with remote endpoints opening at most
+/// 320 new streams per second. Applications which do not require remotely-initiated streams should
+/// set the stream windows to zero.
 pub struct Config {
     /// Maximum number of bidirectional streams that may be initiated by the peer but not yet
     /// accepted locally

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -837,8 +837,8 @@ impl Default for Config {
         rand::thread_rng().fill_bytes(&mut reset_value);
 
         Self {
-            stream_window_bidi: 0,
-            stream_window_uni: 0,
+            stream_window_bidi: 32,
+            stream_window_uni: 32,
             idle_timeout: 10,
             stream_receive_window: STREAM_RWND,
             receive_window: 8 * STREAM_RWND,

--- a/quinn-proto/src/stream.rs
+++ b/quinn-proto/src/stream.rs
@@ -138,7 +138,7 @@ pub struct Recv {
     /// reads
     pub unordered: bool,
     pub assembler: Assembler,
-    /// Whether the application is aware of this stream yet
+    /// Whether the application has been notified of this stream yet
     pub fresh: bool,
 }
 

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -73,10 +73,7 @@ struct Pair {
 
 impl Default for Pair {
     fn default() -> Self {
-        let mut server = Config::default();
-        server.stream_window_uni = 32;
-        server.stream_window_bidi = 32;
-        Pair::new(server, Default::default(), server_config())
+        Pair::new(Default::default(), Default::default(), server_config())
     }
 }
 
@@ -458,8 +455,6 @@ fn server_stateless_reset() {
 
     let server = Config {
         reset_key,
-        stream_window_bidi: 32,
-        stream_window_uni: 32,
         ..Config::default()
     };
 

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -74,8 +74,8 @@ struct Pair {
 impl Default for Pair {
     fn default() -> Self {
         let mut server = Config::default();
-        server.max_remote_streams_uni = 32;
-        server.max_remote_streams_bidi = 32;
+        server.stream_window_uni = 32;
+        server.stream_window_bidi = 32;
         Pair::new(server, Default::default(), server_config())
     }
 }
@@ -458,8 +458,8 @@ fn server_stateless_reset() {
 
     let server = Config {
         reset_key,
-        max_remote_streams_bidi: 32,
-        max_remote_streams_uni: 32,
+        stream_window_bidi: 32,
+        stream_window_uni: 32,
         ..Config::default()
     };
 
@@ -697,7 +697,7 @@ fn close_during_handshake() {
 #[test]
 fn stream_id_backpressure() {
     let server = Config {
-        max_remote_streams_uni: 1,
+        stream_window_uni: 1,
         ..Config::default()
     };
     let mut pair = Pair::new(server, Default::default(), server_config());

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -69,8 +69,8 @@ apply_params!(make_struct);
 impl TransportParameters {
     pub fn new(config: &Config) -> Self {
         TransportParameters {
-            initial_max_streams_bidi: config.max_remote_streams_bidi,
-            initial_max_streams_uni: config.max_remote_streams_uni,
+            initial_max_streams_bidi: config.stream_window_bidi as u64,
+            initial_max_streams_uni: config.stream_window_uni as u64,
             initial_max_data: config.receive_window,
             initial_max_stream_data_bidi_local: config.stream_receive_window,
             initial_max_stream_data_bidi_remote: config.stream_receive_window,

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -103,7 +103,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     server_config.set_certificate(cert_chain, key)?;
 
     let mut endpoint = quinn::EndpointBuilder::new(quinn::Config {
-        max_remote_streams_bidi: 64,
+        stream_window_bidi: 64,
         ..Default::default()
     });
     endpoint.logger(log.clone());

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -102,10 +102,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     let cert_chain = quinn::CertificateChain::from_pem(&cert_chain)?;
     server_config.set_certificate(cert_chain, key)?;
 
-    let mut endpoint = quinn::EndpointBuilder::new(quinn::Config {
-        stream_window_bidi: 64,
-        ..Default::default()
-    });
+    let mut endpoint = quinn::Endpoint::new();
     endpoint.logger(log.clone());
     endpoint.listen(server_config.build());
 

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -45,7 +45,7 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
     server_config.set_certificate(cert_chain, key).unwrap();
 
     let mut server = EndpointBuilder::new(Config {
-        max_remote_streams_bidi: 32,
+        stream_window_bidi: 32,
         ..Config::default()
     });
     server.logger(log.clone());

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -84,11 +84,15 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
                     stream
                         .map_err(|_| ())
                         .and_then(move |stream| {
-                            tokio::io::write_all(stream, b"foo".to_vec()).map_err(|_| ())
+                            tokio::io::write_all(stream, b"foo".to_vec())
+                                .map_err(|e| panic!("write: {}", e))
                         })
-                        .and_then(|(stream, _)| tokio::io::shutdown(stream).map_err(|_| ()))
+                        .and_then(|(stream, _)| {
+                            tokio::io::shutdown(stream).map_err(|e| panic!("finish: {}", e))
+                        })
                         .and_then(move |stream| {
-                            read_to_end(stream, usize::max_value()).map_err(|_| ())
+                            read_to_end(stream, usize::max_value())
+                                .map_err(|e| panic!("read: {}", e))
                         })
                         .and_then(move |(_, data)| {
                             assert_eq!(&data[..], b"foo");


### PR DESCRIPTION
This makes the implementation significantly more flexible and responsive without requiring any particular effort from the application. I'd be interested to hear any thoughts on enabling incoming streams by default; it seems like doing otherwise is a massive gotcha.

Fixes #62