### PR TITLE
Use different project for Azure Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation](https://docs.rs/quinn/badge.svg)](https://docs.rs/quinn/)
 [![Crates.io](https://img.shields.io/crates/v/quinn.svg)](https://crates.io/crates/quinn)
-[![Build Status](https://dev.azure.com/quinn-rs/Quinn/_apis/build/status/djc.quinn?branchName=master)](https://dev.azure.com/quinn-rs/Quinn/_build/latest?definitionId=1&branchName=master)
+[![Build Status](https://dev.azure.com/dochtman/Projects/_apis/build/status/Quinn?branchName=master)](https://dev.azure.com/dochtman/Projects/_build/latest?definitionId=1&branchName=master)
 [![codecov](https://codecov.io/gh/djc/quinn/branch/master/graph/badge.svg)](https://codecov.io/gh/djc/quinn)
 [![Chat](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/djc/quinn)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE-MIT)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Quinn was created and is maintained by Dirkjan Ochtman and Benjamin Saunders.
 
 * Simultaneous client/server operation
 * Ordered and unordered reads for improved performance
-* Works on stable Rust
+* Works on stable Rust, tested on Linux, macOS and Windows
 * Pluggable cryptography, with a standard implementation backed by
   [rustls][rustls] and [*ring*][ring]
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 [badges]
 codecov = { repository = "djc/quinn" }
 maintenance = { status = "experimental" }
-azure-devops = { project = "quinn-rs/Quinn", pipeline = "djc", build = "1" }
+azure-devops = { project = "dochtman/Projects", pipeline = "Quinn", build = "1" }
 
 [dependencies]
 bytes = "0.4.7"


### PR DESCRIPTION
In the initial setup, I skimmed too fast over the paragraph that stated that
Azure DevOps projects must be aligned to GitHub organizations/users. Since
I want to use Azure Pipelines for other projects, too, I've reorganized the
setup a bit, which means the badge links need to be updated.