### PR TITLE
 H3: body AsyncRead implementation

### DIFF
--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -15,7 +15,7 @@ use crate::{
     connection::ConnectionRef,
     frame::FrameStream,
     headers::DecodeHeaders,
-    proto::frame::{DataFrame, HttpFrame, HeadersFrame},
+    proto::frame::{DataFrame, HeadersFrame, HttpFrame},
     try_take, Error,
 };
 
@@ -215,16 +215,12 @@ impl Stream for RecvBodyStream {
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         match try_ready!(self.recv.poll()) {
-            Some(HttpFrame::Data(d)) => {
-                Ok(Async::Ready(Some(d.payload)))
-            }
+            Some(HttpFrame::Data(d)) => Ok(Async::Ready(Some(d.payload))),
             Some(HttpFrame::Headers(d)) => {
                 self.trailers = Some(d);
                 Ok(Async::Ready(None))
             }
-            None => {
-                Ok(Async::Ready(None))
-            }
+            None => Ok(Async::Ready(None)),
             _ => Err(Error::peer("invalid frame type in data")),
         }
     }

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -10,7 +10,7 @@ use slog::{self, o, Logger};
 use tokio_io::io::{Shutdown, WriteAll};
 
 use crate::{
-    body::{Body, RecvBody, SendBody, RecvBodyStream},
+    body::{Body, RecvBody, RecvBodyReader, RecvBodyStream, SendBody},
     connection::{ConnectionDriver, ConnectionRef},
     frame::{FrameDecoder, FrameStream},
     headers::DecodeHeaders,
@@ -320,5 +320,9 @@ impl RecvResponse {
 
     pub fn body_stream(self) -> RecvBodyStream {
         RecvBodyStream::new(self.recv, self.conn, self.stream_id)
+    }
+
+    pub fn body_reader(self) -> RecvBodyReader {
+        RecvBodyReader::new(self.recv, self.conn, self.stream_id)
     }
 }

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -14,10 +14,7 @@ use crate::{
     connection::{ConnectionDriver, ConnectionRef},
     frame::{FrameDecoder, FrameStream},
     headers::DecodeHeaders,
-    proto::{
-        frame::HttpFrame,
-        headers::Header,
-    },
+    proto::{frame::HttpFrame, headers::Header},
     try_take, Error, Settings,
 };
 

--- a/quinn-h3/src/frame.rs
+++ b/quinn-h3/src/frame.rs
@@ -48,6 +48,7 @@ impl Decoder for FrameDecoder {
             Err(e) => Err(e)?,
             Ok(frame) => {
                 src.advance(pos);
+                self.expected = None;
                 Ok(Some(frame))
             }
         }


### PR DESCRIPTION
I'm not sure about the `RecvBodyReader::buf_{pop,push}()` method names.

And about their implementation, I tried to limit the number of copies and allocations by storing the `DataFrame(Bytes)`'s buffer only. It makes `read()` returned size possibly very small compared to the passed buffer size. I'd like some feedback on this as I'm not sure about this choice.

Also, my last `rustup update` for 1.36 made some reformatting happen in the `use` sections (in the last commit), I'm not sure how to handle them?

The only example has been updated to exercise this new API.