### PR TITLE
[WIP] Represent connection closing as instant to the application layer

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1385,20 +1385,12 @@ impl Connection {
             }
             State::Closed(_) => {
                 for frame in frame::Iter::new(packet.payload.into()) {
-                    let peer_reason = match frame {
-                        Frame::ApplicationClose(reason) => {
-                            ConnectionError::ApplicationClosed { reason }
-                        }
-                        Frame::ConnectionClose(reason) => {
-                            ConnectionError::ConnectionClosed { reason }
-                        }
+                    match frame {
+                        Frame::ApplicationClose(_) | Frame::ConnectionClose(_) => {}
                         _ => {
                             continue;
                         }
                     };
-                    self.events.push_back(Event::ConnectionLost {
-                        reason: peer_reason,
-                    });
                     trace!(self.log, "draining");
                     self.state = State::Draining;
                     return Ok(());

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -1031,7 +1031,7 @@ pub enum Event {
     Connected,
     /// A connection was lost.
     ///
-    /// Emitted at the end of the lifetime of a connection, even if it was closed locally.
+    /// Not emitted for locally-closed connections.
     ConnectionLost { reason: ConnectionError },
     /// One or more new streams has been opened and is readable
     StreamOpened,

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -139,7 +139,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
                             .map_err(|e| format_err!("failed to read response: {}", e))
                             .map(move |x| (x, response_start))
                     })
-                    .and_then(move |((_, data), response_start)| {
+                    .map(move |((_, data), response_start)| {
                         let duration = response_start.elapsed();
                         eprintln!(
                             "response received in {:?} - {} KiB/s",
@@ -148,7 +148,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
                         );
                         io::stdout().write_all(&data).unwrap();
                         io::stdout().flush().unwrap();
-                        conn.close(0, b"done").map_err(|_| unreachable!())
+                        conn.close(0, b"done");
                     })
                     .map(|()| eprintln!("drained"))
             }),

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -713,7 +713,10 @@ impl Connection {
         let endpoint = &mut *self.0.endpoint.borrow_mut();
 
         let pending = endpoint.pending.get_mut(&self.0.handle).unwrap();
-        assert!(!pending.closing, "a connection can only be closed once");
+        if pending.closing {
+            debug!(endpoint.log, "connection closed redundantly");
+            return;
+        }
         pending.closing = true;
         pending.fail(ConnectionError::ApplicationClosed {
             reason: quinn::ApplicationClose {

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -87,9 +87,9 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
                             read_to_end(stream, usize::max_value())
                                 .map_err(|e| panic!("read: {}", e))
                         })
-                        .and_then(move |(_, data)| {
+                        .map(move |(_, data)| {
                             assert_eq!(&data[..], b"foo");
-                            conn.close(0, b"done").map_err(|_| unreachable!())
+                            conn.close(0, b"done");
                         })
                 }),
         )


### PR DESCRIPTION
Possible fix for #250, #251, #252. Theoretically complete, but I need to go over this again when I'm more rested to make sure I haven't broken any of the tokio layer's state sync.