### PR TITLE
Return Connections from Endpoints after creation

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -515,7 +515,7 @@ impl Connection {
         self.space_mut(space).pending_acks.subtract(&info.acks);
     }
 
-    fn timeout(&mut self, now: Instant, timer: Timer) {
+    pub(crate) fn timeout(&mut self, now: Instant, timer: Timer) {
         match timer {
             Timer::Close => {
                 self.state = State::Drained;

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -24,7 +24,9 @@ mod transport_parameters;
 pub mod varint;
 
 mod connection;
-pub use crate::connection::{ConnectionError, TimerSetting, TimerUpdate};
+pub use crate::connection::{
+    Connection, ConnectionError, ConnectionEvent, EndpointEvent, TimerSetting, TimerUpdate,
+};
 
 mod crypto;
 pub use crate::crypto::{ClientConfig, TokenKey};
@@ -35,8 +37,8 @@ pub use crate::frame::{ApplicationClose, ConnectionClose};
 
 mod endpoint;
 pub use crate::endpoint::{
-    ConfigError, ConnectError, ConnectionHandle, Endpoint, EndpointConfig, Event, ServerConfig,
-    Timer, TransportConfig,
+    ConfigError, ConnectError, ConnectionHandle, DatagramEvent, Endpoint, EndpointConfig, Event,
+    ServerConfig, Timer, TransportConfig,
 };
 
 mod packet;

--- a/quinn-proto/src/tests.rs
+++ b/quinn-proto/src/tests.rs
@@ -8,6 +8,7 @@ use std::{cmp, env, fmt, mem, str};
 
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
+use fnv::FnvHashMap;
 use rand::RngCore;
 use ring::digest;
 use ring::hmac::SigningKey;
@@ -213,7 +214,7 @@ impl Pair {
 
     fn connect(&mut self) -> (ConnectionHandle, ConnectionHandle) {
         info!(self.log, "connecting");
-        let client_ch = self
+        let (client_ch, client_conn) = self
             .client
             .connect(
                 self.server.addr,
@@ -222,11 +223,26 @@ impl Pair {
                 "localhost",
             )
             .unwrap();
+        self.client.connections.insert(client_ch, client_conn);
         self.drive();
         let server_ch = self.server.assert_accept();
-        assert_matches!(self.client.poll(), Some((ch, Event::Connected { .. })) if ch == client_ch);
-        assert_matches!(self.server.poll(), Some((ch, Event::Connected { .. })) if ch == server_ch);
+        assert_matches!(
+            self.client_conn_mut(client_ch).poll(),
+            Some(Event::Connected { .. })
+        );
+        assert_matches!(
+            self.server_conn_mut(server_ch).poll(),
+            Some(Event::Connected { .. })
+        );
         (client_ch, server_ch)
+    }
+
+    fn client_conn_mut(&mut self, ch: ConnectionHandle) -> &mut Connection {
+        self.client.connections.get_mut(&ch).unwrap()
+    }
+
+    fn server_conn_mut(&mut self, ch: ConnectionHandle) -> &mut Connection {
+        self.server.connections.get_mut(&ch).unwrap()
     }
 }
 
@@ -236,11 +252,12 @@ struct TestEndpoint {
     addr: SocketAddr,
     socket: Option<UdpSocket>,
     timers: [Option<Instant>; Timer::COUNT],
-    conn: Option<ConnectionHandle>,
     outbound: VecDeque<Transmit>,
     delayed: VecDeque<Transmit>,
     inbound: VecDeque<(Instant, Option<EcnCodepoint>, Box<[u8]>)>,
     accepted: Option<ConnectionHandle>,
+    connections: FnvHashMap<ConnectionHandle, Connection>,
+    conn_events: FnvHashMap<ConnectionHandle, VecDeque<ConnectionEvent>>,
 }
 
 impl TestEndpoint {
@@ -260,11 +277,12 @@ impl TestEndpoint {
             addr,
             socket,
             timers: [None; Timer::COUNT],
-            conn: None,
             outbound: VecDeque::new(),
             delayed: VecDeque::new(),
             inbound: VecDeque::new(),
             accepted: None,
+            connections: FnvHashMap::default(),
+            conn_events: FnvHashMap::default(),
         }
     }
 
@@ -277,7 +295,34 @@ impl TestEndpoint {
                 }
             }
         }
-        if let Some(conn) = self.conn {
+
+        while self.inbound.front().map_or(false, |x| x.0 <= now) {
+            let (_, ecn, packet) = self.inbound.pop_front().unwrap();
+            if let Some((ch, event)) =
+                self.endpoint
+                    .handle(now, remote, ecn, Vec::from(packet).into())
+            {
+                match event {
+                    DatagramEvent::NewConnection(conn) => {
+                        self.connections.insert(ch, conn);
+                        self.accepted = Some(ch);
+                    }
+                    DatagramEvent::ConnectionEvent(event) => {
+                        self.conn_events
+                            .entry(ch)
+                            .or_insert_with(|| VecDeque::new())
+                            .push_back(event);
+                    }
+                }
+            }
+        }
+
+        while let Some(x) = self.poll_transmit() {
+            self.outbound.push_back(x);
+        }
+
+        let mut endpoint_events: Vec<(ConnectionHandle, EndpointEvent)> = vec![];
+        for (ch, conn) in self.connections.iter_mut() {
             for &timer in Timer::VALUES.iter() {
                 if let Some(time) = self.timers[timer as usize] {
                     if time <= now {
@@ -288,47 +333,56 @@ impl TestEndpoint {
                             timer = timer
                         );
                         self.timers[timer as usize] = None;
-                        self.endpoint.timeout(now, conn, timer);
+                        conn.timeout(now, timer);
                     }
                 }
             }
-        }
-        while self.inbound.front().map_or(false, |x| x.0 <= now) {
-            let (_, ecn, packet) = self.inbound.pop_front().unwrap();
-            if let Some(ch) = self
-                .endpoint
-                .handle(now, remote, ecn, Vec::from(packet).into())
-            {
-                self.accepted = Some(ch);
+
+            for (_, mut events) in self.conn_events.drain() {
+                for event in events.drain(..) {
+                    conn.handle_event(event);
+                }
+            }
+
+            while let Some(event) = conn.poll_endpoint_events() {
+                endpoint_events.push((*ch, event));
+            }
+
+            while let Some(x) = conn.poll_transmit(now) {
+                self.outbound.push_back(x);
+            }
+
+            while let Some(x) = conn.poll_timers() {
+                self.timers[x.timer as usize] = match x.update {
+                    TimerSetting::Stop => {
+                        trace!(
+                            log,
+                            "{side:?} {timer:?} stop",
+                            side = self.side,
+                            timer = x.timer
+                        );
+                        None
+                    }
+                    TimerSetting::Start(time) => {
+                        trace!(
+                            log,
+                            "{side:?} {timer:?} set to expire at {:?}",
+                            time,
+                            side = self.side,
+                            timer = x.timer,
+                        );
+                        Some(time)
+                    }
+                };
             }
         }
-        self.endpoint.handle_endpoint_events();
-        while let Some(x) = self.endpoint.poll_transmit(now) {
-            self.outbound.push_back(x);
-        }
-        while let Some((ch, x)) = self.endpoint.poll_timers() {
-            self.conn = Some(ch);
-            self.timers[x.timer as usize] = match x.update {
-                TimerSetting::Stop => {
-                    trace!(
-                        log,
-                        "{side:?} {timer:?} stop",
-                        side = self.side,
-                        timer = x.timer
-                    );
-                    None
+
+        for (ch, event) in endpoint_events {
+            if let Some(event) = self.handle_event(ch, event) {
+                if let Some(conn) = self.connections.get_mut(&ch) {
+                    conn.handle_event(event);
                 }
-                TimerSetting::Start(time) => {
-                    trace!(
-                        log,
-                        "{side:?} {timer:?} set to expire at {:?}",
-                        time,
-                        side = self.side,
-                        timer = x.timer,
-                    );
-                    Some(time)
-                }
-            };
+            }
         }
     }
 
@@ -386,7 +440,7 @@ fn version_negotiate_server() {
     )
     .unwrap();
     let now = Instant::now();
-    server.handle(
+    let event = server.handle(
         now,
         client_addr,
         None,
@@ -398,7 +452,9 @@ fn version_negotiate_server() {
         )[..]
             .into(),
     );
-    let io = server.poll_transmit(now);
+    assert!(event.is_none());
+
+    let io = server.poll_transmit();
     assert!(io.is_some());
     if let Some(Transmit { packet, .. }) = io {
         assert_ne!(packet[0] & 0x80, 0);
@@ -407,8 +463,7 @@ fn version_negotiate_server() {
             .chunks(4)
             .any(|x| BigEndian::read_u32(x) == VERSION));
     }
-    assert_matches!(server.poll_transmit(now), None);
-    assert_matches!(server.poll(), None);
+    assert_matches!(server.poll_transmit(), None);
 }
 
 #[test]
@@ -424,7 +479,7 @@ fn version_negotiate_client() {
         None,
     )
     .unwrap();
-    client
+    let (_, mut client_conn) = client
         .connect(
             server_addr,
             Default::default(),
@@ -433,7 +488,7 @@ fn version_negotiate_client() {
         )
         .unwrap();
     let now = Instant::now();
-    client.handle(
+    let opt_event = client.handle(
         now,
         server_addr,
         None,
@@ -444,14 +499,14 @@ fn version_negotiate_client() {
         )[..]
             .into(),
     );
+    if let Some((_, DatagramEvent::ConnectionEvent(event))) = opt_event {
+        client_conn.handle_event(event);
+    }
     assert_matches!(
-        client.poll(),
-        Some((
-            _,
-            Event::ConnectionLost {
-                reason: ConnectionError::VersionMismatch,
-            },
-        ))
+        client_conn.poll(),
+        Some(Event::ConnectionLost {
+            reason: ConnectionError::VersionMismatch,
+        })
     );
 }
 
@@ -459,20 +514,24 @@ fn version_negotiate_client() {
 fn lifecycle() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
-    assert_matches!(pair.client.poll(), None);
-    assert!(pair.client.connection(client_ch).using_ecn());
-    assert!(pair.server.connection(server_ch).using_ecn());
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
+    assert!(pair.client_conn_mut(client_ch).using_ecn());
+    assert!(pair.server_conn_mut(server_ch).using_ecn());
 
     const REASON: &[u8] = b"whee";
     info!(pair.log, "closing");
-    pair.client.close(pair.time, client_ch, 42, REASON.into());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, 42, REASON.into());
     pair.drive();
     assert!(pair.spins > 0);
-    assert_matches!(pair.server.poll(),
-                    Some((_, Event::ConnectionLost { reason: ConnectionError::ApplicationClosed {
+    assert_matches!(pair.server_conn_mut(server_ch).poll(),
+                    Some(Event::ConnectionLost { reason: ConnectionError::ApplicationClosed {
                         reason: ApplicationClose { error_code: 42, ref reason }
-                    }})) if reason == REASON);
-    assert_matches!(pair.client.poll(), None);
+                    }}) if reason == REASON);
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
 }
 
 #[test]
@@ -509,11 +568,19 @@ fn server_stateless_reset() {
     )
     .unwrap();
     // Send something big enough to allow room for a smaller stateless reset.
-    pair.client
-        .close(pair.time, client_ch, 42, (&[0xab; 128][..]).into());
+    pair.client.connections.get_mut(&client_ch).unwrap().close(
+        pair.time,
+        42,
+        (&[0xab; 128][..]).into(),
+    );
     info!(pair.log, "resetting");
     pair.drive();
-    assert_matches!(pair.client.poll(), Some((conn, Event::ConnectionLost { reason: ConnectionError::Reset })) if conn == client_ch);
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ConnectionLost {
+            reason: ConnectionError::Reset
+        })
+    );
 }
 
 #[test]
@@ -538,11 +605,19 @@ fn client_stateless_reset() {
     )
     .unwrap();
     // Send something big enough to allow room for a smaller stateless reset.
-    pair.server
-        .close(pair.time, server_ch, 42, (&[0xab; 128][..]).into());
+    pair.server.connections.get_mut(&server_ch).unwrap().close(
+        pair.time,
+        42,
+        (&[0xab; 128][..]).into(),
+    );
     info!(pair.log, "resetting");
     pair.drive();
-    assert_matches!(pair.server.poll(), Some((conn, Event::ConnectionLost { reason: ConnectionError::Reset })) if conn == server_ch);
+    assert_matches!(
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::ConnectionLost {
+            reason: ConnectionError::Reset
+        })
+    );
 }
 
 #[test]
@@ -550,21 +625,27 @@ fn finish_stream() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
-    let s = pair.client.open(client_ch, Directionality::Uni).unwrap();
+    let s = pair
+        .client_conn_mut(client_ch)
+        .open(Directionality::Uni)
+        .unwrap();
 
     const MSG: &[u8] = b"hello";
-    pair.client.write(client_ch, s, MSG).unwrap();
-    pair.client.finish(client_ch, s);
+    pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
+    pair.client_conn_mut(client_ch).finish(s);
     pair.drive();
 
-    assert_matches!(pair.client.poll(), Some((conn, Event::StreamFinished { stream })) if conn == client_ch && stream == s);
-    assert_matches!(pair.client.poll(), None);
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_ch);
-    assert_matches!(pair.server.accept_stream(server_ch), Some(stream) if stream == s);
-    assert_matches!(pair.server.poll(), None);
-    assert_matches!(pair.server.read_unordered(server_ch, s), Ok((ref data, 0)) if data == MSG);
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), Some(Event::StreamFinished { stream }) if stream == s);
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
+    assert_matches!(pair.server_conn_mut(server_ch).read_unordered(s), Ok((ref data, 0)) if data == MSG);
+    assert_matches!(
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Err(ReadError::Finished)
     );
 }
@@ -574,24 +655,30 @@ fn reset_stream() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
-    let s = pair.client.open(client_ch, Directionality::Uni).unwrap();
+    let s = pair
+        .client_conn_mut(client_ch)
+        .open(Directionality::Uni)
+        .unwrap();
 
     const MSG: &[u8] = b"hello";
-    pair.client.write(client_ch, s, MSG).unwrap();
+    pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive();
 
     info!(pair.log, "resetting stream");
     const ERROR: u16 = 42;
-    pair.client.reset(client_ch, s, ERROR);
+    pair.client_conn_mut(client_ch).reset(s, ERROR);
     pair.drive();
 
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_ch);
-    assert_matches!(pair.server.accept_stream(server_ch), Some(stream) if stream == s);
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Err(ReadError::Reset { error_code: ERROR })
     );
-    assert_matches!(pair.client.poll(), None);
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
 }
 
 #[test]
@@ -599,25 +686,31 @@ fn stop_stream() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
-    let s = pair.client.open(client_ch, Directionality::Uni).unwrap();
+    let s = pair
+        .client_conn_mut(client_ch)
+        .open(Directionality::Uni)
+        .unwrap();
     const MSG: &[u8] = b"hello";
-    pair.client.write(client_ch, s, MSG).unwrap();
+    pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive();
 
     info!(pair.log, "stopping stream");
     const ERROR: u16 = 42;
-    pair.server.stop_sending(server_ch, s, ERROR);
+    pair.server_conn_mut(server_ch).stop_sending(s, ERROR);
     pair.drive();
 
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_ch);
-    assert_matches!(pair.server.accept_stream(server_ch), Some(stream) if stream == s);
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Err(ReadError::Reset { error_code: ERROR })
     );
 
     assert_matches!(
-        pair.client.write(client_ch, s, b"foo"),
+        pair.client_conn_mut(client_ch).write(s, b"foo"),
         Err(WriteError::Stopped { error_code: ERROR })
     );
 }
@@ -630,7 +723,7 @@ fn reject_self_signed_cert() {
 
     let mut pair = Pair::default();
     info!(pair.log, "connecting");
-    let client_ch = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -639,10 +732,11 @@ fn reject_self_signed_cert() {
             "localhost",
         )
         .unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
     pair.drive();
-    assert_matches!(pair.client.poll(),
-                    Some((conn, Event::ConnectionLost { reason: ConnectionError::TransportError(ref error)}))
-                    if conn == client_ch && error.code == TransportErrorCode::crypto(AlertDescription::BadCertificate.get_u8()));
+    assert_matches!(pair.client_conn_mut(client_ch).poll(),
+                    Some(Event::ConnectionLost { reason: ConnectionError::TransportError(ref error)})
+                    if error.code == TransportErrorCode::crypto(AlertDescription::BadCertificate.get_u8()));
 }
 
 #[test]
@@ -650,10 +744,13 @@ fn congestion() {
     let mut pair = Pair::default();
     let (client_ch, _) = pair.connect();
 
-    let initial_congestion_state = pair.client.connection(client_ch).congestion_state();
-    let s = pair.client.open(client_ch, Directionality::Uni).unwrap();
+    let initial_congestion_state = pair.client_conn_mut(client_ch).congestion_state();
+    let s = pair
+        .client_conn_mut(client_ch)
+        .open(Directionality::Uni)
+        .unwrap();
     loop {
-        match pair.client.write(client_ch, s, &[42; 1024]) {
+        match pair.client_conn_mut(client_ch).write(s, &[42; 1024]) {
             Ok(n) => {
                 assert!(n <= 1024);
                 pair.drive_client();
@@ -667,8 +764,10 @@ fn congestion() {
         }
     }
     pair.drive();
-    assert!(pair.client.connection(client_ch).congestion_state() >= initial_congestion_state);
-    pair.client.write(client_ch, s, &[42; 1024]).unwrap();
+    assert!(pair.client_conn_mut(client_ch).congestion_state() >= initial_congestion_state);
+    pair.client_conn_mut(client_ch)
+        .write(s, &[42; 1024])
+        .unwrap();
 }
 
 #[test]
@@ -676,10 +775,10 @@ fn high_latency_handshake() {
     let mut pair = Pair::default();
     pair.latency = Duration::from_micros(200 * 1000);
     let (client_ch, server_ch) = pair.connect();
-    assert_eq!(pair.client.connection(client_ch).bytes_in_flight(), 0);
-    assert_eq!(pair.server.connection(server_ch).bytes_in_flight(), 0);
-    assert!(pair.client.connection(client_ch).using_ecn());
-    assert!(pair.server.connection(server_ch).using_ecn());
+    assert_eq!(pair.client_conn_mut(client_ch).bytes_in_flight(), 0);
+    assert_eq!(pair.server_conn_mut(server_ch).bytes_in_flight(), 0);
+    assert!(pair.client_conn_mut(client_ch).using_ecn());
+    assert!(pair.server_conn_mut(server_ch).using_ecn());
 }
 
 #[test]
@@ -688,7 +787,7 @@ fn zero_rtt() {
     let config = client_config();
 
     // Establish normal connection
-    let client_ch = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -697,9 +796,14 @@ fn zero_rtt() {
             "localhost",
         )
         .unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
     pair.drive();
     pair.server.assert_accept();
-    pair.client.close(pair.time, client_ch, 0, [][..].into());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, 0, [][..].into());
     pair.drive();
 
     pair.client.addr = SocketAddr::new(
@@ -707,19 +811,23 @@ fn zero_rtt() {
         CLIENT_PORTS.lock().unwrap().next().unwrap(),
     );
     info!(pair.log, "resuming session");
-    let client_ch = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(pair.server.addr, Default::default(), config, "localhost")
         .unwrap();
-    assert!(pair.client.connection(client_ch).has_0rtt());
-    let s = pair.client.open(client_ch, Directionality::Uni).unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
+    assert!(pair.client_conn_mut(client_ch).has_0rtt());
+    let s = pair
+        .client_conn_mut(client_ch)
+        .open(Directionality::Uni)
+        .unwrap();
     const MSG: &[u8] = b"Hello, 0-RTT!";
-    pair.client.write(client_ch, s, MSG).unwrap();
+    pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive();
-    assert!(pair.client.connection(client_ch).accepted_0rtt());
+    assert!(pair.client_conn_mut(client_ch).accepted_0rtt());
     let server_ch = pair.server.assert_accept();
-    assert_matches!(pair.server.read_unordered(server_ch, s), Ok((ref data, 0)) if data == MSG);
-    assert_eq!(pair.client.connection(client_ch).lost_packets(), 0);
+    assert_matches!(pair.server_conn_mut(server_ch).read_unordered(s), Ok((ref data, 0)) if data == MSG);
+    assert_eq!(pair.client_conn_mut(client_ch).lost_packets(), 0);
 }
 
 #[test]
@@ -728,7 +836,7 @@ fn zero_rtt_rejection() {
     let mut config = client_config();
 
     // Establish normal connection
-    let client_conn = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -737,46 +845,69 @@ fn zero_rtt_rejection() {
             "localhost",
         )
         .unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
     pair.drive();
-    pair.server.assert_accept();
-    assert_matches!(pair.server.poll(), Some((_, Event::Connected)));
-    assert_matches!(pair.server.poll(), None);
-    pair.client.close(pair.time, client_conn, 0, [][..].into());
+    let server_conn = pair.server.assert_accept();
+    assert_matches!(
+        pair.server_conn_mut(server_conn).poll(),
+        Some(Event::Connected)
+    );
+    assert_matches!(pair.server_conn_mut(server_conn).poll(), None);
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, 0, [][..].into());
     pair.drive();
-    assert_matches!(pair.server.poll(), Some((_, Event::ConnectionLost { .. })));
-    assert_matches!(pair.server.poll(), None);
+    assert_matches!(
+        pair.server_conn_mut(server_conn).poll(),
+        Some(Event::ConnectionLost { .. })
+    );
+    assert_matches!(pair.server_conn_mut(server_conn).poll(), None);
+    pair.client.connections.clear();
+    pair.server.connections.clear();
 
     // Changing protocols invalidates 0-RTT
     Arc::get_mut(&mut config)
         .unwrap()
         .set_protocols(&["foo".into()]);
     info!(pair.log, "resuming session");
-    let client_conn = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(pair.server.addr, Default::default(), config, "localhost")
         .unwrap();
-    assert!(pair.client.connection(client_conn).has_0rtt());
-    let s = pair.client.open(client_conn, Directionality::Uni).unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
+    assert!(pair.client_conn_mut(client_ch).has_0rtt());
+    let s = pair
+        .client_conn_mut(client_ch)
+        .open(Directionality::Uni)
+        .unwrap();
     const MSG: &[u8] = b"Hello, 0-RTT!";
-    pair.client.write(client_conn, s, MSG).unwrap();
+    pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive();
-    assert!(!pair.client.connection(client_conn).accepted_0rtt());
+    assert!(!pair.client_conn_mut(client_ch).accepted_0rtt());
     let server_conn = pair.server.assert_accept();
-    assert_matches!(pair.server.poll(), Some((_, Event::Connected)));
-    assert_matches!(pair.server.poll(), None);
-    let s2 = pair.client.open(client_conn, Directionality::Uni).unwrap();
+    assert_matches!(
+        pair.server_conn_mut(server_conn).poll(),
+        Some(Event::Connected)
+    );
+    assert_matches!(pair.server_conn_mut(server_conn).poll(), None);
+    let s2 = pair
+        .client_conn_mut(client_ch)
+        .open(Directionality::Uni)
+        .unwrap();
     assert_eq!(s, s2);
     assert_eq!(
-        pair.server.read_unordered(server_conn, s2),
+        pair.server_conn_mut(server_conn).read_unordered(s2),
         Err(ReadError::Blocked)
     );
-    assert_eq!(pair.client.connection(client_conn).lost_packets(), 0);
+    assert_eq!(pair.client_conn_mut(client_ch).lost_packets(), 0);
 }
 
 #[test]
 fn close_during_handshake() {
     let mut pair = Pair::default();
-    let c = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -785,7 +916,12 @@ fn close_during_handshake() {
             "localhost",
         )
         .unwrap();
-    pair.client.close(pair.time, c, 0, Bytes::new());
+    pair.client.connections.insert(client_ch, client_conn);
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, 0, Bytes::new());
     // This never actually sends the client's Initial; we may want to behave better here.
 }
 
@@ -803,42 +939,59 @@ fn stream_id_backpressure() {
 
     let s = pair
         .client
-        .open(client_ch, Directionality::Uni)
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .open(Directionality::Uni)
         .expect("couldn't open first stream");
     assert_eq!(
-        pair.client.open(client_ch, Directionality::Uni),
+        pair.client_conn_mut(client_ch).open(Directionality::Uni),
         None,
         "only one stream is permitted at a time"
     );
     // Close the first stream to make room for the second
-    pair.client.finish(client_ch, s);
+    pair.client_conn_mut(client_ch).finish(s);
     pair.drive();
-    assert_matches!(pair.client.poll(), Some((conn, Event::StreamFinished { stream })) if conn == client_ch && stream == s);
-    assert_matches!(pair.client.poll(), None);
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_ch);
-    assert_matches!(pair.server.accept_stream(server_ch), Some(stream) if stream == s);
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), Some(Event::StreamFinished { stream }) if stream == s);
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Err(ReadError::Finished)
     );
     // Server will only send MAX_STREAM_ID now that the application's been notified
     pair.drive();
-    assert_matches!(pair.client.poll(), Some((conn, Event::StreamAvailable { directionality: Directionality::Uni })) if conn == client_ch);
-    assert_matches!(pair.client.poll(), None);
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::StreamAvailable {
+            directionality: Directionality::Uni
+        })
+    );
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
 
     // Try opening the second stream again, now that we've made room
     let s = pair
         .client
-        .open(client_ch, Directionality::Uni)
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .open(Directionality::Uni)
         .expect("didn't get stream id budget");
-    pair.client.finish(client_ch, s);
+    pair.client_conn_mut(client_ch).finish(s);
     pair.drive();
     // Make sure the server actually processes data on the newly-available stream
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_ch);
-    assert_matches!(pair.server.accept_stream(server_ch), Some(stream) if stream == s);
-    assert_matches!(pair.server.poll(), None);
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
+    assert_matches!(
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Err(ReadError::Finished)
     );
 }
@@ -849,31 +1002,37 @@ fn key_update() {
     let (client_ch, server_ch) = pair.connect();
     let s = pair
         .client
-        .open(client_ch, Directionality::Bi)
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .open(Directionality::Bi)
         .expect("couldn't open first stream");
 
     const MSG1: &[u8] = b"hello1";
-    pair.client.write(client_ch, s, MSG1).unwrap();
+    pair.client_conn_mut(client_ch).write(s, MSG1).unwrap();
     pair.drive();
 
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_ch);
-    assert_matches!(pair.server.accept_stream(server_ch), Some(stream) if stream == s);
-    assert_matches!(pair.server.poll(), None);
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
+    assert_matches!(
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Ok((ref data, 0)) if data == MSG1
     );
 
-    pair.client.connections[client_ch].conn.force_key_update();
+    pair.client_conn_mut(client_ch).force_key_update();
 
     const MSG2: &[u8] = b"hello2";
-    pair.client.write(client_ch, s, MSG2).unwrap();
+    pair.client_conn_mut(client_ch).write(s, MSG2).unwrap();
     pair.drive();
 
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamReadable { stream })) if conn == server_ch && stream == s);
-    assert_matches!(pair.server.poll(), None);
+    assert_matches!(pair.server_conn_mut(server_ch).poll(), Some(Event::StreamReadable { stream }) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Ok((ref data, 6)) if data == MSG2
     );
 }
@@ -884,42 +1043,48 @@ fn key_update_reordered() {
     let (client_ch, server_ch) = pair.connect();
     let s = pair
         .client
-        .open(client_ch, Directionality::Bi)
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .open(Directionality::Bi)
         .expect("couldn't open first stream");
 
     const MSG1: &[u8] = b"1";
-    pair.client.write(client_ch, s, MSG1).unwrap();
+    pair.client_conn_mut(client_ch).write(s, MSG1).unwrap();
     pair.client.drive(&pair.log, pair.time, pair.server.addr);
     assert!(!pair.client.outbound.is_empty());
     pair.client.delay_outbound();
 
-    pair.client.connections[client_ch].conn.force_key_update();
+    pair.client_conn_mut(client_ch).force_key_update();
     info!(pair.log, "updated keys");
 
     const MSG2: &[u8] = b"two";
-    pair.client.write(client_ch, s, MSG2).unwrap();
+    pair.client_conn_mut(client_ch).write(s, MSG2).unwrap();
     pair.client.drive(&pair.log, pair.time, pair.server.addr);
     pair.client.finish_delay();
     pair.drive();
 
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_ch);
-    assert_matches!(pair.server.accept_stream(server_ch), Some(stream) if stream == s);
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Ok((ref data, 0)) if data == MSG1
     );
     assert_matches!(
-        pair.server.read_unordered(server_ch, s),
+        pair.server_conn_mut(server_ch).read_unordered(s),
         Ok((ref data, 1)) if data == MSG2
     );
 
-    assert_eq!(pair.client.connection(client_ch).lost_packets(), 0);
+    assert_eq!(pair.client_conn_mut(client_ch).lost_packets(), 0);
 }
 
 #[test]
 fn initial_retransmit() {
     let mut pair = Pair::default();
-    let client_ch = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -928,17 +1093,21 @@ fn initial_retransmit() {
             "localhost",
         )
         .unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
     pair.client.drive(&pair.log, pair.time, pair.server.addr);
     pair.client.outbound.clear(); // Drop initial
     pair.drive();
-    assert_matches!(pair.client.poll(), Some((conn, Event::Connected { .. })) if conn == client_ch);
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::Connected { .. })
+    );
 }
 
 #[test]
 fn instant_close() {
     let mut pair = Pair::default();
     info!(pair.log, "connecting");
-    let client_ch = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -947,17 +1116,27 @@ fn instant_close() {
             "localhost",
         )
         .unwrap();
-    pair.client.close(pair.time, client_ch, 0, Bytes::new());
+    pair.client.connections.insert(client_ch, client_conn);
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, 0, Bytes::new());
     pair.drive();
-    assert_matches!(pair.client.poll(), None);
-    assert_matches!(pair.server.poll(), None);
+    let server_ch = pair.server.assert_accept();
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
+    assert_matches!(pair.server_conn_mut(server_ch).poll(), Some(Event::ConnectionLost {
+        reason: ConnectionError::ApplicationClosed {
+            reason: ApplicationClose { error_code: 0, ref reason }
+        }
+    }) if reason.is_empty());
 }
 
 #[test]
 fn instant_close_2() {
     let mut pair = Pair::default();
     info!(pair.log, "connecting");
-    let client_ch = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -966,17 +1145,22 @@ fn instant_close_2() {
             "localhost",
         )
         .unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
     // Unlike `instant_close`, the server sees a valid Initial packet first.
     pair.drive_client();
-    pair.client.close(pair.time, client_ch, 42, Bytes::new());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, 42, Bytes::new());
     pair.drive();
-    assert_matches!(pair.client.poll(), None);
-    pair.server.assert_accept();
-    assert_matches!(pair.server.poll(), Some((_, Event::ConnectionLost {
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
+    let server_ch = pair.server.assert_accept();
+    assert_matches!(pair.server_conn_mut(server_ch).poll(), Some(Event::ConnectionLost {
         reason: ConnectionError::ApplicationClosed {
             reason: ApplicationClose { error_code: 42, ref reason }
         }
-    })) if reason.is_empty());
+    }) if reason.is_empty());
 }
 
 #[test]
@@ -991,11 +1175,11 @@ fn idle_timeout() {
     };
     let mut pair = Pair::new(Default::default(), server);
     let (client_ch, server_ch) = pair.connect();
-    pair.client.ping(client_ch);
+    pair.client_conn_mut(client_ch).ping();
     let start = pair.time;
 
-    while !pair.client.connection(client_ch).is_closed()
-        || !pair.server.connection(server_ch).is_closed()
+    while !pair.client_conn_mut(client_ch).is_closed()
+        || !pair.server_conn_mut(server_ch).is_closed()
     {
         if !pair.step() {
             if let Some(t) = min_opt(pair.client.next_wakeup(), pair.server.next_wakeup()) {
@@ -1007,22 +1191,16 @@ fn idle_timeout() {
 
     assert!(pair.time - start < 2 * Duration::from_secs(IDLE_TIMEOUT));
     assert_matches!(
-        pair.client.poll(),
-        Some((
-            _,
-            Event::ConnectionLost {
-                reason: ConnectionError::TimedOut,
-            },
-        ))
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ConnectionLost {
+            reason: ConnectionError::TimedOut,
+        })
     );
     assert_matches!(
-        pair.server.poll(),
-        Some((
-            _,
-            Event::ConnectionLost {
-                reason: ConnectionError::TimedOut,
-            },
-        ))
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::ConnectionLost {
+            reason: ConnectionError::TimedOut,
+        })
     );
 }
 
@@ -1035,38 +1213,7 @@ fn server_busy() {
             ..server_config()
         },
     );
-    pair.client
-        .connect(
-            pair.server.addr,
-            Default::default(),
-            client_config(),
-            "localhost",
-        )
-        .unwrap();
-    pair.drive();
-    assert_matches!(
-        pair.client.poll(),
-        Some((
-            _,
-            Event::ConnectionLost {
-                reason:
-                    ConnectionError::ConnectionClosed {
-                        reason:
-                            frame::ConnectionClose {
-                                error_code: TransportErrorCode::SERVER_BUSY,
-                                ..
-                            },
-                    },
-            },
-        ))
-    );
-    assert_matches!(pair.server.poll(), None);
-}
-
-#[test]
-fn server_hs_retransmit() {
-    let mut pair = Pair::default();
-    let client_ch = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -1075,6 +1222,38 @@ fn server_hs_retransmit() {
             "localhost",
         )
         .unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
+    pair.drive();
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ConnectionLost {
+            reason:
+                ConnectionError::ConnectionClosed {
+                    reason:
+                        frame::ConnectionClose {
+                            error_code: TransportErrorCode::SERVER_BUSY,
+                            ..
+                        },
+                },
+        })
+    );
+    // TODO: somehow assert that no state was left on the server?
+    assert_eq!(pair.server.connections.len(), 0);
+}
+
+#[test]
+fn server_hs_retransmit() {
+    let mut pair = Pair::default();
+    let (client_ch, client_conn) = pair
+        .client
+        .connect(
+            pair.server.addr,
+            Default::default(),
+            client_config(),
+            "localhost",
+        )
+        .unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
     pair.step();
     assert!(pair.client.inbound.len() > 1); // Initial + Handshakes
     info!(
@@ -1094,7 +1273,10 @@ fn server_hs_retransmit() {
         pair.client.inbound.drain(..);
     }
     pair.drive();
-    assert_matches!(pair.client.poll(), Some((conn, Event::Connected { .. })) if conn == client_ch);
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::Connected { .. })
+    );
 }
 
 #[test]
@@ -1102,7 +1284,7 @@ fn decode_coalesced() {
     // We can't currently generate coalesced packets natively, but we must support decoding
     // them. Hack around the problem by manually concatenating the server's first flight.
     let mut pair = Pair::default();
-    let client_ch = pair
+    let (client_ch, client_conn) = pair
         .client
         .connect(
             pair.server.addr,
@@ -1111,6 +1293,7 @@ fn decode_coalesced() {
             "localhost",
         )
         .unwrap();
+    pair.client.connections.insert(client_ch, client_conn);
     pair.step();
     assert!(
         pair.client.inbound.len() > 1,
@@ -1124,8 +1307,11 @@ fn decode_coalesced() {
         .inbound
         .push_back((pair.time, Some(EcnCodepoint::ECT0), coalesced.into()));
     pair.drive();
-    assert_matches!(pair.client.poll(), Some((conn, Event::Connected { .. })) if conn == client_ch);
-    assert_eq!(pair.client.connection(client_ch).lost_packets(), 0);
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::Connected { .. })
+    );
+    assert_eq!(pair.client_conn_mut(client_ch).lost_packets(), 0);
 }
 
 #[test]
@@ -1136,10 +1322,10 @@ fn migration() {
         Ipv4Addr::new(127, 0, 0, 1).into(),
         CLIENT_PORTS.lock().unwrap().next().unwrap(),
     );
-    pair.client.ping(client_ch);
+    pair.client_conn_mut(client_ch).ping();
     pair.drive();
-    assert_matches!(pair.client.poll(), None);
-    assert_eq!(pair.server.connection(server_ch).remote(), pair.client.addr);
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
+    assert_eq!(pair.server_conn_mut(server_ch).remote(), pair.client.addr);
 }
 
 fn test_flow_control(config: TransportConfig, window_size: usize) {
@@ -1155,31 +1341,48 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     let mut buf = [0; 4096];
 
     // Stream reset before read
-    let s = pair.client.open(client_conn, Directionality::Uni).unwrap();
-    assert_eq!(pair.client.write(client_conn, s, &msg), Ok(window_size));
+    let s = pair
+        .client_conn_mut(client_conn)
+        .open(Directionality::Uni)
+        .unwrap();
     assert_eq!(
-        pair.client.write(client_conn, s, &msg[window_size..]),
+        pair.client_conn_mut(client_conn).write(s, &msg),
+        Ok(window_size)
+    );
+    assert_eq!(
+        pair.client_conn_mut(client_conn)
+            .write(s, &msg[window_size..]),
         Err(WriteError::Blocked)
     );
     pair.drive();
-    pair.client.reset(client_conn, s, 42);
+    pair.client_conn_mut(client_conn).reset(s, 42);
     pair.drive();
     assert_eq!(
-        pair.server.read(server_conn, s, &mut buf),
+        pair.server_conn_mut(server_conn).read(s, &mut buf),
         Err(ReadError::Reset { error_code: 42 })
     );
 
     // Happy path
-    let s = pair.client.open(client_conn, Directionality::Uni).unwrap();
-    assert_eq!(pair.client.write(client_conn, s, &msg), Ok(window_size));
+    let s = pair
+        .client_conn_mut(client_conn)
+        .open(Directionality::Uni)
+        .unwrap();
     assert_eq!(
-        pair.client.write(client_conn, s, &msg[window_size..]),
+        pair.client_conn_mut(client_conn).write(s, &msg),
+        Ok(window_size)
+    );
+    assert_eq!(
+        pair.client_conn_mut(client_conn)
+            .write(s, &msg[window_size..]),
         Err(WriteError::Blocked)
     );
     pair.drive();
     let mut cursor = 0;
     loop {
-        match pair.server.read(server_conn, s, &mut buf[cursor..]) {
+        match pair
+            .server_conn_mut(server_conn)
+            .read(s, &mut buf[cursor..])
+        {
             Ok(n) => {
                 cursor += n;
             }
@@ -1193,15 +1396,22 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     }
     assert_eq!(cursor, window_size);
     pair.drive();
-    assert_eq!(pair.client.write(client_conn, s, &msg), Ok(window_size));
     assert_eq!(
-        pair.client.write(client_conn, s, &msg[window_size..]),
+        pair.client_conn_mut(client_conn).write(s, &msg),
+        Ok(window_size)
+    );
+    assert_eq!(
+        pair.client_conn_mut(client_conn)
+            .write(s, &msg[window_size..]),
         Err(WriteError::Blocked)
     );
     pair.drive();
     let mut cursor = 0;
     loop {
-        match pair.server.read(server_conn, s, &mut buf[cursor..]) {
+        match pair
+            .server_conn_mut(server_conn)
+            .read(s, &mut buf[cursor..])
+        {
             Ok(n) => {
                 cursor += n;
             }
@@ -1242,19 +1452,29 @@ fn conn_flow_control() {
 fn stop_opens_bidi() {
     let mut pair = Pair::default();
     let (client_conn, server_conn) = pair.connect();
-    let s = pair.client.open(client_conn, Directionality::Bi).unwrap();
+    let s = pair
+        .client_conn_mut(client_conn)
+        .open(Directionality::Bi)
+        .unwrap();
     const ERROR: u16 = 42;
-    pair.client.stop_sending(server_conn, s, ERROR);
+    pair.client
+        .connections
+        .get_mut(&server_conn)
+        .unwrap()
+        .stop_sending(s, ERROR);
     pair.drive();
 
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_conn);
-    assert_matches!(pair.server.accept_stream(server_conn), Some(stream) if stream == s);
     assert_matches!(
-        pair.server.read_unordered(server_conn, s),
+        pair.server_conn_mut(server_conn).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_matches!(pair.server_conn_mut(server_conn).accept(), Some(stream) if stream == s);
+    assert_matches!(
+        pair.server_conn_mut(server_conn).read_unordered(s),
         Err(ReadError::Blocked)
     );
     assert_matches!(
-        pair.server.write(server_conn, s, b"foo"),
+        pair.server_conn_mut(server_conn).write(s, b"foo"),
         Err(WriteError::Stopped { error_code: ERROR })
     );
 }
@@ -1263,14 +1483,25 @@ fn stop_opens_bidi() {
 fn implicit_open() {
     let mut pair = Pair::default();
     let (client_conn, server_conn) = pair.connect();
-    let s1 = pair.client.open(client_conn, Directionality::Uni).unwrap();
-    let s2 = pair.client.open(client_conn, Directionality::Uni).unwrap();
-    pair.client.write(client_conn, s2, b"hello").unwrap();
+    let s1 = pair
+        .client_conn_mut(client_conn)
+        .open(Directionality::Uni)
+        .unwrap();
+    let s2 = pair
+        .client_conn_mut(client_conn)
+        .open(Directionality::Uni)
+        .unwrap();
+    pair.client_conn_mut(client_conn)
+        .write(s2, b"hello")
+        .unwrap();
     pair.drive();
-    assert_matches!(pair.server.poll(), Some((conn, Event::StreamOpened)) if conn == server_conn);
-    assert_eq!(pair.server.accept_stream(server_conn), Some(s1));
-    assert_eq!(pair.server.accept_stream(server_conn), Some(s2));
-    assert_eq!(pair.server.accept_stream(server_conn), None);
+    assert_matches!(
+        pair.server_conn_mut(server_conn).poll(),
+        Some(Event::StreamOpened)
+    );
+    assert_eq!(pair.server_conn_mut(server_conn).accept(), Some(s1));
+    assert_eq!(pair.server_conn_mut(server_conn).accept(), Some(s2));
+    assert_eq!(pair.server_conn_mut(server_conn).accept(), None);
 }
 
 #[test]
@@ -1285,9 +1516,17 @@ fn zero_length_cid() {
     let (client_ch, server_ch) = pair.connect();
     // Ensure we can reconnect after a previous connection is cleaned up
     info!(pair.log, "closing");
-    pair.client.close(pair.time, client_ch, 42, Bytes::new());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, 42, Bytes::new());
     pair.drive();
-    pair.server.close(pair.time, server_ch, 42, Bytes::new());
+    pair.server
+        .connections
+        .get_mut(&server_ch)
+        .unwrap()
+        .close(pair.time, 42, Bytes::new());
     pair.connect();
 }
 
@@ -1312,8 +1551,8 @@ fn keep_alive() {
                 pair.time = time;
             }
         }
-        assert!(!pair.client.connection(client_ch).is_closed());
-        assert!(!pair.server.connection(server_ch).is_closed());
+        assert!(!pair.client_conn_mut(client_ch).is_closed());
+        assert!(!pair.server_conn_mut(server_ch).is_closed());
     }
 }
 

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -163,6 +163,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
 
 fn handle_connection(root: &PathBuf, log: &Logger, conn: quinn::NewConnection) {
     let quinn::NewConnection {
+        driver,
         incoming,
         connection,
     } = conn;
@@ -173,6 +174,8 @@ fn handle_connection(root: &PathBuf, log: &Logger, conn: quinn::NewConnection) {
           "protocol" => connection.protocol().map_or_else(|| "<none>".into(), |x| String::from_utf8_lossy(&x).into_owned()));
     let log2 = log.clone();
     let root = root.clone();
+
+    tokio_current_thread::spawn(driver.map_err(|e| panic!(e)));
 
     // Each stream initiated by the client constitutes a new request.
     tokio_current_thread::spawn(

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -75,6 +75,7 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
     runtime.spawn(server_driver.map_err(|e| panic!("server driver failed: {}", e)));
     runtime.spawn(client_driver.map_err(|e| panic!("client driver failed: {}", e)));
     runtime.spawn(server_incoming.for_each(move |conn| {
+        tokio_current_thread::spawn(conn.driver.map_err(|_| ()));
         tokio_current_thread::spawn(conn.incoming.map_err(|_| ()).for_each(echo));
         Ok(())
     }));
@@ -87,6 +88,7 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
                 .unwrap()
                 .map_err(|e| panic!("connection failed: {}", e))
                 .and_then(move |conn| {
+                    tokio_current_thread::spawn(conn.driver.map_err(|e| panic!(e)));
                     let conn = conn.connection;
                     let stream = conn.open_bi();
                     stream

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -65,6 +65,7 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
 
     let mut client_config = ClientConfigBuilder::default();
     client_config.add_certificate_authority(cert).unwrap();
+    client_config.enable_keylog();
     let mut client = Endpoint::new();
     client.logger(log.clone());
     client.default_client_config(client_config.build());


### PR DESCRIPTION
This is the big one.

Currently not quite done: we need to figure out how to handle the connection closing sequence. Since `Endpoint::close()` is no more, `app_closed` never gets set, so the `ConnectionMeta` state doesn't get cleaned up (I think this is why `zero_length_cid` fails). The quinn tests hang and there is some unused code having to do with cancelable timers that probably should be wired up somehow.

Even after all that gets fixed, I'd prefer not to wait for this to be perfect before we merge it, since it's pretty invasive -- I'll follow up with improvements soon after. However, I'd like to get this to pass the tests and not introduce any substantial functional regressions. Things I'd prefer to address after merging this PR:

- Use of unbounded channels
- Lack of documentation updates
- Performance regressions (unless extreme)
- Move from `Rc<RefCell<>>` to `Arc<Mutex<>>`

Would like your review!