### PR TITLE
Assorted cleanup

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -248,6 +248,11 @@ impl Connection {
         this
     }
 
+    /// Replace the diagnostic logger
+    pub fn set_logger(&mut self, log: Logger) {
+        self.log = log;
+    }
+
     /// Returns timer updates
     ///
     /// Connections should be polled for timer updates after:

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2918,21 +2918,13 @@ impl From<TransportError> for ConnectionError {
 impl From<ConnectionError> for io::Error {
     fn from(x: ConnectionError) -> io::Error {
         use self::ConnectionError::*;
-        match x {
-            TimedOut => io::Error::new(io::ErrorKind::TimedOut, "timed out"),
-            Reset => io::Error::new(io::ErrorKind::ConnectionReset, "reset by peer"),
-            ApplicationClosed { reason } => io::Error::new(
-                io::ErrorKind::ConnectionAborted,
-                format!("closed by peer application: {}", reason),
-            ),
-            ConnectionClosed { reason } => io::Error::new(
-                io::ErrorKind::ConnectionAborted,
-                format!("peer detected an error: {}", reason),
-            ),
-            TransportError(x) => io::Error::new(io::ErrorKind::Other, format!("{}", x)),
-            VersionMismatch => io::Error::new(io::ErrorKind::Other, "version mismatch"),
-            LocallyClosed => io::Error::new(io::ErrorKind::Other, "locally closed"),
-        }
+        let kind = match x {
+            TimedOut => io::ErrorKind::TimedOut,
+            Reset => io::ErrorKind::ConnectionReset,
+            ApplicationClosed { .. } | ConnectionClosed { .. } => io::ErrorKind::ConnectionAborted,
+            TransportError(_) | VersionMismatch | LocallyClosed => io::ErrorKind::Other,
+        };
+        io::Error::new(kind, x)
     }
 }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -176,6 +176,13 @@ pub fn build_server_config() -> ServerConfig {
     cfg
 }
 
+pub fn build_client_config() -> ClientConfig {
+    let mut cfg = ClientConfig::new();
+    cfg.versions = vec![ProtocolVersion::TLSv1_3];
+    cfg.enable_early_data = true;
+    cfg
+}
+
 fn to_vec(side: Side, params: &TransportParameters) -> Vec<u8> {
     let mut bytes = Vec::new();
     params.write(side, &mut bytes);

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -172,6 +172,7 @@ impl DerefMut for TlsSession {
 pub fn build_server_config() -> ServerConfig {
     let mut cfg = ServerConfig::new(NoClientAuth::new());
     cfg.versions = vec![ProtocolVersion::TLSv1_3];
+    cfg.max_early_data_size = u32::max_value();
     cfg
 }
 
@@ -183,8 +184,6 @@ fn to_vec(side: Side, params: &TransportParameters) -> Vec<u8> {
 
 /// Value used in ACKs we transmit
 pub const ACK_DELAY_EXPONENT: u8 = 3;
-/// Magic value used to indicate 0-RTT support in NewSessionTicket
-//pub const TLS_MAX_EARLY_DATA: u32 = 0xffff_ffff;
 
 pub fn reset_token_for(key: &SigningKey, id: &ConnectionId) -> [u8; RESET_TOKEN_SIZE] {
     let signature = hmac::sign(key, id);

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -787,6 +787,11 @@ enum ConnectionOpts {
 /// These arise before any I/O has been performed.
 #[derive(Debug, Error)]
 pub enum ConnectError {
+    /// The endpoint can no longer create new connections
+    ///
+    /// Indicates that a necessary component of the endpoint has been dropped or otherwise disabled.
+    #[error(display = "endpoint stopping")]
+    EndpointStopping,
     /// The domain name supplied was malformed
     #[error(display = "invalid DNS name: {}", _0)]
     InvalidDnsName(String),

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -33,9 +33,9 @@ use crate::{
 
 /// The main entry point to the library
 ///
-/// This object performs no I/O whatsoever. Instead, it generates a stream of I/O operations for a
-/// backend to perform via `poll_io`, and consumes incoming packets and timer expirations via
-/// `handle` and `timeout`.
+/// This object performs no I/O whatsoever. Instead, it generates a stream of packets to send via
+/// `poll_transmit`, and consumes incoming packets and connection-generated events via `handle` and
+/// `handle_event`.
 pub struct Endpoint {
     log: Logger,
     rng: OsRng,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -321,6 +321,7 @@ impl Endpoint {
     /// Initiate a connection
     pub fn connect(
         &mut self,
+        log: Option<Logger>,
         remote: SocketAddr,
         transport_config: Arc<TransportConfig>,
         crypto_config: Arc<crypto::ClientConfig>,
@@ -330,6 +331,7 @@ impl Endpoint {
         let remote_id = ConnectionId::random(&mut self.rng, MAX_CID_SIZE);
         trace!(self.log, "initial dcid"; "value" => %remote_id);
         let (ch, conn) = self.add_connection(
+            log,
             remote_id,
             remote_id,
             remote,
@@ -369,6 +371,7 @@ impl Endpoint {
 
     fn add_connection(
         &mut self,
+        log: Option<Logger>,
         init_cid: ConnectionId,
         rem_cid: ConnectionId,
         remote: SocketAddr,
@@ -406,7 +409,7 @@ impl Endpoint {
             cfg.use_stateless_retry && client_config.is_none()
         });
         let conn = Connection::new(
-            self.log.new(o!("connection" => loc_cid)),
+            log.unwrap_or_else(|| self.log.new(o!("connection" => loc_cid))),
             Arc::clone(&self.config),
             transport_config,
             init_cid,
@@ -554,6 +557,7 @@ impl Endpoint {
 
         let (ch, mut conn) = self
             .add_connection(
+                None,
                 dst_cid,
                 src_cid,
                 remote,

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -29,7 +29,7 @@ mod connection;
 pub use crate::connection::{Connection, ConnectionError, Event, Timer, TimerSetting, TimerUpdate};
 
 mod crypto;
-pub use crate::crypto::{ClientConfig, TokenKey};
+pub use crate::crypto::TokenKey;
 
 mod frame;
 use crate::frame::Frame;
@@ -37,7 +37,8 @@ pub use crate::frame::{ApplicationClose, ConnectionClose};
 
 mod endpoint;
 pub use crate::endpoint::{
-    ConnectError, ConnectionHandle, DatagramEvent, Endpoint, EndpointConfig, ServerConfig,
+    ClientConfig, ConnectError, ConnectionHandle, DatagramEvent, Endpoint, EndpointConfig,
+    ServerConfig,
 };
 
 mod shared;

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -305,8 +305,9 @@ impl EcnCodepoint {
     }
 }
 
+/// Internal structure for client-specific data
 #[derive(Clone)]
-pub struct ClientConfig {
+pub struct ClientOpts {
     pub server_name: String,
-    pub tls_config: Arc<crypto::ClientConfig>,
+    pub crypto: Arc<crypto::ClientConfig>,
 }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -459,7 +459,7 @@ fn zero_rtt_rejection() {
 #[test]
 fn stream_id_backpressure() {
     let server = ServerConfig {
-        transport_config: Arc::new(TransportConfig {
+        transport: Arc::new(TransportConfig {
             stream_window_uni: 1,
             ..TransportConfig::default()
         }),
@@ -669,7 +669,7 @@ fn instant_close_2() {
 fn idle_timeout() {
     const IDLE_TIMEOUT: u64 = 10;
     let server = ServerConfig {
-        transport_config: Arc::new(TransportConfig {
+        transport: Arc::new(TransportConfig {
             idle_timeout: IDLE_TIMEOUT,
             ..TransportConfig::default()
         }),
@@ -808,7 +808,7 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     let mut pair = Pair::new(
         Default::default(),
         ServerConfig {
-            transport_config: Arc::new(config),
+            transport: Arc::new(config),
             ..server_config()
         },
     );
@@ -1010,7 +1010,7 @@ fn zero_length_cid() {
 fn keep_alive() {
     const IDLE_TIMEOUT: u64 = 10_000;
     let server = ServerConfig {
-        transport_config: Arc::new(TransportConfig {
+        transport: Arc::new(TransportConfig {
             keep_alive_interval: IDLE_TIMEOUT as u32 / 2,
             idle_timeout: IDLE_TIMEOUT,
             ..TransportConfig::default()

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -824,8 +824,9 @@ fn server_busy() {
                 },
         })
     );
-    // TODO: somehow assert that no state was left on the server?
     assert_eq!(pair.server.connections.len(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
 }
 
 #[test]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -511,28 +511,6 @@ fn zero_rtt_rejection() {
 }
 
 #[test]
-fn close_during_handshake() {
-    let mut pair = Pair::default();
-    let (client_ch, client_conn) = pair
-        .client
-        .connect(
-            None,
-            pair.server.addr,
-            Default::default(),
-            client_config(),
-            "localhost",
-        )
-        .unwrap();
-    pair.client.connections.insert(client_ch, client_conn);
-    pair.client
-        .connections
-        .get_mut(&client_ch)
-        .unwrap()
-        .close(pair.time, 0, Bytes::new());
-    // This never actually sends the client's Initial; we may want to behave better here.
-}
-
-#[test]
 fn stream_id_backpressure() {
     let server = ServerConfig {
         transport_config: Arc::new(TransportConfig {

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -67,6 +67,7 @@ fn version_negotiate_client() {
     .unwrap();
     let (_, mut client_conn) = client
         .connect(
+            None,
             server_addr,
             Default::default(),
             client_config(),
@@ -316,6 +317,7 @@ fn reject_self_signed_cert() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             Arc::new(client_config),
@@ -380,6 +382,7 @@ fn zero_rtt() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             config.clone(),
@@ -403,7 +406,13 @@ fn zero_rtt() {
     info!(pair.log, "resuming session");
     let (client_ch, client_conn) = pair
         .client
-        .connect(pair.server.addr, Default::default(), config, "localhost")
+        .connect(
+            None,
+            pair.server.addr,
+            Default::default(),
+            config,
+            "localhost",
+        )
         .unwrap();
     pair.client.connections.insert(client_ch, client_conn);
     assert!(pair.client_conn_mut(client_ch).has_0rtt());
@@ -429,6 +438,7 @@ fn zero_rtt_rejection() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             config.clone(),
@@ -464,7 +474,13 @@ fn zero_rtt_rejection() {
     info!(pair.log, "resuming session");
     let (client_ch, client_conn) = pair
         .client
-        .connect(pair.server.addr, Default::default(), config, "localhost")
+        .connect(
+            None,
+            pair.server.addr,
+            Default::default(),
+            config,
+            "localhost",
+        )
         .unwrap();
     pair.client.connections.insert(client_ch, client_conn);
     assert!(pair.client_conn_mut(client_ch).has_0rtt());
@@ -500,6 +516,7 @@ fn close_during_handshake() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             client_config(),
@@ -675,6 +692,7 @@ fn initial_retransmit() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             client_config(),
@@ -698,6 +716,7 @@ fn instant_close() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             client_config(),
@@ -727,6 +746,7 @@ fn instant_close_2() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             client_config(),
@@ -804,6 +824,7 @@ fn server_busy() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             client_config(),
@@ -835,6 +856,7 @@ fn server_hs_retransmit() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             client_config(),
@@ -875,6 +897,7 @@ fn decode_coalesced() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             client_config(),
@@ -1192,6 +1215,7 @@ fn handshake_1rtt_handling() {
     let (client_ch, client_conn) = pair
         .client
         .connect(
+            None,
             pair.server.addr,
             Default::default(),
             client_config(),

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -396,7 +396,7 @@ pub fn server_config() -> ServerConfig {
         .set_single_cert(vec![rustls::Certificate(cert)], rustls::PrivateKey(key))
         .unwrap();
     ServerConfig {
-        tls_config: Arc::new(tls_config),
+        crypto: Arc::new(tls_config),
         ..Default::default()
     }
 }

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -395,7 +395,6 @@ pub fn server_config() -> ServerConfig {
     tls_config
         .set_single_cert(vec![rustls::Certificate(cert)], rustls::PrivateKey(key))
         .unwrap();
-    tls_config.max_early_data_size = 0xffff_ffff;
     ServerConfig {
         tls_config: Arc::new(tls_config),
         ..Default::default()

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -130,6 +130,7 @@ impl Pair {
         let (client_ch, client_conn) = self
             .client
             .connect(
+                None,
                 self.server.addr,
                 Default::default(),
                 client_config(),

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -68,7 +68,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
         .ok_or(format_err!("couldn't resolve to an address"))?;
 
     let mut endpoint = quinn::Endpoint::new();
-    let mut client_config = quinn::ClientConfigBuilder::new();
+    let mut client_config = quinn::ClientConfigBuilder::default();
     client_config.protocols(&[quinn::ALPN_QUIC_HTTP]);
     endpoint.logger(log.clone());
     if options.keylog {

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -84,7 +84,7 @@ fn main() {
 
 fn run(log: Logger, options: Opt) -> Result<()> {
     let server_config = quinn::ServerConfig {
-        transport_config: Arc::new(quinn::TransportConfig {
+        transport: Arc::new(quinn::TransportConfig {
             stream_window_uni: 0,
             ..Default::default()
         }),

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -160,7 +160,7 @@ impl ServerConfigBuilder {
     ///
     /// Useful for debugging encrypted communications with protocol analyzers such as Wireshark.
     pub fn enable_keylog(&mut self) -> &mut Self {
-        Arc::make_mut(&mut self.config.tls_config).key_log = Arc::new(KeyLogFile::new());
+        Arc::make_mut(&mut self.config.crypto).key_log = Arc::new(KeyLogFile::new());
         self
     }
 
@@ -170,7 +170,7 @@ impl ServerConfigBuilder {
         cert_chain: CertificateChain,
         key: PrivateKey,
     ) -> Result<&mut Self, TLSError> {
-        Arc::make_mut(&mut self.config.tls_config).set_single_cert(cert_chain.certs, key.inner)?;
+        Arc::make_mut(&mut self.config.crypto).set_single_cert(cert_chain.certs, key.inner)?;
         Ok(self)
     }
 
@@ -182,7 +182,7 @@ impl ServerConfigBuilder {
     ///
     /// [registry]: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
     pub fn protocols(&mut self, protocols: &[&[u8]]) -> &mut Self {
-        Arc::make_mut(&mut self.config.tls_config).alpn_protocols =
+        Arc::make_mut(&mut self.config.crypto).alpn_protocols =
             protocols.iter().map(|x| x.to_vec()).collect();
         self
     }

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -269,6 +269,7 @@ impl ClientConfigBuilder {
         ClientConfig {
             transport: Arc::new(self.transport),
             tls_config: Arc::new(self.crypto),
+            log: None,
         }
     }
 }
@@ -289,6 +290,11 @@ pub struct ClientConfig {
     ///
     /// `versions` *must* be `vec![ProtocolVersion::TLSv1_3]`.
     pub tls_config: Arc<quinn::ClientConfig>,
+
+    /// Diagnostic logger
+    ///
+    /// If unset, the endpoint's logger is used.
+    pub log: Option<Logger>,
 }
 
 impl Default for ClientConfig {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -203,6 +203,13 @@ impl Connection {
     pub fn force_key_update(&self) {
         self.0.lock().unwrap().inner.force_key_update()
     }
+
+    /// Replace the diagnostic logger
+    pub fn set_logger(&self, log: Logger) {
+        let mut conn = self.0.lock().unwrap();
+        conn.log = log.clone();
+        conn.inner.set_logger(log);
+    }
 }
 
 /// A stream of QUIC streams initiated by a remote peer.

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -24,7 +24,7 @@ pub use crate::quinn::{
 pub use crate::tls::{Certificate, CertificateChain, PrivateKey};
 
 pub use crate::builders::{
-    ClientConfig, ClientConfigBuilder, EndpointBuilder, EndpointError, ServerConfigBuilder,
+    ClientConfigBuilder, EndpointBuilder, EndpointError, ServerConfigBuilder,
 };
 use crate::{ConnectionEvent, EndpointEvent};
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -62,13 +62,13 @@ mod udp;
 use quinn_proto as quinn;
 
 pub use crate::quinn::{
-    ConnectError, ConnectionError, ConnectionId, DatagramEvent, ServerConfig, Transmit,
-    TransportConfig, ALPN_QUIC_H3, ALPN_QUIC_HTTP,
+    ClientConfig, ConnectError, ConnectionError, ConnectionId, DatagramEvent, ServerConfig,
+    Transmit, TransportConfig, ALPN_QUIC_H3, ALPN_QUIC_HTTP,
 };
 pub use crate::tls::{Certificate, CertificateChain, PrivateKey};
 
 pub use crate::builders::{
-    ClientConfig, ClientConfigBuilder, EndpointBuilder, EndpointError, ServerConfigBuilder,
+    ClientConfigBuilder, EndpointBuilder, EndpointError, ServerConfigBuilder,
 };
 
 mod connection;

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -31,7 +31,7 @@ fn handshake_timeout() {
         .block_on(
             client
                 .connect_with(
-                    &client_config,
+                    client_config,
                     &SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1),
                     "localhost",
                 )

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -84,6 +84,21 @@ fn drop_endpoint() {
 }
 
 #[test]
+fn drop_endpoint_driver() {
+    let endpoint = Endpoint::new();
+    let (_, endpoint, _) = endpoint
+        .bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .unwrap();
+
+    assert!(endpoint
+        .connect(
+            &SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234),
+            "localhost",
+        )
+        .is_err());
+}
+
+#[test]
 fn close_endpoint() {
     let endpoint = Endpoint::new();
     let (_driver, endpoint, incoming) = endpoint


### PR DESCRIPTION
No significant behavioral change, but lots of quality-of-life improvements. Allowing per-connection loggers to be specified is especially helpful when trying to diagnose problems in code with many concurrent connections as it allows logs to easily be collected separately and only displayed once the relevant subset are identified.