### PR TITLE
Fixed doc for Session::is_handshaking

### DIFF
--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -52,7 +52,7 @@ pub trait Session: Sized {
     /// If the 0-RTT-encrypted data has been accepted by the peer
     fn early_data_accepted(&self) -> Option<bool>;
 
-    /// Returns true when the handshake has completed
+    /// Returns `true` until the connection is fully established.
     fn is_handshaking(&self) -> bool;
 
     /// Read bytes of handshake data

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -44,9 +44,6 @@ impl Connecting {
     /// intercepted by a man-in-the-middle. If this occurs, the handshake will not complete
     /// successfully.
     ///
-    /// Once [`Connection::is_handshaking`] returns false, further transmissions are unaffected by
-    /// these weaknesses.
-    ///
     /// # Errors
     ///
     /// Outgoing connections are only 0-RTT-capable when a cryptographic session ticket cached from


### PR DESCRIPTION
Moreover, shouldn't a future we provided for the user to wait for the connection to be done with handshaking? This would be useful for a protocol that transmit idempotent metadata to the peer at the connection start, but then needs a proper session once that is done.