### PR TITLE
Draft 23 handshake retransmit, data-bearing probes

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2755,14 +2755,10 @@ where
     }
 
     fn congestion_blocked(&self) -> bool {
-        if let State::Established = self.state {
-            self.path
-                .congestion_window
-                .saturating_sub(self.in_flight.bytes)
-                < u64::from(self.mtu)
-        } else {
-            false
-        }
+        self.path
+            .congestion_window
+            .saturating_sub(self.in_flight.bytes)
+            < u64::from(self.mtu)
     }
 
     fn blocked(&self) -> bool {

--- a/quinn-proto/src/spaces.rs
+++ b/quinn-proto/src/spaces.rs
@@ -155,10 +155,6 @@ pub struct SentPacket {
     pub size: u16,
     /// Whether an acknowledgement is expected directly in response to this packet.
     pub ack_eliciting: bool,
-    /// Whether the packet contains cryptographic handshake messages critical to the completion of
-    /// the QUIC handshake.
-    // FIXME: Implied by retransmits + space
-    pub is_crypto_packet: bool,
     pub acks: RangeSet,
     pub retransmits: Retransmits,
 }


### PR DESCRIPTION
Modifies our probe strategy to retransmit in-flight data rather than
sending a PING frame. This gives us a chance of accelerated loss
recovery and allows adoption of the new draft's simplified handshake
retransmit logic.

Took me a while to decide how to do this, but in the end we've got (theoretically) improved robustness *and* a net code reduction!