### PR TITLE
Backwards-compatible draft 21 updates

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -601,6 +601,7 @@ where
             .rtt
             .smoothed
             .map_or(self.rtt.latest, |x| cmp::max(x, self.rtt.latest));
+        let rtt = cmp::max(rtt, TIMER_GRANULARITY);
         let loss_delay = rtt + ((rtt * u32::from(self.config.time_threshold)) / 65536);
 
         // Packets sent before this time are deemed lost.

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1328,6 +1328,7 @@ where
                             crypto: Some(CryptoSpace::new(S::Keys::new_initial(
                                 &rem_cid, self.side,
                             ))),
+                            next_packet_number: self.spaces[0].next_packet_number,
                             ..PacketSpace::new(now)
                         };
 

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -367,9 +367,16 @@ where
 
         if let Some(info) = self.space(space).sent_packets.get(&ack.largest) {
             if info.ack_eliciting {
-                let delay = Duration::from_micros(ack.delay << self.params.ack_delay_exponent);
+                let delay = if space != SpaceId::Data {
+                    Duration::from_micros(0)
+                } else {
+                    cmp::min(
+                        self.max_ack_delay(),
+                        Duration::from_micros(ack.delay << self.params.ack_delay_exponent),
+                    )
+                };
                 let rtt = instant_saturating_sub(now, info.time_sent);
-                self.rtt.update(cmp::min(delay, self.max_ack_delay()), rtt);
+                self.rtt.update(delay, rtt);
             }
         }
 

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -110,6 +110,11 @@ pub struct TransportConfig {
     pub keep_alive_interval: u32,
     /// Maximum quantity of out-of-order crypto layer data to buffer
     pub crypto_buffer_size: usize,
+    /// Whether the implementation is permitted to set the spin bit on this connection
+    ///
+    /// This allows passive observers to easily judge the round trip time of a connection, which can
+    /// be useful for network administration but sacrifices a small amount of privacy.
+    pub allow_spin: bool,
 }
 
 impl Default for TransportConfig {
@@ -145,6 +150,7 @@ impl Default for TransportConfig {
             persistent_congestion_threshold: 3,
             keep_alive_interval: 0,
             crypto_buffer_size: 16 * 1024,
+            allow_spin: true,
         }
     }
 }

--- a/quinn-proto/src/spaces.rs
+++ b/quinn-proto/src/spaces.rs
@@ -30,7 +30,7 @@ where
     /// The packet number of the next packet that will be sent, if any.
     pub next_packet_number: u64,
     /// The largest packet number the remote peer acknowledged in an ACK frame.
-    pub largest_acked_packet: u64,
+    pub largest_acked_packet: Option<u64>,
     pub largest_acked_packet_sent: Instant,
     /// Transmitted but not acked
     // We use a BTreeMap here so we can efficiently query by range on ACK and for loss detection
@@ -70,7 +70,7 @@ where
             permit_ack_only: false,
 
             next_packet_number: 0,
-            largest_acked_packet: 0,
+            largest_acked_packet: None,
             largest_acked_packet_sent: now,
             sent_packets: BTreeMap::new(),
             ecn_feedback: frame::EcnCounts::ZERO,

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -100,7 +100,6 @@ fn lifecycle() {
         .unwrap()
         .close(pair.time, 42, REASON.into());
     pair.drive();
-    assert!(pair.spins > 0);
     assert_matches!(pair.server_conn_mut(server_ch).poll(),
                     Some(Event::ConnectionLost { reason: ConnectionError::ApplicationClosed {
                         reason: ApplicationClose { error_code: 42, ref reason }

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -57,7 +57,7 @@ pub struct Code(u16);
 
 impl Code {
     /// Create QUIC error code from TLS alert code
-    pub fn crypto(code: u8) -> Self {
+    pub(crate) fn crypto(code: u8) -> Self {
         Code(0x100 | u16::from(code))
     }
 }


### PR DESCRIPTION
I feel like there should be a better way to determine whether an acknowledged packet was sent with 1-RTT keys than the `first_1rtt_sent` field.