### PR TITLE
Optional rustls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
 - RUST_BACKTRACE=1 cargo test --all-features -- --ignored
 - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
     cargo fmt -- --check;
+    cd quinn-proto && cargo test --no-default-features;
   fi
 - if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
     RUST_BACKTRACE=1 cargo tarpaulin --out Xml && bash <(curl -s https://codecov.io/bash);

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -16,6 +16,10 @@ all-features = true
 [badges]
 maintenance = { status = "experimental" }
 
+[features]
+default = ["tls-rustls"]
+tls-rustls = ["rustls", "webpki", "ring"]
+
 [dependencies]
 byteorder = "1.1"
 bytes = "0.4.7"
@@ -23,12 +27,12 @@ err-derive = "0.1.5"
 fnv = "1.0.6"
 lazy_static = "1"
 rand = "0.6"
-ring = "0.14.1"
-rustls = { version = "0.15.2", features = ["quic"] }
+ring = { version = "0.14.1", optional = true }
+rustls = { version = "0.15.2", features = ["quic"], optional = true }
 slab = "0.4"
 slog = "2.2"
 untrusted = "0.6.2"
-webpki = "0.19"
+webpki = { version = "0.19", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2852,13 +2852,13 @@ where
 
     /// The number of bytes of packets containing retransmittable frames that have not been
     /// acknowledged or declared lost.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "rustls"))]
     pub(crate) fn bytes_in_flight(&self) -> u64 {
         self.in_flight.bytes
     }
 
     /// Number of bytes worth of non-ack-only packets that may be sent
-    #[cfg(test)]
+    #[cfg(all(test, feature = "rustls"))]
     pub(crate) fn congestion_state(&self) -> u64 {
         self.congestion_window.saturating_sub(self.in_flight.bytes)
     }
@@ -2871,13 +2871,13 @@ where
     }
 
     /// Total number of outgoing packets that have been deemed lost
-    #[cfg(test)]
+    #[cfg(all(test, feature = "rustls"))]
     pub(crate) fn lost_packets(&self) -> u64 {
         self.lost_packets
     }
 
     /// Whether explicit congestion notification is in use on outgoing packets.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "rustls"))]
     pub(crate) fn using_ecn(&self) -> bool {
         self.sending_ecn
     }

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -17,8 +17,10 @@ use crate::transport_parameters::TransportParameters;
 use crate::{ConnectError, Side, TransportError};
 
 /// Cryptography interface based on *ring*
+#[cfg(feature = "ring")]
 pub mod ring;
 /// TLS interface based on rustls
+#[cfg(feature = "rustls")]
 pub mod rustls;
 
 /// A cryptographic session (commonly TLS)

--- a/quinn-proto/src/crypto/ring.rs
+++ b/quinn-proto/src/crypto/ring.rs
@@ -23,7 +23,8 @@ pub struct Crypto {
 }
 
 impl Crypto {
-    pub(crate) fn new_0rtt(secret: &[u8]) -> Self {
+    /// Create keys for 0-RTT packets based on the given secret
+    pub fn new_0rtt(secret: &[u8]) -> Self {
         Self::new(
             Side::Client, // Meaningless when the secrets are equal
             &digest::SHA256,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -658,7 +658,7 @@ where
         self.reject_new_connections = true;
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "rustls"))]
     pub(crate) fn known_connections(&self) -> usize {
         let x = self.connections.len();
         debug_assert_eq!(x, self.connection_ids_initial.len());
@@ -669,7 +669,7 @@ where
         x
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "rustls"))]
     pub(crate) fn known_cids(&self) -> usize {
         self.connection_ids.len()
     }
@@ -867,10 +867,10 @@ impl From<ConfigError> for ConnectError {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
+    #[cfg(feature = "ring")]
     #[test]
     fn token_sanity() {
+        use super::*;
         use crate::crypto::HmacKey;
         use ring::hmac::SigningKey;
         use std::net::Ipv6Addr;

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -16,10 +16,10 @@
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
-#[cfg(test)]
+#[cfg(all(test, feature = "ring"))]
 #[macro_use]
 extern crate hex_literal;
-#[cfg(test)]
+#[cfg(all(test, feature = "rustls"))]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -36,7 +36,7 @@ pub mod coding;
 mod packet;
 mod range_set;
 mod spaces;
-#[cfg(test)]
+#[cfg(all(test, feature = "rustls"))]
 mod tests;
 mod transport_parameters;
 #[doc(hidden)]
@@ -73,14 +73,22 @@ pub mod generic {
     pub use crate::shared::ServerConfig;
 }
 
-/// A `Connection` using rustls for the cryptography protocol
-pub type Connection = generic::Connection<crypto::rustls::TlsSession>;
-/// A `ClientConfig` containing client-side rustls configuration
-pub type ClientConfig = generic::ClientConfig<crypto::rustls::ClientConfig>;
-/// An `Endpoint` using rustls for the cryptography protocol
-pub type Endpoint = generic::Endpoint<crypto::rustls::TlsSession>;
-/// A `ServerConfig` containing server-side rustls configuration
-pub type ServerConfig = generic::ServerConfig<crypto::rustls::TlsSession>;
+#[cfg(feature = "rustls")]
+mod rustls_impls {
+    use crate::{crypto, generic};
+
+    /// A `Connection` using rustls for the cryptography protocol
+    pub type Connection = generic::Connection<crypto::rustls::TlsSession>;
+    /// A `ClientConfig` containing client-side rustls configuration
+    pub type ClientConfig = generic::ClientConfig<crypto::rustls::ClientConfig>;
+    /// An `Endpoint` using rustls for the cryptography protocol
+    pub type Endpoint = generic::Endpoint<crypto::rustls::TlsSession>;
+    /// A `ServerConfig` containing server-side rustls configuration
+    pub type ServerConfig = generic::ServerConfig<crypto::rustls::TlsSession>;
+}
+
+#[cfg(feature = "rustls")]
+pub use crate::rustls_impls::*;
 
 /// The QUIC protocol version implemented
 pub const VERSION: u32 = 0xff00_0014;

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -844,8 +844,6 @@ impl slog::Value for SpaceId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::{ring::Crypto, Keys};
-    use crate::Side;
     use std::io;
 
     fn check_pn(typed: PacketNumber, encoded: &[u8]) {
@@ -881,8 +879,12 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "ring")]
     #[test]
     fn header_encoding() {
+        use crate::crypto::{ring::Crypto, Keys};
+        use crate::Side;
+
         let dcid = ConnectionId::new(&hex!("06b858ec6f80452b"));
         let client_crypto = Crypto::new_initial(&dcid, Side::Client);
         let client_header_crypto = client_crypto.header_keys();

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -56,7 +56,8 @@ impl slog::Value for Error {
 pub struct Code(u16);
 
 impl Code {
-    pub(crate) fn crypto(code: u8) -> Self {
+    /// Create QUIC error code from TLS alert code
+    pub fn crypto(code: u8) -> Self {
         Code(0x100 | u16::from(code))
     }
 }

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -17,23 +17,6 @@ pub struct Error {
     pub reason: String,
 }
 
-impl Error {
-    pub(crate) fn new<T>(code: Code, frame: Option<frame::Type>, reason: T) -> Self
-    where
-        T: Into<String>,
-    {
-        Self {
-            code,
-            frame,
-            reason: reason.into(),
-        }
-    }
-
-    pub(crate) fn crypto(code: u8, reason: String) -> Self {
-        Self::new(Code::crypto(code), None, reason)
-    }
-}
-
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.code.fmt(f)?;

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -5,7 +5,6 @@ use slog;
 
 use crate::coding::{self, BufExt, BufMutExt};
 use crate::frame;
-use rustls::internal::msgs::{codec::Codec, enums::AlertDescription};
 
 /// Transport-level errors occur when a peer violates the protocol specification
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -117,10 +116,7 @@ macro_rules! errors {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self.0 {
                     $($val => f.write_str(stringify!($name)),)*
-                    x if x >= 0x100 && x < 0x200 => match AlertDescription::read_bytes(&[self.0 as u8]) {
-                        Some(desc) => write!(f, "Code::crypto({:?})", desc),
-                        None => write!(f, "Code::crypto({:02x})", self.0 as u8),
-                    },
+                    x if x >= 0x100 && x < 0x200 => write!(f, "Code::crypto({:02x})", self.0 as u8),
                     _ => write!(f, "Code({:04x})", self.0),
                 }
             }


### PR DESCRIPTION
This doesn't yet fix the parameter defaults as discussed, but it does show that we can compile most of the quinn-proto crate without rustls or ring (although it will only run a few tests).