### PR TITLE
Account for all UDP datagram bytes in anti-amplification

### DIFF
--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -89,9 +89,7 @@ impl PartialDecode {
         self.plain_header.dst_cid()
     }
 
-    /// Length of data being decoded
-    ///
-    /// May account for multiple packets.
+    /// Length of QUIC packet being decoded
     pub fn len(&self) -> usize {
         self.buf.get_ref().len()
     }


### PR DESCRIPTION
Authentication/correctness is an independent concern. Improves behavior when coalesced 0-RTT is rejected, which could otherwise lead to large parts of the initial packet not being counted for anti-amplification credit.