### PR TITLE
Change code coverage command to make build job fail when appropriate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ script:
 - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
     cargo fmt -- --check;
   fi
-
-after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-    cargo tarpaulin --out Xml
-    bash <(curl -s https://codecov.io/bash)
+- if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
+    RUST_BACKTRACE=1 cargo tarpaulin --out Xml && bash <(curl -s https://codecov.io/bash);
   fi


### PR DESCRIPTION
Also get backtraces for the code coverage run.

Doesn't actually work yet, see https://github.com/xd009642/tarpaulin/issues/219.