### PR TITLE
Fix 0-RTT with non-default ciphersuite

### DIFF
--- a/quinn-proto/src/crypto/ring.rs
+++ b/quinn-proto/src/crypto/ring.rs
@@ -23,17 +23,6 @@ pub struct Crypto {
 }
 
 impl Crypto {
-    /// Create keys for 0-RTT packets based on the given secret
-    pub fn new_0rtt(secret: &[u8]) -> Self {
-        Self::new(
-            Side::Client, // Meaningless when the secrets are equal
-            &digest::SHA256,
-            &aead::AES_128_GCM,
-            secret.into(),
-            secret.into(),
-        )
-    }
-
     pub(crate) fn new(
         side: Side,
         digest: &'static digest::Algorithm,

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -349,7 +349,7 @@ fn high_latency_handshake() {
 }
 
 #[test]
-fn zero_rtt() {
+fn zero_rtt_happypath() {
     let mut pair = Pair::default();
     let config = client_config();
 


### PR DESCRIPTION
Must only be merged after https://github.com/ctz/rustls/pull/274 is released, as otherwise 0-RTT cipher suites won't be available and 0-RTT capable clients will panic.

Fixes 0-RTT interop with quant.