### PR TITLE
Expand ECN support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
 script:
 - cargo clean
 - cargo build --all-features
-- cargo test --all-features
+- RUST_BACKTRACE=1 cargo test --all-features
 - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
     cargo fmt -- --check;
   fi

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -35,7 +35,7 @@ untrusted = "0.6.2"
 webpki = "0.19"
 webpki-roots = "0.16"
 ct-logs = "0.5"
-libc = "0.2.46"
+libc = "0.2.49"
 mio = "0.6"
 
 [dev-dependencies]

--- a/quinn/src/platform/cmsg.rs
+++ b/quinn/src/platform/cmsg.rs
@@ -36,7 +36,7 @@ impl<'a> Encoder<'a> {
         assert!(mem::align_of::<T>() <= mem::align_of::<libc::cmsghdr>());
         let space = unsafe { libc::CMSG_SPACE(mem::size_of_val(&value) as _) as usize };
         assert!(
-            self.hdr.msg_controllen >= self.len + space,
+            self.hdr.msg_controllen as usize >= self.len + space,
             "control message buffer too small"
         );
         let cmsg = self.cmsg.take().expect("no control buffer space remaining");
@@ -60,7 +60,7 @@ impl<'a> Encoder<'a> {
 // by `sendmsg`.
 impl<'a> Drop for Encoder<'a> {
     fn drop(&mut self) {
-        self.hdr.msg_controllen = self.len;
+        self.hdr.msg_controllen = self.len as _;
     }
 }
 

--- a/quinn/src/platform/mod.rs
+++ b/quinn/src/platform/mod.rs
@@ -2,15 +2,13 @@
 use quinn_proto::EcnCodepoint;
 use std::{io, net::SocketAddr};
 
-// The Linux code should work for most unixes, but as of this writing nobody's ported the
-// CMSG_... macros to the libc crate for any of the BSDs.
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 mod cmsg;
-#[cfg(target_os = "linux")]
-mod linux;
+#[cfg(unix)]
+mod unix;
 
 // No ECN support
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 mod fallback;
 
 pub trait UdpExt {

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -25,7 +25,7 @@ fn echo_v4() {
 }
 
 #[test]
-#[cfg(target_os = "linux")] // Dual-stack sockets aren't the default anywhere else.
+#[cfg(any(target_os = "linux", target_os = "macos"))] // Dual-stack sockets aren't the default anywhere else.
 fn echo_dualstack() {
     run_echo(
         SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),


### PR DESCRIPTION
libc's CMSG macros got built out to many more platforms. There may remain some obscure platforms where this will still fail to build, but we can account for them as they show up in practice.

Note that some bugs remain in the new libc bindings, so we may want to defer merging this until https://github.com/rust-lang/libc/pull/1235 shows up in a release.