### PR TITLE
Connection lifecycle fixes

### DIFF
--- a/quinn/examples/connection.rs
+++ b/quinn/examples/connection.rs
@@ -28,17 +28,21 @@ fn main() -> Result<(), Box<std::error::Error>> {
     let (driver, incoming, server_cert) = make_server_endpoint(("0.0.0.0", SERVER_PORT))?;
     // drive UDP socket
     runtime.spawn(driver.map_err(|e| panic!("IO error: {}", e)));
-    let handle_incoming_conns = incoming
-        .take(1)
-        .for_each(move |(conn_driver, conn, _incoming)| {
-            current_thread::spawn(conn_driver.map_err(|_| ()));
-            println!(
-                "[server] incoming connection: id={} addr={}",
-                conn.remote_id(),
-                conn.remote_address()
-            );
-            Ok(())
-        });
+    let handle_incoming_conns = incoming.take(1).for_each(move |incoming_conn| {
+        current_thread::spawn(
+            incoming_conn
+                .and_then(|(conn_driver, conn, _incoming)| {
+                    println!(
+                        "[server] incoming connection: id={} addr={}",
+                        conn.remote_id(),
+                        conn.remote_address()
+                    );
+                    conn_driver
+                })
+                .map_err(|_| ()),
+        );
+        Ok(())
+    });
     runtime.spawn(handle_incoming_conns);
 
     let (endpoint, driver) = make_client_endpoint("0.0.0.0:0", &[&server_cert])?;

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -34,17 +34,21 @@ fn run_server<A: ToSocketAddrs>(runtime: &mut Runtime, addr: A) -> Result<(), Bo
     let (driver, incoming, _server_cert) = make_server_endpoint(addr)?;
     // drive UDP socket
     runtime.spawn(driver.map_err(|e| panic!("IO error: {}", e)));
-    let handle_incoming_conns = incoming
-        .take(1)
-        .for_each(move |(conn_driver, conn, _incoming)| {
-            current_thread::spawn(conn_driver.map_err(|_| ()));
-            println!(
-                "[server] incoming connection: id={} addr={}",
-                conn.remote_id(),
-                conn.remote_address()
-            );
-            Ok(())
-        });
+    let handle_incoming_conns = incoming.take(1).for_each(move |incoming_conn| {
+        current_thread::spawn(
+            incoming_conn
+                .and_then(|(conn_driver, conn, _incoming)| {
+                    println!(
+                        "[server] incoming connection: id={} addr={}",
+                        conn.remote_id(),
+                        conn.remote_address()
+                    );
+                    conn_driver
+                })
+                .map_err(|_| ()),
+        );
+        Ok(())
+    });
     runtime.spawn(handle_incoming_conns);
 
     Ok(())

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -93,9 +93,7 @@ impl Future for Connecting {
     }
 }
 
-pub(crate) fn new_connection(
-    conn: ConnectionRef,
-) -> (ConnectionDriver, Connection, IncomingStreams) {
+fn new_connection(conn: ConnectionRef) -> (ConnectionDriver, Connection, IncomingStreams) {
     (
         ConnectionDriver(conn.clone()),
         Connection(conn.clone()),

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -19,7 +19,9 @@ use tokio_timer::Delay;
 use crate::streams::{NewStream, RecvStream, SendStream, WriteError};
 use crate::{ConnectionEvent, EndpointEvent};
 
-/// Connecting future
+/// In-progress connection attempt future
+///
+/// Be sure to spawn the `ConnectionDriver` when complete.
 pub struct Connecting(Option<ConnectionDriver>);
 
 impl Connecting {
@@ -27,7 +29,8 @@ impl Connecting {
         Self(Some(ConnectionDriver(conn)))
     }
 
-    /// Convert into a 0-RTT or 0.5-RTT connection at the cost of weakened security
+    /// Convert into a 0-RTT or 0.5-RTT connection at the cost of weakened security. Be sure to
+    /// spawn the `ConnectionDriver`.
     ///
     /// Opens up the connection for use before the handshake finishes, allowing the API user to
     /// send data with 0-RTT encryption if the necessary key material is available. This is useful

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -256,11 +256,7 @@ impl FuturesStream for IncomingStreams {
     type Error = ConnectionError;
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         let mut conn = self.0.lock().unwrap();
-        if let Some(ConnectionError::LocallyClosed) = conn.error {
-            Ok(Async::Ready(None))
-        } else if let Some(ref e) = conn.error {
-            Err(e.clone())
-        } else if let Some(x) = conn.inner.accept() {
+        if let Some(x) = conn.inner.accept() {
             mem::drop(conn); // Release the lock so clone can take it
             let stream = if x.directionality() == Directionality::Uni {
                 NewStream::Uni(RecvStream::new(self.0.clone(), x, false))
@@ -271,6 +267,10 @@ impl FuturesStream for IncomingStreams {
                 )
             };
             Ok(Async::Ready(Some(stream)))
+        } else if let Some(ConnectionError::LocallyClosed) = conn.error {
+            Ok(Async::Ready(None))
+        } else if let Some(ref e) = conn.error {
+            Err(e.clone())
         } else {
             conn.incoming_streams_reader = Some(task::current());
             Ok(Async::NotReady)

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -39,7 +39,7 @@ impl Endpoint {
         EndpointBuilder::default()
     }
 
-    /// Connect to a remote endpoint.
+    /// Connect to a remote endpoint. Be sure to spawn the `ConnectionDriver` after connecting.
     ///
     /// May fail immediately due to configuration errors, or in the future if the connection could
     /// not be established.

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -31,6 +31,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     let epoch = Instant::now();
     let shared2 = shared.clone();
     let read_incoming_data = incoming_conns
+        .and_then(|connect| connect.map_err(|_| ()))
         .take(expected_messages as u64)
         .map_err(|()| panic!("Listener failed"))
         .for_each(move |(conn_driver, conn, incoming)| {


### PR DESCRIPTION
Looks like we forgot to update `quinn::Incoming` to yield a stream of handshake futures to represent the fact that its connections are not yet fully established.

Fixes #331