### PR TITLE
Fix deprecated rand API use

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -178,7 +178,6 @@ where
         } else {
             Side::Server
         };
-        let rng = OsRng::new().expect("failed to construct RNG");
 
         let initial_space = PacketSpace {
             crypto: Some(CryptoSpace::new(S::Keys::new_initial(&init_cid, side))),
@@ -192,7 +191,7 @@ where
             log,
             endpoint_config,
             server_config,
-            rng,
+            rng: OsRng,
             tls,
             handshake_cid: loc_cid,
             rem_cid,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -75,10 +75,9 @@ where
         server_config: Option<Arc<ServerConfig<S>>>,
     ) -> Result<Self, ConfigError> {
         config.validate()?;
-        let rng = OsRng::new().unwrap();
         Ok(Self {
             log,
-            rng,
+            rng: OsRng,
             transmits: VecDeque::new(),
             connection_ids_initial: FnvHashMap::default(),
             connection_ids: FnvHashMap::default(),


### PR DESCRIPTION
We're probably not benefiting from having an explicit RNG field at this point, but it'll save time if we want to swap it out (e.g. with *ring*'s) in the future.