### PR TITLE
Tweak CI config with latest template changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,8 @@ stages:
    parameters:
      minrust: false
      codecov_token: $(CODECOV_TOKEN_SECRET)
+     test_ignored: true
+     nightly_coverage: true
 
 resources:
   repositories:


### PR DESCRIPTION
- Run ignored tests, used for slow tests (we used to have this on Travis)
- Run coverage on nightly for now due to (see #336)

Enabled by the changes from https://github.com/crate-ci/azure-pipelines/pull/42.