### PR TITLE
Partial draft 23 reliability changes plus miscellany

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -921,6 +921,10 @@ where
             false,
         );
         self.process_early_payload(now, packet)?;
+        if self.space(SpaceId::Initial).crypto_stream.offset() == 0 {
+            debug!(self.log, "dropping Initial with no CRYPTO data");
+            return Ok(());
+        }
         if self.state.is_closed() {
             return Ok(());
         }

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -738,12 +738,12 @@ where
 
     /// Probe Timeout
     fn pto(&self) -> Duration {
-        let rtt = self
-            .path
-            .rtt
-            .smoothed
-            .unwrap_or_else(|| Duration::from_micros(self.config.initial_rtt));
-        rtt + cmp::max(4 * self.path.rtt.var, TIMER_GRANULARITY) + self.max_ack_delay()
+        match self.path.rtt.smoothed {
+            None => 2 * Duration::from_micros(self.config.initial_rtt),
+            Some(srtt) => {
+                srtt + cmp::max(4 * self.path.rtt.var, TIMER_GRANULARITY) + self.max_ack_delay()
+            }
+        }
     }
 
     fn on_packet_authenticated(

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -141,7 +141,7 @@ impl Default for TransportConfig {
             packet_threshold: 3,
             time_threshold: 0x2000, // 1/8
             delayed_ack_timeout: 25 * 1000,
-            initial_rtt: EXPECTED_RTT as u64 * 1000,
+            initial_rtt: 500 * 1000, // 500ms per spec, intentionally distinct from EXPECTED_RTT
 
             max_datagram_size: MAX_DATAGRAM_SIZE,
             initial_window: cmp::min(

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -196,6 +196,10 @@ impl TransportParameters {
         }
         apply_params!(write_params);
 
+        // Add a reserved parameter to keep people on their toes
+        buf.write::<u16>(31 * 5 + 27);
+        buf.write::<u16>(0);
+
         if let Some(ref x) = self.original_connection_id {
             buf.write::<u16>(0x0000);
             buf.write::<u16>(x.len() as u16);

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -14,7 +14,8 @@ use super::{
 
 #[test]
 fn handshake_timeout() {
-    let client = Endpoint::builder();
+    let mut client = Endpoint::builder();
+    client.logger(logger());
     let (client_driver, client, _) = client
         .bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .unwrap();
@@ -26,6 +27,7 @@ fn handshake_timeout() {
     const IDLE_TIMEOUT: u64 = 1_000;
     client_config.transport = Arc::new(crate::TransportConfig {
         idle_timeout: IDLE_TIMEOUT,
+        initial_rtt: 10_000, // Ensure initial PTO doesn't influence the timeout significantly
         ..Default::default()
     });
 


### PR DESCRIPTION
Handshake recovery logic changes still TODO, since an undocumented requirement for probe packets to retransmit CRYPTO data seems to have been introduced (see https://github.com/quicwg/base-drafts/issues/3056).