### PR TITLE
Remove ToSocketAddrs from EndpointBuilder::bind

### DIFF
--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -170,7 +170,7 @@ impl State {
     async fn rebind(self: Arc<Self>) -> Result<()> {
         let mut builder = quinn::Endpoint::builder();
         builder.logger(self.log.clone());
-        let (endpoint_driver, endpoint, _) = builder.bind("[::]:0")?;
+        let (endpoint_driver, endpoint, _) = builder.bind(&"[::]:0".parse().unwrap())?;
         tokio::runtime::current_thread::spawn(
             endpoint_driver.unwrap_or_else(|e| eprintln!("IO error: {}", e)),
         );
@@ -266,7 +266,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     };
 
     builder.logger(log.clone());
-    let (endpoint_driver, endpoint, _) = builder.bind("[::]:0")?;
+    let (endpoint_driver, endpoint, _) = builder.bind(&"[::]:0".parse().unwrap())?;
     runtime.spawn(endpoint_driver.unwrap_or_else(|e| eprintln!("IO error: {}", e)));
 
     let state = Arc::new(State {

--- a/quinn-h3/examples/h3.rs
+++ b/quinn-h3/examples/h3.rs
@@ -109,7 +109,7 @@ fn server(
     let server = ServerBuilder::new(endpoint);
 
     let (endpoint_driver, mut incoming) = {
-        let (driver, _server, incoming) = server.bind(options.listen)?;
+        let (driver, _server, incoming) = server.bind(&options.listen)?;
         (driver, incoming)
     };
 
@@ -204,7 +204,7 @@ fn build_client(log: Logger, cert: Certificate) -> Result<(Client, quinn::Endpoi
     client_config.add_certificate_authority(cert)?;
     endpoint.default_client_config(client_config.build());
 
-    let (endpoint_driver, endpoint, _) = endpoint.bind("[::]:0")?;
+    let (endpoint_driver, endpoint, _) = endpoint.bind(&"[::]:0".parse().unwrap())?;
     Ok((
         ClientBuilder::new().endpoint(endpoint.clone()),
         endpoint_driver,

--- a/quinn-h3/examples/simple_client.rs
+++ b/quinn-h3/examples/simple_client.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("failed to ad cert");
     endpoint.default_client_config(client_config.build());
 
-    let (endpoint_driver, endpoint, _) = endpoint.bind("[::]:0")?;
+    let (endpoint_driver, endpoint, _) = endpoint.bind(&"[::]:0".parse().unwrap())?;
     tokio::spawn(async move {
         if let Err(e) = endpoint_driver.await {
             eprintln!("quic client error: {}", e)

--- a/quinn-h3/examples/simple_server.rs
+++ b/quinn-h3/examples/simple_server.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = ServerBuilder::new(endpoint);
 
     let (endpoint_driver, mut incoming) = {
-        let (driver, _server, incoming) = server.bind(opt.listen).expect("bind failed");
+        let (driver, _server, incoming) = server.bind(&opt.listen).expect("bind failed");
         (driver, incoming)
     };
 

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -1,5 +1,5 @@
 use std::mem;
-use std::net::ToSocketAddrs;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::Context;
 
@@ -46,9 +46,9 @@ impl Builder {
         self
     }
 
-    pub fn bind<T: ToSocketAddrs>(
+    pub fn bind(
         self,
-        addr: T,
+        addr: &SocketAddr,
     ) -> Result<(EndpointDriver, Server, IncomingConnection), EndpointError> {
         let (endpoint_driver, _endpoint, incoming) = self.endpoint.bind(addr)?;
         Ok((

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -31,7 +31,7 @@ fn throughput(c: &mut Criterion) {
     let mut client = Endpoint::builder();
     client.default_client_config(client_config.build());
     let (client_driver, client, _) = client
-        .bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0))
+        .bind(&SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0))
         .unwrap();
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -97,7 +97,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
 
     endpoint.default_client_config(client_config.build());
 
-    let (endpoint_driver, endpoint, _) = endpoint.bind("[::]:0")?;
+    let (endpoint_driver, endpoint, _) = endpoint.bind(&"[::]:0".parse().unwrap())?;
     let mut runtime = Runtime::new()?;
     runtime.spawn(endpoint_driver.unwrap_or_else(|e| eprintln!("IO error: {}", e)));
 

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -21,7 +21,8 @@ pub fn make_client_endpoint<A: ToSocketAddrs>(
     let client_cfg = configure_client(server_certs)?;
     let mut endpoint_builder = Endpoint::builder();
     endpoint_builder.default_client_config(client_cfg);
-    let (driver, endpoint, _incoming) = endpoint_builder.bind(bind_addr)?;
+    let (driver, endpoint, _incoming) =
+        endpoint_builder.bind(&bind_addr.to_socket_addrs().unwrap().next().unwrap())?;
     Ok((endpoint, driver))
 }
 
@@ -40,7 +41,8 @@ pub fn make_server_endpoint<A: ToSocketAddrs>(
     let (server_config, server_cert) = configure_server()?;
     let mut endpoint_builder = Endpoint::builder();
     endpoint_builder.listen(server_config);
-    let (driver, _endpoint, incoming) = endpoint_builder.bind(bind_addr)?;
+    let (driver, _endpoint, incoming) =
+        endpoint_builder.bind(&bind_addr.to_socket_addrs().unwrap().next().unwrap())?;
     Ok((driver, incoming, server_cert))
 }
 

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -56,7 +56,7 @@ fn run_client(runtime: &mut Runtime, server_port: u16) -> Result<(), Box<dyn Err
     let mut endpoint_builder = Endpoint::builder();
     endpoint_builder.default_client_config(client_cfg);
 
-    let (driver, endpoint, _) = endpoint_builder.bind("0.0.0.0:0")?;
+    let (driver, endpoint, _) = endpoint_builder.bind(&"0.0.0.0:0".parse().unwrap())?;
     runtime.spawn(driver.unwrap_or_else(|e| panic!("IO error: {}", e)));
 
     let server_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), server_port));

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -129,7 +129,7 @@ fn run(log: Logger, options: Opt) -> Result<()> {
     }
 
     let (endpoint_driver, mut incoming) = {
-        let (driver, endpoint, incoming) = endpoint.bind(options.listen)?;
+        let (driver, endpoint, incoming) = endpoint.bind(&options.listen)?;
         info!(log, "listening on {}", endpoint.local_addr()?);
         (driver, incoming)
     };

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::net::ToSocketAddrs;
+use std::net::SocketAddr;
 use std::str;
 use std::sync::Arc;
 
@@ -33,9 +33,9 @@ impl EndpointBuilder {
     }
 
     /// Build an endpoint bound to `addr`.
-    pub fn bind<T: ToSocketAddrs>(
+    pub fn bind(
         self,
-        addr: T,
+        addr: &SocketAddr,
     ) -> Result<(EndpointDriver, Endpoint, Incoming), EndpointError> {
         let socket = std::net::UdpSocket::bind(addr).map_err(EndpointError::Socket)?;
         self.with_socket(socket)

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -12,7 +12,7 @@
 //! let mut runtime = tokio::runtime::Runtime::new().unwrap();
 //! let mut builder = quinn::Endpoint::builder();
 //! // <configure builder>
-//! let (endpoint_driver, endpoint, _) = builder.bind("[::]:0").unwrap();
+//! let (endpoint_driver, endpoint, _) = builder.bind(&"[::]:0".parse().unwrap()).unwrap();
 //! runtime.spawn(endpoint_driver.unwrap_or_else(|e| panic!("I/O error: {}", e)));
 //! // <use endpoint>
 //! # }

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -17,7 +17,7 @@ fn handshake_timeout() {
     let mut client = Endpoint::builder();
     client.logger(logger());
     let (client_driver, client, _) = client
-        .bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .unwrap();
 
     let runtime = tokio::runtime::Runtime::new().unwrap();
@@ -57,7 +57,7 @@ fn handshake_timeout() {
 fn drop_endpoint() {
     let endpoint = Endpoint::builder();
     let (driver, endpoint, _) = endpoint
-        .bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .unwrap();
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
@@ -88,7 +88,7 @@ fn drop_endpoint() {
 fn drop_endpoint_driver() {
     let endpoint = Endpoint::builder();
     let (_, endpoint, _) = endpoint
-        .bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .unwrap();
 
     assert!(endpoint
@@ -103,7 +103,7 @@ fn drop_endpoint_driver() {
 fn close_endpoint() {
     let endpoint = Endpoint::builder();
     let (_driver, endpoint, incoming) = endpoint
-        .bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .unwrap();
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
@@ -131,7 +131,7 @@ fn close_endpoint() {
 fn local_addr() {
     let port = 56987;
     let (_, ep, _) = Endpoint::builder()
-        .bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
+        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
         .expect("Could not bind to localhost");
     assert_eq!(
         port,
@@ -204,7 +204,7 @@ fn endpoint() -> (Logger, EndpointDriver, Endpoint, Incoming) {
     endpoint.logger(log.new(o!("side" => "Server")));
 
     let (x, y, z) = endpoint
-        .bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .unwrap();
     (log, x, y, z)
 }
@@ -372,7 +372,7 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
         let mut client = Endpoint::builder();
         client.logger(log.new(o!("side" => "Client")));
         client.default_client_config(client_config.build());
-        let (client_driver, client, _) = client.bind(client_addr).unwrap();
+        let (client_driver, client, _) = client.bind(&client_addr).unwrap();
 
         runtime.spawn(server_driver.unwrap_or_else(|e| panic!("server driver failed: {}", e)));
         runtime.spawn(client_driver.unwrap_or_else(|e| panic!("client driver failed: {}", e)));

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -23,7 +23,8 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     let (cfg, listener_cert) = configure_listener();
     let mut ep_builder = quinn::Endpoint::builder();
     ep_builder.listen(cfg);
-    let (driver, endpoint, incoming_conns) = unwrap!(ep_builder.bind(&("127.0.0.1", 0)));
+    let (driver, endpoint, incoming_conns) =
+        unwrap!(ep_builder.bind(&"127.0.0.1:0".parse().unwrap()));
     runtime.spawn(driver.unwrap_or_else(|e| panic!("Listener IO error: {}", e)));
     let listener_addr = unwrap!(endpoint.local_addr());
 


### PR DESCRIPTION
Improves consistency with Endpoint::connect and removes the
possibility of silent blocking should the user pass in a domain
name. The generic API was originally motivated by the convenience of
passing in numeric addresses as strings, but `.parse().unwrap()` is
pretty easy too.