### PR TITLE
Return Err when writing to unknown stream (see #87)

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2678,7 +2678,7 @@ impl Connection {
         let budget_res = self
             .streams
             .get_send_mut(stream)
-            .expect("stream already closed")
+            .ok_or(WriteError::UnknownStream)?
             .write_budget();
 
         let stream_budget = match budget_res {
@@ -2695,6 +2695,7 @@ impl Connection {
                 );
                 return Err(e);
             }
+            Err(WriteError::UnknownStream) => unreachable!("not returned here"),
         };
 
         let conn_budget = cmp::min(

--- a/quinn-proto/src/stream.rs
+++ b/quinn-proto/src/stream.rs
@@ -328,6 +328,9 @@ pub enum WriteError {
     /// The peer is no longer accepting data on this stream.
     #[error(display = "stopped by peer: error {}", error_code)]
     Stopped { error_code: u16 },
+    /// Unknown stream
+    #[error(display = "unknown stream")]
+    UnknownStream,
 }
 
 #[derive(Debug)]

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -598,6 +598,9 @@ impl Write for BiStream {
             Err(Stopped { error_code }) => {
                 return Err(WriteError::Stopped { error_code });
             }
+            Err(UnknownStream) => {
+                return Err(WriteError::UnknownStream);
+            }
         };
         conn.notify();
         Ok(Async::Ready(n))
@@ -704,6 +707,9 @@ impl io::Write for BiStream {
                 io::ErrorKind::ConnectionAborted,
                 format!("connection closed: {}", e),
             )),
+            Err(WriteError::UnknownStream) => {
+                Err(io::Error::new(io::ErrorKind::Other, "unknown stream"))
+            }
         }
     }
 
@@ -971,4 +977,7 @@ pub enum WriteError {
     /// The connection was closed.
     #[error(display = "connection closed: {}", _0)]
     ConnectionClosed(ConnectionError),
+    /// Unknown stream
+    #[error(display = "unknown stream")]
+    UnknownStream,
 }


### PR DESCRIPTION
Since we've grown a similar enum variant for `ReadError` in the meantime, I figured I'd follow through on @icefoxen's PR #87.