### PR TITLE
Don't export VERSION constant

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2914,13 +2914,13 @@ where
 
     /// The number of bytes of packets containing retransmittable frames that have not been
     /// acknowledged or declared lost.
-    #[cfg(all(test, feature = "rustls"))]
+    #[cfg(test)]
     pub(crate) fn bytes_in_flight(&self) -> u64 {
         self.in_flight.bytes
     }
 
     /// Number of bytes worth of non-ack-only packets that may be sent
-    #[cfg(all(test, feature = "rustls"))]
+    #[cfg(test)]
     pub(crate) fn congestion_state(&self) -> u64 {
         self.congestion_window.saturating_sub(self.in_flight.bytes)
     }
@@ -2933,13 +2933,13 @@ where
     }
 
     /// Total number of outgoing packets that have been deemed lost
-    #[cfg(all(test, feature = "rustls"))]
+    #[cfg(test)]
     pub(crate) fn lost_packets(&self) -> u64 {
         self.lost_packets
     }
 
     /// Whether explicit congestion notification is in use on outgoing packets.
-    #[cfg(all(test, feature = "rustls"))]
+    #[cfg(test)]
     pub(crate) fn using_ecn(&self) -> bool {
         self.sending_ecn
     }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -646,7 +646,7 @@ where
         self.reject_new_connections = true;
     }
 
-    #[cfg(all(test, feature = "rustls"))]
+    #[cfg(test)]
     pub(crate) fn known_connections(&self) -> usize {
         let x = self.connections.len();
         debug_assert_eq!(x, self.connection_ids_initial.len());
@@ -657,7 +657,7 @@ where
         x
     }
 
-    #[cfg(all(test, feature = "rustls"))]
+    #[cfg(test)]
     pub(crate) fn known_cids(&self) -> usize {
         self.connection_ids.len()
     }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -13,6 +13,8 @@
 //! managing a single connection and all the related state (such as streams).
 
 #![warn(missing_docs)]
+#![cfg_attr(test, allow(dead_code))]
+
 #[macro_use]
 extern crate slog;
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -86,7 +86,7 @@ mod rustls_impls {
 pub use crate::rustls_impls::*;
 
 /// The QUIC protocol version implemented
-pub const VERSION: u32 = 0xff00_0016;
+const VERSION: u32 = 0xff00_0016;
 
 /// Whether an endpoint was the initiator of a connection
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -841,18 +841,18 @@ mod tests {
 
     #[test]
     fn roundtrip_packet_numbers() {
-        check_pn(PacketNumber::U8(0x7f), &[0x7f]);
-        check_pn(PacketNumber::U16(0x80), &[0x00, 0x80]);
-        check_pn(PacketNumber::U16(0x3fff), &[0x3f, 0xff]);
-        check_pn(PacketNumber::U32(0x00004000), &[0x00, 0x00, 0x40, 0x00]);
-        check_pn(PacketNumber::U32(0xffffffff), &[0xff, 0xff, 0xff, 0xff]);
+        check_pn(PacketNumber::U8(0x7f), &hex!("7f"));
+        check_pn(PacketNumber::U16(0x80), &hex!("0080"));
+        check_pn(PacketNumber::U16(0x3fff), &hex!("3fff"));
+        check_pn(PacketNumber::U32(0x00004000), &hex!("00004000"));
+        check_pn(PacketNumber::U32(0xffffffff), &hex!("ffffffff"));
     }
 
     #[test]
     fn pn_encode() {
-        check_pn(PacketNumber::new(0x10, 0), &[0x10]);
-        check_pn(PacketNumber::new(0x100, 0), &[0x01, 0x00]);
-        check_pn(PacketNumber::new(0x10000, 0), &[0x01, 0x00, 0x00]);
+        check_pn(PacketNumber::new(0x10, 0), &hex!("10"));
+        check_pn(PacketNumber::new(0x100, 0), &hex!("0100"));
+        check_pn(PacketNumber::new(0x10000, 0), &hex!("010000"));
     }
 
     #[test]


### PR DESCRIPTION
It's not clear why downstream code would need this.