### PR TITLE
H3: body AsyncRead implementation

### DIFF
--- a/quinn-h3/examples/h3.rs
+++ b/quinn-h3/examples/h3.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
-use std::{fmt, fs, io, mem};
+use std::{fmt, fs, io};
 
 use failure::{bail, format_err, Error, Fail, ResultExt};
-use futures::{try_ready, Future, Poll, Stream};
+use futures::{future::Either, Future, Stream};
 use http::{header::HeaderValue, method::Method, HeaderMap, Request, Response, StatusCode};
 use slog::{info, o, Drain, Logger};
 use structopt::{self, StructOpt};
@@ -17,10 +17,8 @@ use url::Url;
 use quinn::ConnectionDriver as QuicDriver;
 use quinn_h3::{
     self,
-    body::RecvBodyStream,
     client::Builder as ClientBuilder,
     connection::ConnectionDriver,
-    headers::DecodeHeaders,
     server::{Builder as ServerBuilder, IncomingRequest, RequestReady},
 };
 use quinn_proto::crypto::rustls::{Certificate, CertificateChain, PrivateKey};
@@ -204,9 +202,10 @@ fn handle_request(request: RequestReady) -> impl Future<Item = (), Error = Error
                 println!("server received trailers: {:?}", trailers);
             }
 
+            let body = "r".repeat(1024 * 800);
             let response = Response::builder()
                 .status(StatusCode::OK)
-                .body("response body")
+                .body(body.as_str())
                 .expect("failed to build response");
 
             let mut trailer = HeaderMap::with_capacity(2);
@@ -270,62 +269,30 @@ fn client(
             conn.send_request_trailers(request, trailer)
                 .map_err(|e| format_err!("send request: {}", e))
                 .and_then(|response| {
-                    println!("received headers: {:?}", response.response());
-                    ProcessResponse {
-                        state: ProcessResponseState::Body(response.body_stream()),
-                    }
-                    .map_err(|e| format_err!("send request: {}", e))
+                    let buf = Vec::with_capacity(1024 * 10); // 10K
+                    tokio_io::io::read_to_end(response.body_reader(), buf)
+                        .map_err(|e| format_err!("receive response failed: {}", e))
+                        .and_then(|(reader, data)| {
+                            println!("received body len = {}", data.len());
+                            if let Some(decode_trailers) = reader.trailers() {
+                                return Either::A(
+                                    decode_trailers
+                                        .map_err(|e| format_err!("decode trailers failed: {}", e))
+                                        .and_then(|trailers| {
+                                            println!(
+                                                "received trailers: {:?}",
+                                                trailers.into_fields()
+                                            );
+                                            futures::future::ok(())
+                                        }),
+                                );
+                            }
+                            Either::B(futures::future::ok(()))
+                        })
                 })
         });
 
     Ok((endpoint_driver, Box::new(fut)))
-}
-
-struct ProcessResponse {
-    state: ProcessResponseState,
-}
-
-impl Future for ProcessResponse {
-    type Item = ();
-    type Error = quinn_h3::Error;
-
-    fn poll(&mut self) -> Poll<(), Self::Error> {
-        loop {
-            match self.state {
-                ProcessResponseState::Body(ref mut b) => match try_ready!(b.poll()) {
-                    Some(chunk) => {
-                        println!("got chunk = {:?}", chunk);
-                    }
-                    None => {
-                        if b.has_trailers() {
-                            self.state =
-                                match mem::replace(&mut self.state, ProcessResponseState::Finished)
-                                {
-                                    ProcessResponseState::Body(b) => {
-                                        ProcessResponseState::Trailers(b.trailers().unwrap())
-                                    }
-                                    _ => unreachable!(),
-                                }
-                        } else {
-                            self.state = ProcessResponseState::Finished;
-                        }
-                    }
-                },
-                ProcessResponseState::Trailers(ref mut t) => {
-                    let trailers = try_ready!(t.poll());
-                    println!("got trailers: {:?}", trailers.into_fields());
-                    return Ok(().into());
-                }
-                ProcessResponseState::Finished => panic!("polled after finished"),
-            }
-        }
-    }
-}
-
-enum ProcessResponseState {
-    Body(RecvBodyStream),
-    Trailers(DecodeHeaders),
-    Finished,
 }
 
 fn build_certs(log: Logger, options: Opt) -> Result<(CertificateChain, Certificate, PrivateKey)> {

--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -1,11 +1,15 @@
-use std::mem;
+use std::{
+    cmp,
+    io::{self, ErrorKind},
+    mem,
+};
 
 use bytes::{Bytes, BytesMut};
 use futures::{try_ready, Async, Future, Poll, Stream};
 use http::HeaderMap;
 use quinn::SendStream;
 use quinn_proto::StreamId;
-use tokio_io::io::WriteAll;
+use tokio_io::{io::WriteAll, AsyncRead};
 
 use crate::{
     connection::ConnectionRef,
@@ -218,6 +222,89 @@ impl Stream for RecvBodyStream {
             }
             None => Ok(Async::Ready(None)),
             _ => Err(Error::peer("invalid frame type in data")),
+        }
+    }
+}
+
+pub struct BodyReader {
+    recv: FrameStream,
+    trailers: Option<HeadersFrame>,
+    conn: ConnectionRef,
+    stream_id: StreamId,
+    buf: Option<Bytes>,
+}
+
+impl BodyReader {
+    pub(crate) fn new(recv: FrameStream, conn: ConnectionRef, stream_id: StreamId) -> Self {
+        BodyReader {
+            recv,
+            conn,
+            stream_id,
+            trailers: None,
+            buf: None,
+        }
+    }
+
+    fn buf_read(&mut self, buf: &mut [u8]) -> usize {
+        match self.buf {
+            None => 0,
+            Some(ref mut b) => {
+                let size = cmp::min(buf.len(), b.len());
+                buf[..size].copy_from_slice(&b.split_to(size));
+                if b.is_empty() {
+                    self.buf = None;
+                }
+                size
+            }
+        }
+    }
+
+    fn buf_put(&mut self, buf: Bytes) {
+        assert!(self.buf.is_none());
+        self.buf = Some(buf)
+    }
+
+    pub fn trailers(self) -> Option<DecodeHeaders> {
+        let (trailers, conn, stream_id) = (self.trailers, self.conn, self.stream_id);
+        trailers.map(|t| DecodeHeaders::new(t, conn, stream_id))
+    }
+}
+
+impl AsyncRead for BodyReader {
+    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
+        false
+    }
+}
+
+impl io::Read for BodyReader {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        let size = self.buf_read(buf);
+        if size == buf.len() {
+            return Ok(size);
+        }
+
+        match self.recv.poll() {
+            Err(err) => Err(io::Error::new(ErrorKind::Other, Error::from(err))),
+            Ok(Async::NotReady) => Err(io::Error::new(ErrorKind::WouldBlock, "stream blocked")),
+            Ok(Async::Ready(r)) => match r {
+                None => Ok(size),
+                Some(HttpFrame::Data(mut d)) => {
+                    if d.payload.len() >= buf.len() - size {
+                        let tail = d.payload.split_off(buf.len() - size);
+                        self.buf_put(tail);
+                    }
+                    buf[size..size + d.payload.len()].copy_from_slice(&d.payload);
+                    Ok(size + d.payload.len())
+                }
+                Some(HttpFrame::Headers(d)) => {
+                    self.trailers = Some(d);
+                    Ok(size)
+                }
+                _ => Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    "received an invalid frame type",
+                )),
+            },
         }
     }
 }

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -10,7 +10,7 @@ use slog::{self, o, Logger};
 use tokio_io::io::{Shutdown, WriteAll};
 
 use crate::{
-    body::{Body, RecvBody, RecvBodyStream, SendBody},
+    body::{Body, BodyReader, RecvBody, RecvBodyStream, SendBody},
     connection::{ConnectionDriver, ConnectionRef},
     frame::{FrameDecoder, FrameStream},
     headers::DecodeHeaders,
@@ -317,5 +317,9 @@ impl RecvResponse {
 
     pub fn body_stream(self) -> RecvBodyStream {
         RecvBodyStream::new(self.recv, self.conn, self.stream_id)
+    }
+
+    pub fn body_reader(self) -> BodyReader {
+        BodyReader::new(self.recv, self.conn, self.stream_id)
     }
 }

--- a/quinn-h3/src/frame.rs
+++ b/quinn-h3/src/frame.rs
@@ -48,6 +48,7 @@ impl Decoder for FrameDecoder {
             Err(e) => Err(e)?,
             Ok(frame) => {
                 src.advance(pos);
+                self.expected = None;
                 Ok(Some(frame))
             }
         }


### PR DESCRIPTION
I'm not sure about the RecvBodyReader::buf_{pop,push}() method names.

And about their implementation, I tried to limit the number of copies and allocations by storing the DataFrame(Bytes)'s buffer only. It makes read() returned size possibly very small compared to the passed buffer size. I'd like some feedback on this as I'm not sure about this choice.

The only example has been updated to exercise this new API.