### PR TITLE
Don't bother copying empty slices

### DIFF
--- a/quinn-proto/src/assembler.rs
+++ b/quinn-proto/src/assembler.rs
@@ -46,7 +46,7 @@ impl Assembler {
         // return directly, indicating whether the chunk can be discarded.
         if chunk.offset > self.offset {
             return false;
-        } else if (chunk.offset + chunk.bytes.len() as u64) < self.offset {
+        } else if (chunk.offset + chunk.bytes.len() as u64) <= self.offset {
             return true;
         }
 


### PR DESCRIPTION
If a chunk of data ends at `self.offset` exactly, we can discard it immediately.

No changes in intended or actual semantics, just a trivial optimization.