### PR TITLE
Congestion control fix

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1255,13 +1255,9 @@ impl Connection {
 
                         if self.side.is_client() {
                             // Client-only beceause server params were set from the client's Initial
-                            let params = match self.tls.transport_parameters() {
-                                Ok(Some(params)) => Ok(params),
-                                Ok(None) => Err(TransportError::PROTOCOL_VIOLATION(
-                                    "transport parameters missing",
-                                )),
-                                Err(e) => Err(e),
-                            }?;
+                            let params = self.tls.transport_parameters()?.ok_or(
+                                TransportError::PROTOCOL_VIOLATION("transport parameters missing"),
+                            )?;
 
                             if self.has_0rtt() {
                                 if !self.tls.as_client().is_early_data_accepted() {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -461,7 +461,7 @@ impl Connection {
         if info.ack_eliciting {
             // Congestion control
             // Do not increase congestion window in recovery period.
-            if !self.in_recovery(packet) {
+            if !self.in_recovery(info.time_sent) {
                 if self.congestion_window < self.ssthresh {
                     // Slow start.
                     self.congestion_window += info.size as u64;


### PR DESCRIPTION
I think this accounts for the bulk of the strangely pessimal performance I've been observing correlated with early packet loss: the connection was getting stuck in congestion recovery mode, because packet numbers tend to be much smaller than microsecond timestamps.