### PR TITLE
Opaque NewConnection struct

### DIFF
--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -114,11 +114,12 @@ impl Future for Connecting {
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let (driver, conn, incoming) = try_ready!(self.connecting.poll());
-        let conn_ref = ConnectionRef::new(conn.clone(), self.settings.clone())?;
+        let mut conn = try_ready!(self.connecting.poll());
+        let driver = conn.driver();
+        let conn_ref = ConnectionRef::new(conn.handle(), self.settings.clone())?;
         Ok(Async::Ready((
             driver,
-            ConnectionDriver::new(conn_ref.clone(), incoming, self.log.clone()),
+            ConnectionDriver::new(conn_ref.clone(), conn.incoming_streams(), self.log.clone()),
             Connection(conn_ref),
         )))
     }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -97,11 +97,12 @@ impl Future for Connecting {
     type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let (driver, conn, incoming) = try_ready!(self.connecting.poll());
-        let conn_ref = ConnectionRef::new(conn.clone(), self.settings.clone())?;
+        let mut conn = try_ready!(self.connecting.poll());
+        let driver = conn.driver();
+        let conn_ref = ConnectionRef::new(conn.handle(), self.settings.clone())?;
         Ok(Async::Ready((
             driver,
-            ConnectionDriver::new(conn_ref.clone(), incoming, self.log.clone()),
+            ConnectionDriver::new(conn_ref.clone(), conn.incoming_streams(), self.log.clone()),
             IncomingRequest(conn_ref),
         )))
     }

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -114,11 +114,14 @@ fn run(log: Logger, options: Opt) -> Result<()> {
         endpoint
             .connect(&remote, &host)?
             .map_err(|e| format_err!("failed to connect: {}", e))
-            .and_then(move |(conn_driver, conn, _)| {
+            .and_then(move |mut new_conn| {
                 eprintln!("connected at {:?}", start.elapsed());
                 tokio_current_thread::spawn(
-                    conn_driver.map_err(|e| eprintln!("connection lost: {}", e)),
+                    new_conn
+                        .driver()
+                        .map_err(|e| eprintln!("connection lost: {}", e)),
                 );
+                let conn = new_conn.handle();
                 let stream = conn.open_bi();
                 stream
                     .map_err(|e| format_err!("failed to open stream: {}", e))

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -181,7 +181,8 @@ fn handle_connection(root: &PathBuf, log: &Logger, conn: quinn::Connecting) {
                     error!(log, "incoming handshake failed: {reason}", reason = e.to_string());
                 }
             })
-            .and_then(move |(conn_driver, conn, incoming_streams)| {
+            .and_then(move |mut new_conn| {
+                let conn = new_conn.handle();
                 info!(log, "connection established";
                       "remote_id" => %conn.remote_id(),
                       "address" => %conn.remote_address(),
@@ -190,7 +191,7 @@ fn handle_connection(root: &PathBuf, log: &Logger, conn: quinn::Connecting) {
 
                 // Each stream initiated by the client constitutes a new request.
                 tokio_current_thread::spawn(
-                    incoming_streams
+                    new_conn.incoming_streams()
                         .map_err(move |e| info!(log2, "connection terminated"; "reason" => %e))
                         .for_each(move |stream| {
                             handle_request(&root, &log, stream);
@@ -199,7 +200,7 @@ fn handle_connection(root: &PathBuf, log: &Logger, conn: quinn::Connecting) {
                 );
 
                 // We ignore errors from the driver because they'll be reported by the `incoming` handler anyway.
-                conn_driver.map_err(|_| ())
+                new_conn.driver().map_err(|_| ())
             }),
     );
 }


### PR DESCRIPTION
Based on discussion in gitter (see also https://github.com/djc/quinn/issues/207#issuecomment-518042632). I'm not sure how I feel about this. Forwards-compatibility is definitely nice. Panicing on drop without the driver having been taken is interesting, but I worry that it will convert harmless behavior into crashes, e.g. in the quinn-h3 client/server changes you can see where I had to carefully avoid that. Acquiring the components of a connection with one-time accessors also seems less obvious than destructuring them out of public fields, no matter how well-documented the accessors are.