### PR TITLE
Coalesce outgoing packets

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2150,7 +2150,7 @@ impl Connection {
 
         Some(Transmit {
             destination: remote,
-            packet: buf.into(),
+            contents: buf.into(),
             ecn: if self.sending_ecn {
                 Some(EcnCodepoint::ECT0)
             } else {

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1946,13 +1946,13 @@ impl Connection {
             return None;
         }
 
-        let (space_id, close) = match self.state {
+        let (spaces, close) = match self.state {
             State::Draining | State::Drained => {
                 return None;
             }
             State::Closed(_) => {
                 if mem::replace(&mut self.io.close, false) {
-                    (self.highest_space, true)
+                    (vec![self.highest_space], true)
                 } else {
                     return None;
                 }
@@ -1968,176 +1968,204 @@ impl Connection {
                                         && self.side.is_client()
                                         && (self.space(x).can_send() || self.can_send_1rtt()))))
                     })
-                    .next()?,
+                    .collect(),
                 false,
             ),
         };
 
         let mut remote = self.remote;
-        let probe = !close && self.io.probes != 0;
-        let mut ack_only = self.space(space_id).pending.is_empty();
-        if space_id == SpaceId::Data {
-            ack_only &= self.path_response.is_none();
-            if !probe && !ack_only && self.congestion_blocked() {
-                return None;
-            }
-        }
-
-        //
-        // From here on, we've determined that a packet will definitely be sent.
-        //
-
-        self.io.probes = self.io.probes.saturating_sub(1);
-        if self.spaces[SpaceId::Initial as usize].crypto.is_some()
-            && space_id == SpaceId::Handshake
-            && self.side.is_client()
-        {
-            // A client stops both sending and processing Initial packets when it
-            // sends its first Handshake packet.
-            self.discard_space(SpaceId::Initial)
-        }
-        if let Some(ref mut prev) = self.prev_crypto {
-            prev.update_unacked = false;
-        }
-
-        let space = &mut self.spaces[space_id as usize];
-        let exact_number = space.get_tx_number();
-        trace!(
-            self.log,
-            "sending {space:?} packet {number}",
-            space = space_id,
-            number = exact_number
-        );
-        let number = PacketNumber::new(exact_number, space.largest_acked_packet);
-        let header = match space_id {
-            SpaceId::Data if space.crypto.is_some() => Header::Short {
-                dst_cid: self.rem_cid,
-                number,
-                spin: self.spin,
-                key_phase: self.key_phase,
-            },
-            SpaceId::Data => Header::Long {
-                ty: LongType::ZeroRtt,
-                src_cid: self.handshake_cid,
-                dst_cid: self.rem_cid,
-                number,
-            },
-            SpaceId::Handshake => Header::Long {
-                ty: LongType::Handshake,
-                src_cid: self.handshake_cid,
-                dst_cid: self.rem_cid,
-                number,
-            },
-            SpaceId::Initial => Header::Initial {
-                src_cid: self.handshake_cid,
-                dst_cid: self.rem_cid,
-                token: match self.state {
-                    State::Handshake(ref state) => state.token.clone().unwrap_or_else(Bytes::new),
-                    _ => Bytes::new(),
-                },
-                number,
-            },
-        };
         let mut buf = Vec::with_capacity(self.mtu as usize);
-        let partial_encode = header.encode(&mut buf);
+        let mut coalesce = spaces.len() > 1;
+        let pad_space = if self.side.is_client() && spaces.first() == Some(&SpaceId::Initial) {
+            spaces.last().cloned()
+        } else {
+            None
+        };
 
-        if probe && ack_only && header.is_1rtt() {
-            // Nothing ack-eliciting to send, so we need to make something up
-            self.ping_pending = true;
-        }
-        ack_only &= !self.ping_pending;
-
-        let sent = if close {
-            trace!(self.log, "sending CONNECTION_CLOSE");
-            let max_len = buf.capacity()
-                - partial_encode.header_len
-                - space.crypto.as_ref().unwrap().packet.tag_len();
-            match self.state {
-                State::Closed(state::Closed {
-                    reason: state::CloseReason::Application(ref x),
-                }) => x.encode(&mut buf, max_len),
-                State::Closed(state::Closed {
-                    reason: state::CloseReason::Connection(ref x),
-                }) => x.encode(&mut buf, max_len),
-                _ => unreachable!("tried to make a close packet when the connection wasn't closed"),
+        for space_id in spaces {
+            let probe = !close && self.io.probes != 0;
+            let mut ack_only = self.space(space_id).pending.is_empty();
+            if space_id == SpaceId::Data {
+                ack_only &= self.path_response.is_none();
+                if !probe && !ack_only && self.congestion_blocked() {
+                    continue;
+                }
             }
-            None
-        } else if let Some((path_remote, token)) = self.offpath_responses.pop() {
-            // For simplicity's sake, we don't bother trying to batch together or deduplicate path
-            // validation probes.
-            trace!(self.log, "PATH_RESPONSE {token:08x}", token = token);
-            buf.write(frame::Type::PATH_RESPONSE);
-            buf.write(token);
-            remote = path_remote;
-            None
-        } else {
-            Some(self.populate_packet(now, space_id, &mut buf))
-        };
 
-        let space = &mut self.spaces[space_id as usize];
-        let crypto = if let Some(ref crypto) = space.crypto {
-            crypto
-        } else if space_id == SpaceId::Data {
-            self.zero_rtt_crypto.as_ref().unwrap()
-        } else {
-            unreachable!("tried to send {:?} packet without keys", space_id);
-        };
+            //
+            // From here on, we've determined that a packet will definitely be sent.
+            //
 
-        let mut padded = if self.side.is_client()
-            && space_id == SpaceId::Initial
-            && buf.len() < MIN_INITIAL_SIZE - crypto.packet.tag_len()
-        {
-            // Initial-only packets MUST be padded
-            buf.resize(MIN_INITIAL_SIZE - crypto.packet.tag_len(), 0);
-            true
-        } else {
-            false
-        };
+            self.io.probes = self.io.probes.saturating_sub(1);
+            if self.spaces[SpaceId::Initial as usize].crypto.is_some()
+                && space_id == SpaceId::Handshake
+                && self.side.is_client()
+            {
+                // A client stops both sending and processing Initial packets when it
+                // sends its first Handshake packet.
+                self.discard_space(SpaceId::Initial)
+            }
+            if let Some(ref mut prev) = self.prev_crypto {
+                prev.update_unacked = false;
+            }
 
-        let pn_len = number.len();
-        // To ensure that sufficient data is available for sampling, packets are padded so that the
-        // combined lengths of the encoded packet number and protected payload is at least 4 bytes
-        // longer than the sample required for header protection.
-        let protected_payload_len =
-            (buf.len() + crypto.packet.tag_len()) - partial_encode.header_len;
-        if let Some(padding_minus_one) =
-            (crypto.header.sample_size() + 3).checked_sub(pn_len + protected_payload_len)
-        {
-            let padding = padding_minus_one + 1;
-            padded = true;
-            trace!(self.log, "PADDING * {count}", count = padding);
-            buf.resize(buf.len() + padding, 0);
-        }
-        buf.resize(buf.len() + crypto.packet.tag_len(), 0);
-        partial_encode.finish(
-            &mut buf,
-            &crypto.header,
-            Some((exact_number, &crypto.packet)),
-        );
-
-        if let Some((sent, acks)) = sent {
-            // If we sent any acks, don't immediately resend them. Setting this even if ack_only is
-            // false needlessly prevents us from ACKing the next packet if it's ACK-only, but saves
-            // the need for subtler logic to avoid double-transmitting acks all the time.
-            space.permit_ack_only &= acks.is_empty();
-
-            self.on_packet_sent(
-                now,
-                space_id,
-                exact_number,
-                SentPacket {
-                    acks,
-                    time_sent: now,
-                    size: if padded || !ack_only {
-                        buf.len() as u16
-                    } else {
-                        0
-                    },
-                    is_crypto_packet: space_id != SpaceId::Data && !sent.crypto.is_empty(),
-                    ack_eliciting: !ack_only,
-                    retransmits: sent,
-                },
+            let space = &mut self.spaces[space_id as usize];
+            let exact_number = space.get_tx_number();
+            trace!(
+                self.log,
+                "sending {space:?} packet {number}",
+                space = space_id,
+                number = exact_number
             );
+            let number = PacketNumber::new(exact_number, space.largest_acked_packet);
+            let header = match space_id {
+                SpaceId::Data if space.crypto.is_some() => Header::Short {
+                    dst_cid: self.rem_cid,
+                    number,
+                    spin: self.spin,
+                    key_phase: self.key_phase,
+                },
+                SpaceId::Data => Header::Long {
+                    ty: LongType::ZeroRtt,
+                    src_cid: self.handshake_cid,
+                    dst_cid: self.rem_cid,
+                    number,
+                },
+                SpaceId::Handshake => Header::Long {
+                    ty: LongType::Handshake,
+                    src_cid: self.handshake_cid,
+                    dst_cid: self.rem_cid,
+                    number,
+                },
+                SpaceId::Initial => Header::Initial {
+                    src_cid: self.handshake_cid,
+                    dst_cid: self.rem_cid,
+                    token: match self.state {
+                        State::Handshake(ref state) => {
+                            state.token.clone().unwrap_or_else(Bytes::new)
+                        }
+                        _ => Bytes::new(),
+                    },
+                    number,
+                },
+            };
+            let partial_encode = header.encode(&mut buf);
+            coalesce = coalesce && !header.is_short();
+
+            if probe && ack_only && header.is_1rtt() {
+                // Nothing ack-eliciting to send, so we need to make something up
+                self.ping_pending = true;
+            }
+            ack_only &= !self.ping_pending;
+
+            let sent = if close {
+                trace!(self.log, "sending CONNECTION_CLOSE");
+                let max_len = buf.capacity()
+                    - partial_encode.start
+                    - partial_encode.header_len
+                    - space.crypto.as_ref().unwrap().packet.tag_len();
+                match self.state {
+                    State::Closed(state::Closed {
+                        reason: state::CloseReason::Application(ref x),
+                    }) => x.encode(&mut buf, max_len),
+                    State::Closed(state::Closed {
+                        reason: state::CloseReason::Connection(ref x),
+                    }) => x.encode(&mut buf, max_len),
+                    _ => unreachable!(
+                        "tried to make a close packet when the connection wasn't closed"
+                    ),
+                }
+                coalesce = false;
+                None
+            } else if let Some((path_remote, token)) = self.offpath_responses.pop() {
+                // For simplicity's sake, we don't bother trying to batch together or deduplicate path
+                // validation probes.
+                trace!(self.log, "PATH_RESPONSE {token:08x}", token = token);
+                buf.write(frame::Type::PATH_RESPONSE);
+                buf.write(token);
+                remote = path_remote;
+                coalesce = false;
+                None
+            } else {
+                Some(self.populate_packet(now, space_id, &mut buf))
+            };
+
+            let space = &mut self.spaces[space_id as usize];
+            let crypto = if let Some(ref crypto) = space.crypto {
+                crypto
+            } else if space_id == SpaceId::Data {
+                self.zero_rtt_crypto.as_ref().unwrap()
+            } else {
+                unreachable!("tried to send {:?} packet without keys", space_id);
+            };
+
+            let mut padded = if pad_space == Some(space_id)
+                && buf.len() < MIN_INITIAL_SIZE - crypto.packet.tag_len()
+            {
+                // Initial-only packets MUST be padded
+                buf.resize(MIN_INITIAL_SIZE - crypto.packet.tag_len(), 0);
+                true
+            } else {
+                false
+            };
+
+            let pn_len = number.len();
+            // To ensure that sufficient data is available for sampling, packets are padded so that the
+            // combined lengths of the encoded packet number and protected payload is at least 4 bytes
+            // longer than the sample required for header protection.
+            let protected_payload_len = (buf.len() + crypto.packet.tag_len())
+                - partial_encode.start
+                - partial_encode.header_len;
+            if let Some(padding_minus_one) =
+                (crypto.header.sample_size() + 3).checked_sub(pn_len + protected_payload_len)
+            {
+                let padding = padding_minus_one + 1;
+                padded = true;
+                trace!(self.log, "PADDING * {count}", count = padding);
+                buf.resize(buf.len() + padding, 0);
+            }
+
+            buf.resize(buf.len() + crypto.packet.tag_len(), 0);
+            debug_assert!(buf.len() < self.mtu as usize);
+            let packet_buf = &mut buf[partial_encode.start..];
+            partial_encode.finish(
+                packet_buf,
+                &crypto.header,
+                Some((exact_number, &crypto.packet)),
+            );
+
+            if let Some((sent, acks)) = sent {
+                // If we sent any acks, don't immediately resend them. Setting this even if ack_only is
+                // false needlessly prevents us from ACKing the next packet if it's ACK-only, but saves
+                // the need for subtler logic to avoid double-transmitting acks all the time.
+                space.permit_ack_only &= acks.is_empty();
+
+                self.on_packet_sent(
+                    now,
+                    space_id,
+                    exact_number,
+                    SentPacket {
+                        acks,
+                        time_sent: now,
+                        size: if padded || !ack_only {
+                            buf.len() as u16
+                        } else {
+                            0
+                        },
+                        is_crypto_packet: space_id != SpaceId::Data && !sent.crypto.is_empty(),
+                        ack_eliciting: !ack_only,
+                        retransmits: sent,
+                    },
+                );
+            }
+
+            if !coalesce || buf.capacity() - buf.len() < MIN_PACKET_SPACE {
+                break;
+            }
+        }
+
+        if buf.is_empty() {
+            return None;
         }
 
         trace!(
@@ -3385,3 +3413,5 @@ fn instant_saturating_sub(x: Instant, y: Instant) -> Duration {
 
 // Prevents overflow and improves behavior in extreme circumstances
 const MAX_BACKOFF_EXPONENT: u32 = 16;
+// Minimal remaining size to allow packet coalescing
+const MIN_PACKET_SPACE: usize = 40;

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2114,6 +2114,7 @@ impl Connection {
         if !header.is_short() {
             set_payload_length(&mut buf, header_len, pn_len, crypto.packet.tag_len());
         }
+        buf.resize(buf.len() + crypto.packet.tag_len(), 0);
         crypto.packet.encrypt(exact_number, &mut buf, header_len);
         partial_encode.finish(&mut buf, &crypto.header);
 
@@ -2976,6 +2977,7 @@ where
         state::CloseReason::Connection(ref x) => x.encode(&mut buf, max_len),
     }
     set_payload_length(&mut buf, header_len, number.len(), crypto.tag_len());
+    buf.resize(buf.len() + crypto.tag_len(), 0);
     crypto.encrypt(u64::from(packet_number), &mut buf, header_len);
     partial_encode.finish(&mut buf, header_crypto);
     buf.into()

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2038,7 +2038,7 @@ impl Connection {
                 number,
             },
         };
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(self.mtu as usize);
         let partial_encode = header.encode(&mut buf);
 
         if probe && ack_only && header.is_1rtt() {
@@ -2049,7 +2049,7 @@ impl Connection {
 
         let sent = if close {
             trace!(self.log, "sending CONNECTION_CLOSE");
-            let max_len = self.mtu as usize
+            let max_len = buf.capacity()
                 - partial_encode.header_len
                 - space.crypto.as_ref().unwrap().packet.tag_len();
             match self.state {
@@ -2182,7 +2182,7 @@ impl Connection {
             })
             .packet
             .tag_len();
-        let max_size = self.mtu as usize - tag_len;
+        let max_size = buf.capacity() - tag_len;
         let is_0rtt = space_id == SpaceId::Data && space.crypto.is_none();
         let is_1rtt = space_id == SpaceId::Data && space.crypto.is_some();
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -178,7 +178,7 @@ impl Endpoint {
                 self.transmits.push_back(Transmit {
                     destination: remote,
                     ecn: None,
-                    packet: buf.into(),
+                    contents: buf.into(),
                 });
                 return None;
             }
@@ -336,7 +336,7 @@ impl Endpoint {
         self.transmits.push_back(Transmit {
             destination: remote,
             ecn: None,
-            packet: buf.into(),
+            contents: buf.into(),
         });
     }
 
@@ -509,7 +509,7 @@ impl Endpoint {
             self.transmits.push_back(Transmit {
                 destination: remote,
                 ecn: None,
-                packet: initial_close(
+                contents: initial_close(
                     crypto,
                     header_crypto,
                     &src_cid,
@@ -532,7 +532,7 @@ impl Endpoint {
             self.transmits.push_back(Transmit {
                 destination: remote,
                 ecn: None,
-                packet: initial_close(
+                contents: initial_close(
                     crypto,
                     header_crypto,
                     &src_cid,
@@ -578,7 +578,7 @@ impl Endpoint {
                 self.transmits.push_back(Transmit {
                     destination: remote,
                     ecn: None,
-                    packet: buf.into(),
+                    contents: buf.into(),
                 });
                 return None;
             }
@@ -615,7 +615,7 @@ impl Endpoint {
                 self.transmits.push_back(Transmit {
                     destination: remote,
                     ecn: None,
-                    packet: initial_close(crypto, header_crypto, &src_cid, &temp_loc_cid, 0, e),
+                    contents: initial_close(crypto, header_crypto, &src_cid, &temp_loc_cid, 0, e),
                 });
                 None
             }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -572,7 +572,7 @@ impl Endpoint {
                     orig_dst_cid: dst_cid,
                 };
                 let encode = header.encode(&mut buf);
-                encode.finish(&mut buf, header_crypto);
+                encode.finish(&mut buf, header_crypto, None);
                 buf.put_slice(&token);
 
                 self.transmits.push_back(Transmit {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -230,7 +230,7 @@ pub struct Transmit {
     /// Explicit congestion notification bits to set on the packet
     pub ecn: Option<EcnCodepoint>,
     /// Contents of the datagram
-    pub packet: Box<[u8]>,
+    pub contents: Box<[u8]>,
 }
 
 //

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -245,6 +245,7 @@ pub enum Header {
 impl Header {
     pub fn encode(&self, w: &mut Vec<u8>) -> PartialEncode {
         use self::Header::*;
+        let start = w.len();
         match *self {
             Initial {
                 ref dst_cid,
@@ -260,7 +261,8 @@ impl Header {
                 w.write::<u16>(0); // Placeholder for payload length; see `set_payload_length`
                 number.encode(w);
                 PartialEncode {
-                    header_len: w.len(),
+                    start,
+                    header_len: w.len() - start,
                     pn: Some((number.len(), true)),
                 }
             }
@@ -276,7 +278,8 @@ impl Header {
                 w.write::<u16>(0); // Placeholder for payload length; see `set_payload_length`
                 number.encode(w);
                 PartialEncode {
-                    header_len: w.len(),
+                    start,
+                    header_len: w.len() - start,
                     pn: Some((number.len(), true)),
                 }
             }
@@ -295,7 +298,8 @@ impl Header {
                 Self::encode_cids(w, dst_cid, src_cid);
                 w.put_slice(orig_dst_cid);
                 PartialEncode {
-                    header_len: w.len(),
+                    start,
+                    header_len: w.len() - start,
                     pn: None,
                 }
             }
@@ -314,7 +318,8 @@ impl Header {
                 w.put_slice(dst_cid);
                 number.encode(w);
                 PartialEncode {
-                    header_len: w.len(),
+                    start,
+                    header_len: w.len() - start,
                     pn: Some((number.len(), false)),
                 }
             }
@@ -327,7 +332,8 @@ impl Header {
                 w.write::<u32>(0);
                 Self::encode_cids(w, dst_cid, src_cid);
                 PartialEncode {
-                    header_len: w.len(),
+                    start,
+                    header_len: w.len() - start,
                     pn: None,
                 }
             }
@@ -425,6 +431,7 @@ impl Header {
 }
 
 pub struct PartialEncode {
+    pub start: usize,
     pub header_len: usize,
     // Packet number length, payload length needed
     pn: Option<(usize, bool)>,

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -878,6 +878,7 @@ mod tests {
             buf[..],
             hex!("c0ff0000145006b858ec6f80452b00402100 00000000000000000000000000000000")[..]
         );
+        buf.resize(buf.len() + client_crypto.tag_len(), 0);
 
         client_crypto.encrypt(0, &mut buf, header_len);
         encode.finish(&mut buf, &client_header_crypto);

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -750,23 +750,8 @@ fn server_hs_retransmit() {
     let mut pair = Pair::default();
     let client_ch = pair.begin_connect(client_config());
     pair.step();
-    assert!(pair.client.inbound.len() > 1); // Initial + Handshakes
-    info!(
-        pair.log,
-        "dropping {} server handshake packets",
-        pair.client.inbound.len() - 1
-    );
-    pair.client.inbound.drain(1..);
-    // Client's Initial ACK buys a lot of budget, so keep dropping...
-    for _ in 0..3 {
-        pair.step();
-        info!(
-            pair.log,
-            "dropping {} server handshake packets",
-            pair.client.inbound.len()
-        );
-        pair.client.inbound.drain(..);
-    }
+    assert!(pair.client.inbound.len() > 0); // Initial + Handshakes
+    pair.client.inbound.clear();
     pair.drive();
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -41,10 +41,10 @@ fn version_negotiate_server() {
 
     let io = server.poll_transmit();
     assert!(io.is_some());
-    if let Some(Transmit { packet, .. }) = io {
-        assert_ne!(packet[0] & 0x80, 0);
-        assert_eq!(&packet[1..14], hex!("00000000 11 00000000 00000000"));
-        assert!(packet[14..]
+    if let Some(Transmit { contents, .. }) = io {
+        assert_ne!(contents[0] & 0x80, 0);
+        assert_eq!(&contents[1..14], hex!("00000000 11 00000000 00000000"));
+        assert!(contents[14..]
             .chunks(4)
             .any(|x| BigEndian::read_u32(x) == VERSION));
     }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -760,32 +760,6 @@ fn server_hs_retransmit() {
 }
 
 #[test]
-fn decode_coalesced() {
-    // We can't currently generate coalesced packets natively, but we must support decoding
-    // them. Hack around the problem by manually concatenating the server's first flight.
-    let mut pair = Pair::default();
-    let client_ch = pair.begin_connect(client_config());
-    pair.step();
-    assert!(
-        pair.client.inbound.len() > 1,
-        "if the server's flight isn't multiple packets, this test is redundant"
-    );
-    let mut coalesced = Vec::new();
-    for (_, _, packet) in pair.client.inbound.drain(..) {
-        coalesced.extend_from_slice(&packet);
-    }
-    pair.client
-        .inbound
-        .push_back((pair.time, Some(EcnCodepoint::ECT0), coalesced.into()));
-    pair.drive();
-    assert_matches!(
-        pair.client_conn_mut(client_ch).poll(),
-        Some(Event::Connected { .. })
-    );
-    assert_eq!(pair.client_conn_mut(client_ch).lost_packets(), 0);
-}
-
-#[test]
 fn migration() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -94,18 +94,18 @@ impl Pair {
         trace!(self.log, "client running");
         self.client.drive(&self.log, self.time, self.server.addr);
         for x in self.client.outbound.drain(..) {
-            if x.packet[0] & packet::LONG_HEADER_FORM == 0 {
-                let spin = x.packet[0] & packet::SPIN_BIT != 0;
+            if x.contents[0] & packet::LONG_HEADER_FORM == 0 {
+                let spin = x.contents[0] & packet::SPIN_BIT != 0;
                 self.spins += (spin == self.last_spin) as u64;
                 self.last_spin = spin;
             }
             if let Some(ref socket) = self.client.socket {
-                socket.send_to(&x.packet, x.destination).unwrap();
+                socket.send_to(&x.contents, x.destination).unwrap();
             }
             if self.server.addr == x.destination {
                 self.server
                     .inbound
-                    .push_back((self.time + self.latency, x.ecn, x.packet));
+                    .push_back((self.time + self.latency, x.ecn, x.contents));
             }
         }
     }
@@ -115,12 +115,12 @@ impl Pair {
         self.server.drive(&self.log, self.time, self.client.addr);
         for x in self.server.outbound.drain(..) {
             if let Some(ref socket) = self.server.socket {
-                socket.send_to(&x.packet, x.destination).unwrap();
+                socket.send_to(&x.contents, x.destination).unwrap();
             }
             if self.client.addr == x.destination {
                 self.client
                     .inbound
-                    .push_back((self.time + self.latency, x.ecn, x.packet));
+                    .push_back((self.time + self.latency, x.ecn, x.contents));
             }
         }
     }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -262,7 +262,7 @@ impl EndpointInner {
             .pop_front()
             .or_else(|| self.inner.poll_transmit())
         {
-            match self.socket.poll_send(&t.destination, t.ecn, &t.packet) {
+            match self.socket.poll_send(&t.destination, t.ecn, &t.contents) {
                 Ok(Async::Ready(_)) => {}
                 Ok(Async::NotReady) => {
                     self.outgoing.push_front(t);


### PR DESCRIPTION
Results in 3 fewer datagrams on the `echo_v4` test.

Currently the `server_hs_retransmit()` test is still broken. @Ralith any suggestions if/how this should be fixed?