### PR TITLE
Use Instant and Duration for timing

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -684,9 +684,7 @@ impl Connection {
 
         // Calculate PTO duration
         const MAX_PTO_EXPONENT: u32 = 24; // 2^24μs = ~17 seconds
-        let timeout = self.rtt.smoothed + 4 * self.rtt.var + self.max_ack_delay();
-        let timeout = cmp::max(timeout, TIMER_GRANULARITY)
-            * 2u64.pow(cmp::min(self.pto_count, MAX_PTO_EXPONENT));
+        let timeout = self.pto() * 2u64.pow(cmp::min(self.pto_count, MAX_PTO_EXPONENT));
         self.io.timer_start(
             Timer::LossDetection,
             self.time_of_last_sent_ack_eliciting_packet + timeout,

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -695,7 +695,6 @@ impl Connection {
         }
 
         // Calculate PTO duration
-        const MAX_PTO_EXPONENT: u32 = 24; // 2^24μs = ~17 seconds
         let timeout = self.pto() * 2u32.pow(cmp::min(self.pto_count, MAX_PTO_EXPONENT));
         self.io.timer_start(
             Timer::LossDetection,
@@ -3553,3 +3552,5 @@ struct PathResponse {
 fn micros_from(x: Duration) -> u64 {
     x.as_secs() * 1000 * 1000 + x.subsec_micros() as u64
 }
+
+const MAX_PTO_EXPONENT: u32 = 24; // 2^24μs = ~17 seconds

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -13,6 +13,7 @@ extern crate slog;
 use std::fmt;
 use std::net::SocketAddr;
 use std::ops;
+use std::time::Duration;
 
 mod coding;
 mod dedup;
@@ -213,4 +214,4 @@ const MAX_CID_SIZE: usize = 18;
 const MIN_CID_SIZE: usize = 4;
 const MIN_INITIAL_SIZE: usize = 1200;
 const MIN_MTU: u16 = 1232;
-const TIMER_GRANULARITY: u64 = 1000;
+const TIMER_GRANULARITY: Duration = Duration::from_millis(1);

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -6,7 +6,6 @@ use std::net::ToSocketAddrs;
 use std::rc::Rc;
 use std::str;
 use std::sync::Arc;
-use std::time::Instant;
 
 use err_derive::Error;
 use fnv::FnvHashMap;
@@ -71,7 +70,6 @@ impl<'a> EndpointBuilder<'a> {
                 self.server_config.map(Arc::new),
             )?,
             outgoing: None,
-            epoch: Instant::now(),
             pending: FnvHashMap::default(),
             timers: FuturesUnordered::new(),
             buffered_incoming: VecDeque::new(),


### PR DESCRIPTION
Thought about this after that slowdown bug -- it seems pretty okay? Not sure why you went with `u64` in the first place, so curious about your thinking there.

This compiles and passes the -proto tests, but fails the high-level echo tests for now.