### PR TITLE
Fix reordered data packets being incorrectly acknowledged

### DIFF
--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -110,7 +110,7 @@ impl Pair {
         }
     }
 
-    fn drive_server(&mut self) {
+    pub fn drive_server(&mut self) {
         trace!(self.log, "server running");
         self.server.drive(&self.log, self.time, self.client.addr);
         for x in self.server.outbound.drain(..) {

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -156,6 +156,9 @@ fn run(log: Logger, options: Opt) -> Result<()> {
             }),
     )?;
 
+    // Let the connection to finish closing gracefully
+    runtime.run()?;
+
     Ok(())
 }
 

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -246,7 +246,9 @@ fn process_get(root: &Path, x: &[u8]) -> Result<Box<[u8]>> {
     if x[4..].len() < 2 || &x[x.len() - 2..] != b"\r\n" {
         bail!("missing \\r\\n");
     }
-    let path = str::from_utf8(&x[4..x.len() - 2]).context("path is malformed UTF-8")?;
+    let x = &x[4..x.len() - 2];
+    let end = x.iter().position(|&c| c == b' ').unwrap_or_else(|| x.len());
+    let path = str::from_utf8(&x[..end]).context("path is malformed UTF-8")?;
     let path = Path::new(&path);
     let mut real_path = PathBuf::from(root);
     let mut components = path.components();


### PR DESCRIPTION
This lead the peer to believe we've processed data that we haven't, causing all manner of inconsistent state.