### PR TITLE
ReadToEnd future cleanup

### DIFF
--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -336,7 +336,7 @@ fn h3_get(
             recv.read_to_end(usize::max_value())
                 .map_err(|e| format_err!("failed to send Request frame: {}", e))
         })
-        .and_then(move |(_, data)| h3_resp(&table, data))
+        .and_then(move |data| h3_resp(&table, data))
 }
 
 fn h3_resp(table: &qpack::DynamicTable, data: Vec<u8>) -> Result<Bytes> {
@@ -375,7 +375,7 @@ fn get(
             recv.read_to_end(usize::max_value())
                 .map_err(|e| format_err!("failed to read response: {}", e))
         })
-        .map(|(_, data)| data)
+        .map(|data| data)
 }
 
 struct InteropVerifier(Arc<Mutex<State>>);

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -334,6 +334,7 @@ fn h3_get(
         .map_err(|e| format_err!("failed to send Request frame: {}", e))
         .and_then(|(_, _)| {
             recv.read_to_end(usize::max_value())
+                .unwrap()
                 .map_err(|e| format_err!("failed to send Request frame: {}", e))
         })
         .and_then(move |data| h3_resp(&table, data))
@@ -373,6 +374,7 @@ fn get(
         })
         .and_then(move |_| {
             recv.read_to_end(usize::max_value())
+                .unwrap()
                 .map_err(|e| format_err!("failed to read response: {}", e))
         })
         .map(|data| data)

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -138,6 +138,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
                                 let response_start = Instant::now();
                                 eprintln!("request sent at {:?}", response_start - start);
                                 recv.read_to_end(usize::max_value())
+                                    .unwrap()
                                     .map_err(|e| format_err!("failed to read response: {}", e))
                                     .map(move |x| (x, response_start))
                             })

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -142,7 +142,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
                                     .map(move |x| (x, response_start))
                             })
                     })
-                    .map(move |((_, data), response_start)| {
+                    .map(move |(data, response_start)| {
                         let duration = response_start.elapsed();
                         eprintln!(
                             "response received in {:?} - {} KiB/s",

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -211,7 +211,7 @@ fn handle_request(root: &PathBuf, log: &Logger, stream: quinn::NewStream) {
     tokio_current_thread::spawn(
         recv.read_to_end(64 * 1024) // Read the request, which must be at most 64KiB
             .map_err(|e| format_err!("failed reading request: {}", e))
-            .and_then(move |(_, req)| {
+            .and_then(move |req| {
                 let mut escaped = String::new();
                 for &x in &req[..] {
                     let part = ascii::escape_default(x).collect::<Vec<_>>();

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -210,6 +210,7 @@ fn handle_request(root: &PathBuf, log: &Logger, stream: quinn::NewStream) {
 
     tokio_current_thread::spawn(
         recv.read_to_end(64 * 1024) // Read the request, which must be at most 64KiB
+            .unwrap()
             .map_err(|e| format_err!("failed reading request: {}", e))
             .and_then(move |req| {
                 let mut escaped = String::new();

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -227,6 +227,7 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
                                     })
                                     .and_then(move |_| {
                                         recv.read_to_end(usize::max_value())
+                                            .unwrap()
                                             .map_err(|e| panic!("read: {}", e))
                                     })
                             })

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -230,7 +230,7 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
                                             .map_err(|e| panic!("read: {}", e))
                                     })
                             })
-                            .map(move |(_, data)| {
+                            .map(move |data| {
                                 assert_eq!(&data[..], b"foo");
                                 conn.close(0, b"done");
                             })

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -115,6 +115,7 @@ fn read_from_peer(
 
     stream
         .read_to_end(1024 * 1024 * 5)
+        .unwrap()
         .map_err(|e| {
             use quinn::ReadError::*;
             match e {

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -123,7 +123,7 @@ fn read_from_peer(
                 ConnectionClosed(e) => e,
             }
         })
-        .and_then(move |(_stream, data)| {
+        .and_then(move |data| {
             assert!(hash_correct(&data));
             Ok(())
         })


### PR DESCRIPTION
You can't do anything with a finished receive stream, so there's no point preserving it even under futures 0.1 idioms.