### PR TITLE
H3 streamed body server

### DIFF
--- a/quinn-h3/examples/h3.rs
+++ b/quinn-h3/examples/h3.rs
@@ -17,7 +17,7 @@ use url::Url;
 use quinn::ConnectionDriver as QuicDriver;
 use quinn_h3::{
     self,
-    body::Receiver,
+    body::RecvBody,
     client::Builder as ClientBuilder,
     connection::ConnectionDriver,
     server::{Builder as ServerBuilder, IncomingRequest, Sender},
@@ -191,7 +191,7 @@ fn handle_connection(
 
 fn handle_request(
     request: Request<()>,
-    body: Receiver,
+    body: RecvBody,
     sender: Sender,
 ) -> impl Future<Item = (), Error = Error> {
     println!("received request: {:?}", request);

--- a/quinn-h3/examples/h3.rs
+++ b/quinn-h3/examples/h3.rs
@@ -279,9 +279,10 @@ fn client(
 
             conn.send_request_trailers(request, trailer)
                 .map_err(|e| format_err!("send request: {}", e))
-                .and_then(|response| {
+                .and_then(|(response, body)| {
+                    println!("received response: {:?}", response);
                     let buf = Vec::with_capacity(1024 * 10); // 10K
-                    tokio_io::io::read_to_end(response.body_reader(), buf)
+                    tokio_io::io::read_to_end(body.into_reader(), buf)
                         .map_err(|e| format_err!("receive response failed: {}", e))
                         .and_then(|(reader, data)| {
                             println!("received body len = {}", data.len());

--- a/quinn-h3/examples/h3.rs
+++ b/quinn-h3/examples/h3.rs
@@ -17,7 +17,7 @@ use url::Url;
 use quinn::ConnectionDriver as QuicDriver;
 use quinn_h3::{
     self,
-    body::RecvBody,
+    body::Receiver,
     client::Builder as ClientBuilder,
     connection::ConnectionDriver,
     server::{Builder as ServerBuilder, IncomingRequest, Sender},
@@ -191,7 +191,7 @@ fn handle_connection(
 
 fn handle_request(
     request: Request<()>,
-    body: RecvBody,
+    body: Receiver,
     sender: Sender,
 ) -> impl Future<Item = (), Error = Error> {
     println!("received request: {:?}", request);

--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -157,14 +157,6 @@ impl ReadToEnd {
             state: RecvBodyState::Receiving(BytesMut::with_capacity(capacity)),
         }
     }
-
-    pub fn into_reader(self) -> BodyReader {
-        BodyReader::new(self.recv, self.conn, self.stream_id)
-    }
-
-    pub fn into_stream(self) -> RecvBodyStream {
-        RecvBodyStream::new(self.recv, self.conn, self.stream_id)
-    }
 }
 
 enum RecvBodyState {

--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -131,6 +131,14 @@ impl RecvBody {
 
         self
     }
+
+    pub fn into_reader(self) -> BodyReader {
+        BodyReader::new(self.recv, self.conn, self.stream_id)
+    }
+
+    pub fn into_stream(self) -> RecvBodyStream {
+        RecvBodyStream::new(self.recv, self.conn, self.stream_id)
+    }
 }
 
 const RECV_BODY_MAX_SIZE_DEFAULT: usize = 20 * 1024 * 1024; // 20 MB

--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -97,6 +97,34 @@ impl Future for SendBody {
     }
 }
 
+pub struct Receiver {
+    recv: FrameStream,
+    conn: ConnectionRef,
+    stream_id: StreamId,
+}
+
+impl Receiver {
+    pub(crate) fn new(recv: FrameStream, conn: ConnectionRef, stream_id: StreamId) -> Self {
+        Self {
+            conn,
+            stream_id,
+            recv,
+        }
+    }
+
+    pub fn into_future(self) -> RecvBody {
+        RecvBody::new(self.recv, self.conn, self.stream_id)
+    }
+
+    pub fn into_reader(self) -> BodyReader {
+        BodyReader::new(self.recv, self.conn, self.stream_id)
+    }
+
+    pub fn into_stream(self) -> RecvBodyStream {
+        RecvBodyStream::new(self.recv, self.conn, self.stream_id)
+    }
+}
+
 pub struct RecvBody {
     state: RecvBodyState,
     capacity: usize,

--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -1,8 +1,7 @@
 use std::{
-    cmp,
+    cmp, fmt,
     io::{self, ErrorKind},
     mem,
-    fmt,
 };
 
 use bytes::{Bytes, BytesMut};
@@ -123,6 +122,12 @@ impl RecvBody {
 
     pub fn into_stream(self) -> RecvBodyStream {
         RecvBodyStream::new(self.recv, self.conn, self.stream_id)
+    }
+}
+
+impl fmt::Debug for RecvBody {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RecvBody {{ stream_id: {:?} }}", self.stream_id)
     }
 }
 

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -176,22 +176,17 @@ impl SendRequest {
 
     fn build_response(&mut self, header: Header) -> Result<Response<RecvBody>, Error> {
         let (status, headers) = header.into_response_parts()?;
-        let mut response = Response::builder();
-        response.status(status);
-        response.version(http::version::Version::HTTP_3);
-        *response
-            .headers_mut()
-            .ok_or_else(|| Error::peer("invalid response"))? = headers;
-
-        let body = RecvBody::new(
-            try_take(&mut self.recv, "recv is none")?,
-            self.conn.clone(),
-            try_take(&mut self.stream_id, "stream is none")?,
-        );
-
-        Ok(response
-            .body(body)
-            .or(Err(Error::Internal("failed to build response")))?)
+        let mut response = Response::builder()
+            .status(status)
+            .version(http::version::Version::HTTP_3)
+            .body(RecvBody::new(
+                try_take(&mut self.recv, "recv is none")?,
+                self.conn.clone(),
+                try_take(&mut self.stream_id, "stream is none")?,
+            ))
+            .unwrap();
+        *response.headers_mut() = headers;
+        Ok(response)
     }
 }
 

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -306,13 +306,7 @@ impl RecvResponse {
     }
 
     pub fn body(self) -> RecvBody {
-        RecvBody::with_capacity(
-            self.recv,
-            10_240,
-            1_024_000,
-            self.conn.clone(),
-            self.stream_id,
-        )
+        RecvBody::new(self.recv, self.conn.clone(), self.stream_id)
     }
 
     pub fn body_stream(self) -> RecvBodyStream {

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -10,7 +10,7 @@ use slog::{self, o, Logger};
 use tokio_io::io::{Shutdown, WriteAll};
 
 use crate::{
-    body::{Body, Receiver, SendBody},
+    body::{Body, RecvBody, SendBody},
     connection::{ConnectionDriver, ConnectionRef},
     frame::{FrameDecoder, FrameStream},
     headers::DecodeHeaders,
@@ -190,7 +190,7 @@ impl SendRequest {
 }
 
 impl Future for SendRequest {
-    type Item = (Response<()>, Receiver);
+    type Item = (Response<()>, RecvBody);
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -269,7 +269,7 @@ impl Future for SendRequest {
                         SendRequestState::Ready(h) => {
                             return Ok(Async::Ready((
                                 Self::build_response(h)?,
-                                Receiver::new(
+                                RecvBody::new(
                                     try_take(&mut self.recv, "Recv is none")?,
                                     self.conn.clone(),
                                     try_take(&mut self.stream_id, "stream is none")?,

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -10,7 +10,7 @@ use slog::{self, o, Logger};
 use tokio_io::io::{Shutdown, WriteAll};
 
 use crate::{
-    body::{Body, RecvBody, SendBody},
+    body::{Body, Receiver, SendBody},
     connection::{ConnectionDriver, ConnectionRef},
     frame::{FrameDecoder, FrameStream},
     headers::DecodeHeaders,
@@ -190,7 +190,7 @@ impl SendRequest {
 }
 
 impl Future for SendRequest {
-    type Item = (Response<()>, RecvBody);
+    type Item = (Response<()>, Receiver);
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -269,7 +269,7 @@ impl Future for SendRequest {
                         SendRequestState::Ready(h) => {
                             return Ok(Async::Ready((
                                 Self::build_response(h)?,
-                                RecvBody::new(
+                                Receiver::new(
                                     try_take(&mut self.recv, "Recv is none")?,
                                     self.conn.clone(),
                                     try_take(&mut self.stream_id, "stream is none")?,

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -174,7 +174,7 @@ impl SendRequest {
         }
     }
 
-    fn build_response(header: Header) -> Result<Response<()>, Error> {
+    fn build_response(&mut self, header: Header) -> Result<Response<RecvBody>, Error> {
         let (status, headers) = header.into_response_parts()?;
         let mut response = Response::builder();
         response.status(status);
@@ -183,14 +183,20 @@ impl SendRequest {
             .headers_mut()
             .ok_or_else(|| Error::peer("invalid response"))? = headers;
 
+        let body = RecvBody::new(
+            try_take(&mut self.recv, "recv is none")?,
+            self.conn.clone(),
+            try_take(&mut self.stream_id, "stream is none")?,
+        );
+
         Ok(response
-            .body(())
+            .body(body)
             .or(Err(Error::Internal("failed to build response")))?)
     }
 }
 
 impl Future for SendRequest {
-    type Item = (Response<()>, RecvBody);
+    type Item = Response<RecvBody>;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -267,14 +273,7 @@ impl Future for SendRequest {
                 SendRequestState::Ready(_) => {
                     match mem::replace(&mut self.state, SendRequestState::Finished) {
                         SendRequestState::Ready(h) => {
-                            return Ok(Async::Ready((
-                                Self::build_response(h)?,
-                                RecvBody::new(
-                                    try_take(&mut self.recv, "Recv is none")?,
-                                    self.conn.clone(),
-                                    try_take(&mut self.stream_id, "stream is none")?,
-                                ),
-                            )));
+                            return Ok(Async::Ready(self.build_response(h)?));
                         }
                         _ => unreachable!(),
                     }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -10,7 +10,7 @@ use slog::{self, o, Logger};
 use tokio_io::io::{Shutdown, WriteAll};
 
 use crate::{
-    body::{Body, RecvBody, SendBody},
+    body::{Body, Receiver, SendBody},
     connection::{ConnectionDriver, ConnectionRef},
     frame::{FrameDecoder, FrameStream},
     headers::DecodeHeaders,
@@ -172,7 +172,7 @@ impl RecvRequest {
 }
 
 impl Future for RecvRequest {
-    type Item = (Request<()>, RecvBody, Sender);
+    type Item = (Request<()>, Receiver, Sender);
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -195,7 +195,7 @@ impl Future for RecvRequest {
                     let (recv, send) = try_take(&mut self.streams, "Recv request invalid state")?;
                     return Ok(Async::Ready((
                         Self::build_request(header)?,
-                        RecvBody::new(recv, self.conn.clone(), self.stream_id),
+                        Receiver::new(recv, self.conn.clone(), self.stream_id),
                         Sender {
                             send,
                             stream_id: self.stream_id,

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -282,7 +282,7 @@ impl RecvBodyServer {
             stream_id,
             conn: conn.clone(),
             send: Some(send),
-            body: RecvBody::with_capacity(recv, 10_240, 1_024_000, conn, stream_id),
+            body: RecvBody::new(recv, conn, stream_id),
         }
     }
 }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -164,10 +164,9 @@ impl RecvRequest {
         request.method(method);
         request.uri(uri);
         request.version(http::version::Version::HTTP_3);
-        match request.headers_mut() {
-            Some(h) => *h = headers,
-            None => return Err(Error::peer("invalid header")),
-        }
+        *request
+            .headers_mut()
+            .ok_or_else(|| Error::peer("invalid header"))? = headers;
 
         Ok(request
             .body(RecvBody::new(recv, self.conn.clone(), self.stream_id))

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -10,7 +10,7 @@ use slog::{self, o, Logger};
 use tokio_io::io::{Shutdown, WriteAll};
 
 use crate::{
-    body::{Body, Receiver, SendBody},
+    body::{Body, RecvBody, SendBody},
     connection::{ConnectionDriver, ConnectionRef},
     frame::{FrameDecoder, FrameStream},
     headers::DecodeHeaders,
@@ -172,7 +172,7 @@ impl RecvRequest {
 }
 
 impl Future for RecvRequest {
-    type Item = (Request<()>, Receiver, Sender);
+    type Item = (Request<()>, RecvBody, Sender);
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -160,17 +160,14 @@ impl RecvRequest {
         recv: FrameStream,
     ) -> Result<Request<RecvBody>, Error> {
         let (method, uri, headers) = headers.into_request_parts()?;
-        let mut request = Request::builder();
-        request.method(method);
-        request.uri(uri);
-        request.version(http::version::Version::HTTP_3);
-        *request
-            .headers_mut()
-            .ok_or_else(|| Error::peer("invalid header"))? = headers;
-
-        Ok(request
+        let mut request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .version(http::version::Version::HTTP_3)
             .body(RecvBody::new(recv, self.conn.clone(), self.stream_id))
-            .map_err(|e| Error::Peer(format!("invalid request: {:?}", e)))?)
+            .unwrap();
+        *request.headers_mut() = headers;
+        Ok(request)
     }
 }
 


### PR DESCRIPTION
This PR makes it possible to use the `body.rs` reading API in server code. Reading a request body from the
server code has something particular compared to reading body from the client: it needs to cary a `SendStream`
to the next step. So response can be sent back.

I added a type parameter that receives this `SendStream`, so APIs can use the same implementation underneath,
while having a slightly different chain of steps:

```
Client:
RecvResponse.body_reader() -> BodyReader<()> -> DecodeHeader<()>

Server:
RequestReady.body_reader() -> BodyReader<SendStream> -> DecodeHeader<Sendstream>.into_sender() -> Sender.send(response)
```

I created a trait to extract this `SendStream` and turn it into a `Sender`:

```rust
impl IntoSender for RecvBodyStream<SendStream> {
    fn into_sender(self) -> Sender {
        Sender::new(self.conn, self.stream_id, self.inner)
    }
}
```

The `Sender` type provides a method chaining API to send the response:

```rust
sender
    .with_trailers(trailers)
    .send(response) // -> server::SendResponse Future
```

Concerning the API parts that involve `Future` implementation (`RecvBody` and `DecodeHeaders`), I made
different impl blocks for each type parameter values:

```
impl Future for DecodeHeaders<()> {
    type Item = Header;
    ...
}

impl Future for DecodeHeaders<SendStream> {
    type Item = (Header, Sender);
    ...
}
```

Notice `DecodeHeaders<SendStream>` resolves with a `Sender`.

The idea behind all that is also to offer a Type-level API usage inforcement. So compilation
ganrantees it'll work as expected.

This should be the last PR related to #356.
