### PR TITLE
Assorted fixes

### DIFF
--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -394,9 +394,7 @@ pub fn hkdf_expand(key: &SigningKey, label: &[u8], out: &mut [u8]) {
 
 fn initial_secret(conn_id: &ConnectionId) -> SigningKey {
     let key = SigningKey::new(&digest::SHA256, &INITIAL_SALT);
-    let mut buf = Vec::with_capacity(8);
-    buf.put_slice(conn_id);
-    hkdf::extract(&key, &buf)
+    hkdf::extract(&key, conn_id)
 }
 
 const INITIAL_SALT: [u8; 20] = [

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -122,6 +122,7 @@ impl Endpoint {
                         connection::Io::RetireConnectionId { connection_id } => {
                             self.connection_ids.remove(&connection_id);
                             let new_cid = self.new_cid();
+                            self.connection_ids.insert(new_cid, conn);
                             self.connections[conn.0].issue_cid(new_cid);
                             continue;
                         }
@@ -202,6 +203,7 @@ impl Endpoint {
             // We've already issued one CID as part of the normal handshake process.
             for _ in 1..LOCAL_CID_COUNT {
                 let cid = self.new_cid();
+                self.connection_ids.insert(cid, conn);
                 self.connections[conn.0].issue_cid(cid);
             }
         }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -781,8 +781,7 @@ pub struct Config {
     pub stream_window_uni: u64,
     /// Maximum duration of inactivity to accept before timing out the connection (s).
     ///
-    /// Maximum value is 600 seconds. The actual value used is the minimum of this and the peer's
-    /// own idle timeout. 0 for none.
+    /// The actual value used is the minimum of this and the peer's own idle timeout. 0 for none.
     pub idle_timeout: u64,
     /// Maximum number of bytes the peer may transmit without acknowledgement on any one stream
     /// before becoming blocked.
@@ -814,11 +813,15 @@ pub struct Config {
     /// The RTT used before an RTT sample is taken (μs)
     pub initial_rtt: u64,
 
-    /// The default max packet size used for calculating default and minimum congestion windows.
+    /// The max packet size that was used for calculating default and minimum congestion windows.
     pub max_datagram_size: u64,
     /// Default limit on the amount of outstanding data in bytes.
+    ///
+    /// Recommended value: `min(10 * max_datagram_size, max(2 * max_datagram_size, 14600))`
     pub initial_window: u64,
     /// Default minimum congestion window.
+    ///
+    /// Recommended value: `2 * max_datagram_size`.
     pub minimum_window: u64,
     /// Reduction in congestion window when a new loss event is detected. 0.16 format
     pub loss_reduction_factor: u16,


### PR DESCRIPTION
I continue to get a lot of mileage out of browsing around at random and second-guessing things.

I almost added a `packet.is_initial()` guard to the `connection_ids_initial` query, but I can't think of any case where it would matter.