### PR TITLE
Restore NewConnection struct for parts of a connection

### DIFF
--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -114,11 +114,16 @@ impl Future for Connecting {
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let (driver, conn, incoming) = try_ready!(self.connecting.poll());
-        let conn_ref = ConnectionRef::new(conn.clone(), self.settings.clone())?;
+        let quinn::NewConnection {
+            driver,
+            connection,
+            streams,
+            ..
+        } = try_ready!(self.connecting.poll());
+        let conn_ref = ConnectionRef::new(connection, self.settings.clone())?;
         Ok(Async::Ready((
             driver,
-            ConnectionDriver::new(conn_ref.clone(), incoming, self.log.clone()),
+            ConnectionDriver::new(conn_ref.clone(), streams, self.log.clone()),
             Connection(conn_ref),
         )))
     }

--- a/quinn-h3/src/qpack/prefix_string/decode.rs
+++ b/quinn-h3/src/qpack/prefix_string/decode.rs
@@ -1657,5 +1657,4 @@ mod tests {
         let res: Result<Vec<_>, Error> = bytes.hpack_decode().collect();
         assert_eq!(res, Ok(expected));
     }
-
 }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -97,11 +97,16 @@ impl Future for Connecting {
     type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let (driver, conn, incoming) = try_ready!(self.connecting.poll());
-        let conn_ref = ConnectionRef::new(conn.clone(), self.settings.clone())?;
+        let quinn::NewConnection {
+            driver,
+            connection,
+            streams,
+            ..
+        } = try_ready!(self.connecting.poll());
+        let conn_ref = ConnectionRef::new(connection, self.settings.clone())?;
         Ok(Async::Ready((
             driver,
-            ConnectionDriver::new(conn_ref.clone(), incoming, self.log.clone()),
+            ConnectionDriver::new(conn_ref.clone(), streams, self.log.clone()),
             IncomingRequest(conn_ref),
         )))
     }

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -113,11 +113,14 @@ fn run(log: Logger, options: Opt) -> Result<()> {
         endpoint
             .connect(&remote, &host)?
             .map_err(|e| format_err!("failed to connect: {}", e))
-            .and_then(move |(conn_driver, conn, _)| {
+            .and_then(move |new_conn| {
                 eprintln!("connected at {:?}", start.elapsed());
                 tokio_current_thread::spawn(
-                    conn_driver.map_err(|e| eprintln!("connection lost: {}", e)),
+                    new_conn
+                        .driver
+                        .map_err(|e| eprintln!("connection lost: {}", e)),
                 );
+                let conn = new_conn.connection;
                 let stream = conn.open_bi();
                 stream
                     .map_err(|e| format_err!("failed to open stream: {}", e))

--- a/quinn/examples/connection.rs
+++ b/quinn/examples/connection.rs
@@ -31,13 +31,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let handle_incoming_conns = incoming.take(1).for_each(move |incoming_conn| {
         current_thread::spawn(
             incoming_conn
-                .and_then(|(conn_driver, conn, _incoming)| {
+                .and_then(|new_conn| {
                     println!(
                         "[server] incoming connection: id={} addr={}",
-                        conn.remote_id(),
-                        conn.remote_address()
+                        new_conn.connection.remote_id(),
+                        new_conn.connection.remote_address()
                     );
-                    conn_driver
+                    new_conn.driver
                 })
                 .map_err(|_| ()),
         );
@@ -53,12 +53,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let connect = endpoint
         .connect(&server_addr, "localhost")?
         .map_err(|e| panic!("Failed to connect: {}", e))
-        .and_then(|(conn_driver, conn, _)| {
-            current_thread::spawn(conn_driver.map_err(|_| ()));
+        .and_then(|new_conn| {
+            current_thread::spawn(new_conn.driver.map_err(|_| ()));
             println!(
                 "[client] connected: id={}, addr={}",
-                conn.remote_id(),
-                conn.remote_address()
+                new_conn.connection.remote_id(),
+                new_conn.connection.remote_address()
             );
             Ok(())
         });

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -37,13 +37,13 @@ fn run_server<A: ToSocketAddrs>(runtime: &mut Runtime, addr: A) -> Result<(), Bo
     let handle_incoming_conns = incoming.take(1).for_each(move |incoming_conn| {
         current_thread::spawn(
             incoming_conn
-                .and_then(|(conn_driver, conn, _incoming)| {
+                .and_then(|new_conn| {
                     println!(
                         "[server] incoming connection: id={} addr={}",
-                        conn.remote_id(),
-                        conn.remote_address()
+                        new_conn.connection.remote_id(),
+                        new_conn.connection.remote_address()
                     );
-                    conn_driver
+                    new_conn.driver
                 })
                 .map_err(|_| ()),
         );
@@ -66,12 +66,12 @@ fn run_client(runtime: &mut Runtime, server_port: u16) -> Result<(), Box<dyn Err
     let connect = endpoint
         .connect(&server_addr, "localhost")?
         .map_err(|e| panic!("Failed to connect: {}", e))
-        .and_then(|(conn_driver, conn, _)| {
-            current_thread::spawn(conn_driver.map_err(|_| ()));
+        .and_then(|new_conn| {
+            current_thread::spawn(new_conn.driver.map_err(|_| ()));
             println!(
                 "[client] connected: id={}, addr={}",
-                conn.remote_id(),
-                conn.remote_address()
+                new_conn.connection.remote_id(),
+                new_conn.connection.remote_address()
             );
             Ok(())
         });

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -56,14 +56,14 @@ impl Connecting {
     /// ticket is found, `self` is returned unmodified.
     ///
     /// For incoming connections, a 0.5-RTT connection will always be successfully constructed.
-    pub fn into_0rtt(mut self) -> Result<(ConnectionDriver, Connection, IncomingStreams), Self> {
+    pub fn into_0rtt(mut self) -> Result<NewConnection, Self> {
         // This lock borrows `self` and would normally be dropped at the end of this scope, so we'll
         // have to release it explicitly before returning `self` by value.
         let conn = (self.0.as_mut().unwrap().0).lock().unwrap();
         if conn.inner.has_0rtt() || conn.inner.side().is_server() {
             drop(conn);
             let ConnectionDriver(conn) = self.0.take().unwrap();
-            Ok(new_connection(conn))
+            Ok(NewConnection::new(conn))
         } else {
             drop(conn);
             Err(self)
@@ -72,7 +72,7 @@ impl Connecting {
 }
 
 impl Future for Connecting {
-    type Item = (ConnectionDriver, Connection, IncomingStreams);
+    type Item = NewConnection;
     type Error = ConnectionError;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let connected = match &mut self.0 {
@@ -86,19 +86,36 @@ impl Future for Connecting {
         };
         if connected {
             let ConnectionDriver(conn) = self.0.take().unwrap();
-            Ok(Async::Ready(new_connection(conn)))
+            Ok(Async::Ready(NewConnection::new(conn)))
         } else {
             Ok(Async::NotReady)
         }
     }
 }
 
-fn new_connection(conn: ConnectionRef) -> (ConnectionDriver, Connection, IncomingStreams) {
-    (
-        ConnectionDriver(conn.clone()),
-        Connection(conn.clone()),
-        IncomingStreams(conn),
-    )
+/// Components of a newly established connection
+///
+/// Ensure `driver` runs or the connection will not work.
+pub struct NewConnection {
+    /// The future responsible for handling I/O on the connection
+    pub driver: ConnectionDriver,
+    /// Handle for interacting with the connection
+    pub connection: Connection,
+    /// Streams initiated by the peer, in the order they were opened
+    pub streams: IncomingStreams,
+    /// Leave room for future extensions
+    _non_exhaustive: (),
+}
+
+impl NewConnection {
+    fn new(conn: ConnectionRef) -> Self {
+        Self {
+            driver: ConnectionDriver(conn.clone()),
+            connection: Connection(conn.clone()),
+            streams: IncomingStreams(conn),
+            _non_exhaustive: (),
+        }
+    }
 }
 
 /// A future that drives protocol logic for a connection

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -66,7 +66,9 @@ pub use crate::builders::{
 };
 
 mod connection;
-pub use connection::{Connecting, Connection, ConnectionDriver, IncomingStreams, OpenBi, OpenUni};
+pub use connection::{
+    Connecting, Connection, ConnectionDriver, IncomingStreams, NewConnection, OpenBi, OpenUni,
+};
 
 mod endpoint;
 pub use endpoint::{Endpoint, EndpointDriver, Incoming};


### PR DESCRIPTION
This enables forwards-compatibility with future extensions such as a datagram stream.

Partially unblocks #395.