### PR TITLE
Fix bad behavior opening streams on a closed connection

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2575,6 +2575,9 @@ where
     ///
     /// Returns `None` if the streams in the given direction are currently exhausted.
     pub fn open(&mut self, dir: Dir) -> Option<StreamId> {
+        if self.state.is_closed() {
+            return None;
+        }
         let id = self.streams.open(self.side, dir)?;
         // TODO: Queue STREAM_ID_BLOCKED if None
         self.streams.send_mut(id).unwrap().max_data = match dir {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -185,7 +185,9 @@ impl Connection {
         let (send, recv) = oneshot::channel();
         {
             let mut conn = self.0.lock().unwrap();
-            if let Some(x) = conn.inner.open(Dir::Uni) {
+            if let Some(ref e) = conn.error {
+                let _ = send.send(Err(e.clone()));
+            } else if let Some(x) = conn.inner.open(Dir::Uni) {
                 let _ = send.send(Ok((
                     x,
                     conn.inner.side().is_client() && conn.inner.is_handshaking(),
@@ -211,7 +213,9 @@ impl Connection {
         let (send, recv) = oneshot::channel();
         {
             let mut conn = self.0.lock().unwrap();
-            if let Some(x) = conn.inner.open(Dir::Bi) {
+            if let Some(ref e) = conn.error {
+                let _ = send.send(Err(e.clone()));
+            } else if let Some(x) = conn.inner.open(Dir::Bi) {
                 let _ = send.send(Ok((
                     x,
                     conn.inner.side().is_client() && conn.inner.is_handshaking(),


### PR DESCRIPTION
The low-level API would unintuitively appear to succeed until the
window is exhausted, at which point the high-level API would yield
futures that would never resolve.

Remarkably, this PR applies cleanly on both master and std-futures, so no need to delay!