### PR TITLE
Clearer handling of ConnectionHandles

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -3141,15 +3141,6 @@ struct SentPacket {
     retransmits: Retransmits,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct ConnectionHandle(pub usize);
-
-impl From<ConnectionHandle> for usize {
-    fn from(x: ConnectionHandle) -> usize {
-        x.0
-    }
-}
-
 /// Ensures we can always fit all our ACKs in a single minimum-MTU packet with room to spare
 const MAX_ACK_BLOCKS: usize = 64;
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -16,7 +16,7 @@ use slog::{self, Logger};
 
 use crate::coding::BufMutExt;
 use crate::connection::{
-    self, initial_close, ClientConfig, Connection, ConnectionError, ConnectionHandle, TimerUpdate,
+    self, initial_close, ClientConfig, Connection, ConnectionError, TimerUpdate,
 };
 use crate::crypto::{
     self, reset_token_for, ConnectError, Crypto, HeaderCrypto, TlsSession, TokenKey,
@@ -1027,6 +1027,15 @@ impl slog::Value for Timer {
         serializer: &mut dyn slog::Serializer,
     ) -> slog::Result {
         serializer.emit_arguments(key, &format_args!("{:?}", self))
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ConnectionHandle(pub usize);
+
+impl From<ConnectionHandle> for usize {
+    fn from(x: ConnectionHandle) -> usize {
+        x.0
     }
 }
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -22,7 +22,7 @@ mod transport_parameters;
 mod varint;
 
 mod connection;
-pub use crate::connection::{ConnectionError, ConnectionHandle, TimerUpdate};
+pub use crate::connection::{ConnectionError, TimerUpdate};
 
 mod crypto;
 pub use crate::crypto::{ClientConfig, ConnectError, TokenKey};
@@ -32,7 +32,9 @@ use crate::frame::Frame;
 pub use crate::frame::{ApplicationClose, ConnectionClose};
 
 mod endpoint;
-pub use crate::endpoint::{Config, Endpoint, EndpointError, Event, Io, ServerConfig, Timer};
+pub use crate::endpoint::{
+    Config, ConnectionHandle, Endpoint, EndpointError, Event, Io, ServerConfig, Timer,
+};
 
 mod packet;
 pub use crate::packet::{ConnectionId, EcnCodepoint};

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -802,7 +802,7 @@ fn key_update() {
         Ok((ref data, 0)) if data == MSG1
     );
 
-    pair.client.connections[client_ch.0].force_key_update();
+    pair.client.connections[client_ch].force_key_update();
 
     const MSG2: &[u8] = b"hello2";
     pair.client.write(client_ch, s, MSG2).unwrap();
@@ -831,7 +831,7 @@ fn key_update_reordered() {
     assert!(!pair.client.outbound.is_empty());
     pair.client.delay_outbound();
 
-    pair.client.connections[client_ch.0].force_key_update();
+    pair.client.connections[client_ch].force_key_update();
     info!(pair.log, "updated keys");
 
     const MSG2: &[u8] = b"two";


### PR DESCRIPTION
I opted for using `ch` everywhere except as a field on the `ConnectionInner` type in the quinn crate: since that represents a `Connection`, I felt `handle` made the code easier to read.

Also made it so the type is a little more abstracted.