### PR TITLE
Implement the unreliable datagram extension

### DIFF
--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -40,13 +40,16 @@ mod timer;
 pub use timer::{Timer, TimerTable, TimerTableIter, TimerTableIterMut};
 
 mod connection;
-pub use crate::connection::{ConnectionError, Event, TimerSetting, TimerUpdate};
+pub use crate::connection::{
+    ConnectionError, DatagramSender, DatagramTooLarge, Event, SendDatagramError, TimerSetting,
+    TimerUpdate,
+};
 
 pub mod crypto;
 
 mod frame;
 use crate::frame::Frame;
-pub use crate::frame::{ApplicationClose, ConnectionClose};
+pub use crate::frame::{ApplicationClose, ConnectionClose, Datagram};
 
 mod endpoint;
 pub use crate::endpoint::{ConnectError, ConnectionHandle, DatagramEvent};

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -118,6 +118,12 @@ pub struct TransportConfig {
     /// This allows passive observers to easily judge the round trip time of a connection, which can
     /// be useful for network administration but sacrifices a small amount of privacy.
     pub allow_spin: bool,
+    /// Maximum number of application datagram bytes to buffer, or None to disable datagrams
+    ///
+    /// The peer is forbidden to send single datagrams larger than this size. If the aggregate size
+    /// of all datagrams that have been received from the peer but not consumed by the application
+    /// exceeds this value, old datagrams are dropped until it is no longer exceeded.
+    pub datagram_window: Option<usize>,
 }
 
 impl Default for TransportConfig {
@@ -154,6 +160,7 @@ impl Default for TransportConfig {
             keep_alive_interval: 0,
             crypto_buffer_size: 16 * 1024,
             allow_spin: true,
+            datagram_window: Some(STREAM_RWND as usize),
         }
     }
 }

--- a/quinn/src/broadcast.rs
+++ b/quinn/src/broadcast.rs
@@ -1,0 +1,61 @@
+use std::task::{Context, Waker};
+
+/// Helper for waking unpredictable numbers of tasks simultaneously
+///
+/// # Rationale
+///
+/// Sometimes we want to let an arbitrary number of tasks wait for the same transient condition. If
+/// a task is polled and finds that the condition of interest is not in effect, it must register a
+/// `Waker` to arrange to be polled when that may have changed. The number of such tasks is
+/// indefinite, so we collect multiple `Waker`s in a `Vec` to be triggered en masse when the
+/// condition arises.
+///
+/// Complication arises from the spurious polling expected by futures. If each interested task
+/// blindly registered a new `Waker` on finding the condition not in effect, the `Vec` would grow
+/// with proportion to the (unbounded) number of spurious wakeups that interested tasks undergo. To
+/// resolve this, we increment a generation counter every time we drain the `Vec`, and associate
+/// with each interested task the generation at which it last registered. If a spurious wakeup
+/// occurs, the task's generation is current, and we can avoid growing the `Vec`. If, however, the
+/// wakeup is genuine but the condition of interest has already passed, then the task's generation
+/// no longer matches the counter, and we infer that the task's `Waker` is no longer stored and a
+/// new one must be recorded.
+pub struct Broadcast {
+    wakers: Vec<Waker>,
+    generation: u64,
+}
+
+impl Broadcast {
+    pub fn new() -> Self {
+        Self {
+            wakers: Vec::new(),
+            generation: 0,
+        }
+    }
+
+    /// Ensure the next `wake` call will wake the calling task
+    ///
+    /// Checks the task-associated generation counter stored in `state`. If it's present and
+    /// current, we already have this task's `Waker` and no action is necessary. Otherwise, record a
+    /// `Waker` and store the current generation in `state`.
+    pub fn register(&mut self, cx: &mut Context, state: &mut State) {
+        if state.0 == Some(self.generation) {
+            return;
+        }
+        state.0 = Some(self.generation);
+        self.wakers.push(cx.waker().clone());
+    }
+
+    /// Wake all known `Waker`s
+    pub fn wake(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        for waker in self.wakers.drain(..) {
+            waker.wake();
+        }
+    }
+}
+
+/// State maintained by each interested task
+///
+/// Stores the generation at which the task previously registered a `Waker`, if any.
+#[derive(Default)]
+pub struct State(Option<u64>);

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -48,6 +48,7 @@
 #[macro_use]
 extern crate slog;
 
+mod broadcast;
 mod builders;
 mod platform;
 mod udp;


### PR DESCRIPTION
Fixes #207.

~This extension isn't stable yet, and (partly in the interest of avoiding rebase churn in std-futures branch) I haven't yet implemented the high level API, but this is the bulk of the work, and the API is ready to receive feedback.~