### PR TITLE
Make stream read API more Stream-like

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -76,7 +76,9 @@ mod endpoint;
 pub use endpoint::{Endpoint, EndpointDriver, Incoming};
 
 mod streams;
-pub use streams::{NewStream, ReadError, ReadToEnd, RecvStream, SendStream, WriteError};
+pub use streams::{
+    NewStream, ReadError, ReadToEnd, ReadToEndError, RecvStream, SendStream, WriteError,
+};
 
 #[cfg(test)]
 mod tests;

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -118,11 +118,11 @@ fn read_from_peer(
         .read_to_end(1024 * 1024 * 5)
         .unwrap()
         .map_err(|e| {
-            use quinn::ReadError::*;
+            use quinn::{ReadError::*, ReadToEndError::*};
             match e {
-                Finished | UnknownStream | ZeroRttRejected => unreachable!(),
-                Reset { error_code } => panic!("unexpected stream reset: {}", error_code),
-                ConnectionClosed(e) => e,
+                TooLong | Read(UnknownStream) | Read(ZeroRttRejected) => unreachable!(),
+                Read(Reset { error_code }) => panic!("unexpected stream reset: {}", error_code),
+                Read(ConnectionClosed(e)) => e,
             }
         })
         .and_then(move |data| {


### PR DESCRIPTION
It occurred to me that `ReadError::Finished` is a bit weird because `Finished` isn't really an error. This change fixes that only in the `quinn` crate, where it does seem to achieve a natural alignment with `futures::Stream`-like handling. I looked at extending it to quinn-proto as well, but I'm not sure it's worth it there.