### PR TITLE
More flexible RecvStream::read_to_end

### DIFF
--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -333,7 +333,6 @@ fn h3_get(
         .map_err(|e| format_err!("failed to send Request frame: {}", e))
         .and_then(|(_, _)| {
             recv.read_to_end(usize::max_value())
-                .unwrap()
                 .map_err(|e| format_err!("failed to send Request frame: {}", e))
         })
         .and_then(move |data| h3_resp(&table, data))
@@ -374,7 +373,6 @@ fn get(
         })
         .and_then(move |_| {
             recv.read_to_end(usize::max_value())
-                .unwrap()
                 .map_err(|e| format_err!("failed to read response: {}", e))
         })
         .map(|data| data)

--- a/quinn-proto/src/streams.rs
+++ b/quinn-proto/src/streams.rs
@@ -133,6 +133,10 @@ impl Streams {
         }
     }
 
+    /// Access a receive stream due to a message from the peer
+    ///
+    /// Similar to `get_recv_mut`, but with additional sanity-checks are performed to detect peer
+    /// misbehavior.
     pub fn get_recv_stream(
         &mut self,
         side: Side,

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -142,7 +142,6 @@ fn run(log: Logger, options: Opt) -> Result<()> {
                                 let response_start = Instant::now();
                                 eprintln!("request sent at {:?}", response_start - start);
                                 recv.read_to_end(usize::max_value())
-                                    .unwrap()
                                     .map_err(|e| format_err!("failed to read response: {}", e))
                                     .map(move |x| (x, response_start))
                             })

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -213,7 +213,6 @@ fn handle_request(root: &PathBuf, log: &Logger, stream: quinn::NewStream) {
 
     tokio_current_thread::spawn(
         recv.read_to_end(64 * 1024) // Read the request, which must be at most 64KiB
-            .unwrap()
             .map_err(|e| format_err!("failed reading request: {}", e))
             .and_then(move |req| {
                 let mut escaped = String::new();

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -181,7 +181,6 @@ fn read_after_close() {
                                     .expect("missing stream")
                                     .unwrap_uni()
                                     .read_to_end(usize::max_value())
-                                    .unwrap()
                                     .map_err(|e| panic!("read_to_end: {}", e))
                                     .map(|msg| {
                                         assert_eq!(msg, MSG);
@@ -234,7 +233,6 @@ fn zero_rtt() {
         tokio::runtime::current_thread::spawn(streams.map_err(|_| ()).for_each(|x| {
             x.unwrap_uni()
                 .read_to_end(usize::max_value())
-                .unwrap()
                 .map_err(|_| ())
                 .map(|msg| {
                     assert_eq!(msg, MSG);
@@ -271,7 +269,6 @@ fn zero_rtt() {
                                             .expect("missing stream")
                                             .unwrap_uni()
                                             .read_to_end(usize::max_value())
-                                            .unwrap()
                                             .map_err(|e| panic!("read_to_end: {}", e))
                                             .map(|msg| {
                                                 assert_eq!(msg, MSG);
@@ -312,7 +309,6 @@ fn zero_rtt() {
                         .expect("missing stream")
                         .unwrap_uni()
                         .read_to_end(usize::max_value())
-                        .unwrap()
                         .map_err(|e| panic!("read_to_end: {}", e))
                         .map(|msg| {
                             assert_eq!(msg, MSG);
@@ -414,7 +410,6 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
                                     .and_then(move |_| {
                                         // Rely on send being implicitly finished when we drop it
                                         recv.read_to_end(usize::max_value())
-                                            .unwrap()
                                             .map_err(|e| panic!("read: {}", e))
                                     })
                             })

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -116,7 +116,6 @@ fn read_from_peer(
 
     stream
         .read_to_end(1024 * 1024 * 5)
-        .unwrap()
         .map_err(|e| {
             use quinn::{ReadError::*, ReadToEndError::*};
             match e {


### PR DESCRIPTION
Constantly unwrapping this was bugging me, and reasonable users might want this after having read a prefix anyway. The behavior when used following an unordered read may bear some consideration.