### PR TITLE
Fix version negotiation on outgoing connections

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2657,8 +2657,8 @@ impl Connection {
         now: Instant,
         packet: &mut Packet,
     ) -> Result<Option<u64>, Option<TransportError>> {
-        if packet.header.is_retry() {
-            // Retry packets are not encrypted and have no packet number
+        if !packet.header.is_protected() {
+            // Unprotected packets also don't have packet numbers
             return Ok(None);
         }
         let space = packet.header.space();

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -339,10 +339,11 @@ impl Header {
         w.put_slice(src_cid);
     }
 
-    pub fn is_retry(&self) -> bool {
+    /// Whether the packet is encrypted on the wire
+    pub fn is_protected(&self) -> bool {
         match *self {
-            Header::Retry { .. } => true,
-            _ => false,
+            Header::Retry { .. } | Header::VersionNegotiate { .. } => false,
+            _ => true,
         }
     }
 


### PR DESCRIPTION
We were trying to decrypt version negotiation packets, which aren't encrypted in the first place, leading to the packets being dropped and the connection timing out, taking longer than necessary and giving a less helpful error when connecting to a server that does not support the version we implement.