### PR TITLE
Per-directionality accept

### DIFF
--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -212,9 +212,9 @@ fn finish_stream() {
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Uni })
     );
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     assert_matches!(
         pair.server_conn_mut(server_ch).read_unordered(s),
@@ -241,9 +241,9 @@ fn reset_stream() {
 
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Uni })
     );
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
     assert_matches!(
         pair.server_conn_mut(server_ch).read_unordered(s),
         Err(ReadError::Reset { error_code: ERROR })
@@ -270,9 +270,9 @@ fn stop_stream() {
 
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Uni })
     );
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
     assert_matches!(
         pair.server_conn_mut(server_ch).read_unordered(s),
         Err(ReadError::Reset { error_code: ERROR })
@@ -502,9 +502,9 @@ fn stream_id_backpressure() {
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Uni })
     );
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
     assert_matches!(pair.server_conn_mut(server_ch).read_unordered(s), Ok(None));
     // Server will only send MAX_STREAM_ID now that the application's been notified
     pair.drive();
@@ -527,9 +527,9 @@ fn stream_id_backpressure() {
     // Make sure the server actually processes data on the newly-available stream
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Uni })
     );
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     assert_matches!(pair.server_conn_mut(server_ch).read_unordered(s), Ok(None));
 }
@@ -552,9 +552,9 @@ fn key_update() {
 
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Bi })
     );
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Bi), Some(stream) if stream == s);
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     assert_matches!(
         pair.server_conn_mut(server_ch).read_unordered(s),
@@ -608,9 +608,9 @@ fn key_update_reordered() {
     assert_eq!(pair.client_conn_mut(client_ch).lost_packets(), 0);
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Bi })
     );
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Bi), Some(stream) if stream == s);
     let mut buf = [0; 32];
     assert_matches!(pair.server_conn_mut(server_ch).read(s, &mut buf),
                     Ok(Some(n)) if n == MSG1.len() + MSG2.len());
@@ -912,9 +912,9 @@ fn stop_opens_bidi() {
 
     assert_matches!(
         pair.server_conn_mut(server_conn).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Bi })
     );
-    assert_matches!(pair.server_conn_mut(server_conn).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_conn).accept(Dir::Bi), Some(stream) if stream == s);
     assert_matches!(
         pair.server_conn_mut(server_conn).read_unordered(s),
         Err(ReadError::Blocked)
@@ -937,11 +937,11 @@ fn implicit_open() {
     pair.drive();
     assert_matches!(
         pair.server_conn_mut(server_conn).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Uni })
     );
-    assert_eq!(pair.server_conn_mut(server_conn).accept(), Some(s1));
-    assert_eq!(pair.server_conn_mut(server_conn).accept(), Some(s2));
-    assert_eq!(pair.server_conn_mut(server_conn).accept(), None);
+    assert_eq!(pair.server_conn_mut(server_conn).accept(Dir::Uni), Some(s1));
+    assert_eq!(pair.server_conn_mut(server_conn).accept(Dir::Uni), Some(s2));
+    assert_eq!(pair.server_conn_mut(server_conn).accept(Dir::Uni), None);
 }
 
 #[test]
@@ -1029,9 +1029,9 @@ fn finish_stream_flow_control_reordered() {
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::StreamOpened)
+        Some(Event::StreamOpened { dir: Dir::Uni })
     );
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
     assert_matches!(pair.server_conn_mut(server_ch).read_unordered(s), Ok(None));
 }
 
@@ -1099,7 +1099,7 @@ fn stop_during_finish() {
     pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive();
 
-    assert_matches!(pair.server_conn_mut(server_ch).accept(), Some(stream) if stream == s);
+    assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
     info!(pair.log, "stopping and finishing stream");
     const ERROR: VarInt = VarInt(42);
     pair.server_conn_mut(server_ch)

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -6,7 +6,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion
 use futures::{StreamExt, TryFutureExt};
 use tokio;
 
-use quinn::{ClientConfigBuilder, Endpoint, NewStream, ReadError, RecvStream, ServerConfigBuilder};
+use quinn::{ClientConfigBuilder, Endpoint, ReadError, RecvStream, ServerConfigBuilder};
 
 criterion_group!(benches, throughput);
 criterion_main!(benches);
@@ -47,12 +47,8 @@ fn throughput(c: &mut Criterion) {
                     .driver
                     .unwrap_or_else(|e| ignore_timeout("server connection driver", e)),
             );
-            while let Some(stream) = new_conn.streams.next().await {
-                if let NewStream::Uni(recv) = stream.unwrap() {
-                    read_all(recv).await.unwrap();
-                } else {
-                    unreachable!("only benchmarking uni streams")
-                }
+            while let Some(Ok(stream)) = new_conn.uni_streams.next().await {
+                read_all(stream).await.unwrap();
             }
         }
     });

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -64,7 +64,8 @@ pub use crate::builders::{
 
 mod connection;
 pub use connection::{
-    Connecting, Connection, ConnectionDriver, IncomingStreams, NewConnection, OpenBi, OpenUni,
+    Connecting, Connection, ConnectionDriver, IncomingBiStreams, IncomingUniStreams, NewConnection,
+    OpenBi, OpenUni,
 };
 
 mod endpoint;
@@ -72,8 +73,8 @@ pub use endpoint::{Endpoint, EndpointDriver, Incoming};
 
 mod streams;
 pub use streams::{
-    NewStream, Read, ReadError, ReadExact, ReadExactError, ReadToEnd, ReadToEndError, RecvStream,
-    SendStream, WriteError,
+    Read, ReadError, ReadExact, ReadExactError, ReadToEnd, ReadToEndError, RecvStream, SendStream,
+    WriteError,
 };
 
 #[cfg(test)]

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -13,38 +13,6 @@ use proto::{ConnectionError, StreamId};
 use crate::connection::ConnectionRef;
 use crate::VarInt;
 
-/// A stream initiated by a remote peer.
-pub enum NewStream {
-    /// A unidirectional stream.
-    Uni(RecvStream),
-    /// A bidirectional stream.
-    Bi(SendStream, RecvStream),
-}
-
-impl NewStream {
-    /// Assume this is a unidirectional stream
-    ///
-    /// Panics if this is actually a bidirectional stream. Useful if the behavior of the peer is
-    /// guaranteed, e.g. by setting `TransportConfig::stream_window_bidi` to 0.
-    pub fn unwrap_uni(self) -> RecvStream {
-        match self {
-            NewStream::Uni(x) => x,
-            NewStream::Bi(_, _) => panic!("unexpected bidirectional stream"),
-        }
-    }
-
-    /// Assume this is a bidirectional stream
-    ///
-    /// Panics if this is actually a unidirectional stream. Useful if the behavior of the peer is
-    /// guaranteed, e.g. by setting `TransportConfig::stream_window_uni` to 0.
-    pub fn unwrap_bi(self) -> (SendStream, RecvStream) {
-        match self {
-            NewStream::Uni(_) => panic!("unexpected unirectional stream"),
-            NewStream::Bi(x, y) => (x, y),
-        }
-    }
-}
-
 /// A stream that can only be used to send data
 ///
 /// If dropped, streams that haven't been explicitly `reset` will continue to (re)transmit

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -42,7 +42,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
 
             let shared = shared2.clone();
             let task = new_conn
-                .streams
+                .uni_streams
                 .try_for_each(move |stream| {
                     let conn = conn.clone();
                     read_from_peer(stream).map(move |_| {
@@ -113,8 +113,8 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     }
 }
 
-async fn read_from_peer(stream: quinn::NewStream) -> Result<(), quinn::ConnectionError> {
-    match stream.unwrap_uni().read_to_end(1024 * 1024 * 5).await {
+async fn read_from_peer(stream: quinn::RecvStream) -> Result<(), quinn::ConnectionError> {
+    match stream.read_to_end(1024 * 1024 * 5).await {
         Ok(data) => {
             assert!(hash_correct(&data));
             Ok(())


### PR DESCRIPTION
The order in which streams are opened is preserved only between streams of the same directionality, and backpressure similarly exists only within streams of the same directionality. As a result, if an application wants to process a certain stream identified by opening sequence (e.g. the first unidirectional stream, perhaps containing important session parameters), it must accept and buffer an arbitrarily large number of streams of the other type.

To correct this, we need to allow applications to be notified of and accept streams of a specific directionality, while allowing others to remain pending.

The incidental renaming improves concision substantially, and I don't think the increase in ambiguity is significant.