### PR TITLE
Update initial salt and QUIC version to draft 23

### DIFF
--- a/quinn-proto/src/crypto/ring.rs
+++ b/quinn-proto/src/crypto/ring.rs
@@ -252,8 +252,8 @@ fn initial_secret(conn_id: &ConnectionId) -> hkdf::Prk {
 }
 
 const INITIAL_SALT: [u8; 20] = [
-    0x7f, 0xbc, 0xdb, 0x0e, 0x7c, 0x66, 0xbb, 0xe9, 0x19, 0x3a, 0x96, 0xcd, 0x21, 0x51, 0x9e, 0xbd,
-    0x7a, 0x02, 0x64, 0x4a,
+    0xc3, 0xee, 0xf7, 0x12, 0xc7, 0x2e, 0xbb, 0x5a, 0x11, 0xa7, 0xd2, 0x43, 0x2b, 0xb4, 0x63, 0x65,
+    0xbe, 0xf9, 0xf5, 0x02,
 ];
 
 impl crypto::HmacKey for hmac::Key {
@@ -311,11 +311,11 @@ mod test {
         // Key secrets are opaque, so we cannot check them
         let client_secret = expanded_initial_secret(&initial_secret, b"client in");
         let (_, client_iv) = Crypto::get_keys(cipher, &client_secret);
-        assert_eq!(&client_iv.0[..], hex!("fb33da41a8f297d482df670e"));
+        assert_eq!(&client_iv.0[..], hex!("8681359410a70bb9c92f0420"));
 
         let server_secret = expanded_initial_secret(&initial_secret, b"server in");
         let (_, server_iv) = Crypto::get_keys(cipher, &server_secret);
-        assert_eq!(&server_iv.0[..], hex!("74fc8e534408a0b3928a3906"));
+        assert_eq!(&server_iv.0[..], hex!("5e5ae651fd1e8495af13508b"));
     }
 
     #[test]
@@ -334,11 +334,11 @@ mod test {
         );
         const HEADER_LEN: usize = 19;
         let protected = hex!(
-            "cfff00001205f067a5502a4262b5004074b517
-             cacd4600a63aee6eff75daa86546b48f 0c560e2730cb549780493f537a3a6e3b
-             de8cbdd2dc6037a784e54651b6b78c76 a65be06d0adc945c134f327c00c28edf
-             9dcec89806ebf5087a462b9a856e0ad6 085f14ebc6ffbb7288e691da3fb71b75
-             7efcf8a4c83ca4a3f69ecb7a510f2e03 4fcd"
+            "caff00001205f067a5502a4262b50040749256
+             8d33da8c3cae26ced25553d671d872ec 84c61c11b81ca2a29eecf7637a1aa920
+             638e8bc0263f4554c831ee9ab2e19425 e08d1fa53f38581e420ba88f3667968a
+             205573d4532422c8934a9bd8786209db 16515d8e2a3443b707c7e7e1f79b565b
+             9a015c2b0ae33a485cfa0df39e8adcd8 2756"
         );
         let mut packet = plaintext.to_vec();
         packet.resize(packet.len() + server.tag_len(), 0);

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -88,7 +88,7 @@ mod rustls_impls {
 pub use crate::rustls_impls::*;
 
 /// The QUIC protocol version implemented
-const VERSION: u32 = 0xff00_0016;
+const VERSION: u32 = 0xff00_0017;
 
 /// Whether an endpoint was the initiator of a connection
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -892,8 +892,8 @@ mod tests {
         assert_eq!(
             buf[..],
             hex!(
-                "ccff0000160806b858ec6f80452b0000402109
-                 e4b61459302616f71d1fcd1b5ce0090a5557e4b0c5b47911d4713cc32ab8e590"
+                "c4ff0000170806b858ec6f80452b00004021d9
+                 540018670adb60eab8efbd35425c2d9b04e4f71c89995d07cd3a435d2a36e000"
             )[..]
         );
 
@@ -903,7 +903,7 @@ mod tests {
         let mut packet = decode.finish(Some(&server_header_crypto)).unwrap();
         assert_eq!(
             packet.header_data[..],
-            hex!("c0ff0000160806b858ec6f80452b0000402100")[..]
+            hex!("c0ff0000170806b858ec6f80452b0000402100")[..]
         );
         server_crypto
             .decrypt(0, &packet.header_data, &mut packet.payload)

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -79,4 +79,4 @@ fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
 }
 
 #[allow(unused)]
-pub const ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-20", b"hq-22"];
+pub const ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-23"];


### PR DESCRIPTION
This passes the tests at least, and it gets VHDR with quicly.