### PR TITLE
H3 control stream

### DIFF
--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -93,14 +93,13 @@ impl Future for Connecting {
         let quinn::NewConnection {
             driver,
             connection,
-            bi_streams,
             uni_streams,
             ..
         } = ready!(Pin::new(&mut self.connecting).poll(cx))?;
         let conn_ref = ConnectionRef::new(connection, self.settings.clone())?;
         Poll::Ready(Ok((
             driver,
-            ConnectionDriver::new(conn_ref.clone(), uni_streams, bi_streams),
+            ConnectionDriver::new_client(conn_ref.clone(), uni_streams),
             Connection(conn_ref),
         )))
     }

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -94,12 +94,13 @@ impl Future for Connecting {
             driver,
             connection,
             bi_streams,
+            uni_streams,
             ..
         } = ready!(Pin::new(&mut self.connecting).poll(cx))?;
         let conn_ref = ConnectionRef::new(connection, self.settings.clone())?;
         Poll::Ready(Ok((
             driver,
-            ConnectionDriver::new(conn_ref.clone(), bi_streams),
+            ConnectionDriver::new(conn_ref.clone(), uni_streams, bi_streams),
             Connection(conn_ref),
         )))
     }

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -4,21 +4,126 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Waker};
 
 use futures::{Future, Poll, Stream};
-use quinn::{RecvStream, SendStream};
+use quinn::{IncomingBiStreams, IncomingUniStreams, RecvStream, SendStream};
 
 use crate::{
+    frame::FrameStream,
     proto::connection::{Connection, Error as ProtoError},
-    Error, Settings,
+    streams::{NewUni, RecvUni},
+    Error, ErrorCode, Settings,
 };
 
 pub struct ConnectionDriver {
     conn: ConnectionRef,
-    incoming: quinn::IncomingBiStreams,
+    incoming_bi: IncomingBiStreams,
+    incoming_uni: IncomingUniStreams,
+    pending_uni: VecDeque<Option<RecvUni>>,
+    control: Option<FrameStream>,
+    error: Option<(ErrorCode, String)>,
 }
 
 impl ConnectionDriver {
-    pub(crate) fn new(conn: ConnectionRef, incoming: quinn::IncomingBiStreams) -> Self {
-        Self { conn, incoming }
+    pub(crate) fn new(
+        conn: ConnectionRef,
+        incoming_uni: IncomingUniStreams,
+        incoming_bi: IncomingBiStreams,
+    ) -> Self {
+        Self {
+            pending_uni: VecDeque::with_capacity(10),
+            control: None,
+            error: None,
+            conn,
+            incoming_bi,
+            incoming_uni,
+        }
+    }
+
+    fn set_error(&mut self, code: ErrorCode, msg: String) {
+        self.error = Some((code, msg.into()));
+    }
+
+    fn poll_pending_uni(&mut self, cx: &mut Context) {
+        let resolved: Vec<(usize, Result<NewUni, Error>)> = self
+            .pending_uni
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(i, x)| {
+                let mut pending = x.take().unwrap();
+                match Pin::new(&mut pending).poll(cx) {
+                    Poll::Ready(y) => Some((i, y)),
+                    Poll::Pending => {
+                        std::mem::replace(x, Some(pending));
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        for (i, res) in resolved {
+            self.pending_uni.remove(i);
+            match res {
+                Err(Error::UnknownStream(ty)) => println!("unknown stream type {}", ty),
+                Err(e) => {
+                    self.set_error(ErrorCode::STREAM_CREATION_ERROR, format!("{:?}", e));
+                }
+                Ok(n) => match n {
+                    NewUni::Control(stream) => match self.control {
+                        None => self.control = Some(stream),
+                        Some(_) => {
+                            self.set_error(
+                                ErrorCode::STREAM_CREATION_ERROR,
+                                "control stream already open".into(),
+                            );
+                        }
+                    },
+                    NewUni::Decoder(_) => println!("decoder stream ignored"),
+                    NewUni::Encoder(_) => println!("encoder stream ignored"),
+                    NewUni::Push(_) => println!("push stream ignored"),
+                },
+            }
+        }
+    }
+
+    fn poll_control(&mut self, cx: &mut Context) {
+        let mut control = match self.control.as_mut() {
+            None => return,
+            Some(c) => c,
+        };
+
+        match Pin::new(&mut control).poll_next(cx) {
+            Poll::Ready(None) => {
+                self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "control closed".into())
+            }
+            Poll::Ready(Some(Err(e))) => {
+                let (code, msg) = e.into();
+                self.set_error(code, msg)
+            }
+            Poll::Ready(Some(Ok(frame))) => {
+                let conn = &mut self.conn.h3;
+                let has_remote_settings = conn.lock().unwrap().inner.remote_settings().is_some();
+
+                match (has_remote_settings, frame) {
+                    (_, HttpFrame::Settings(s)) => {
+                        conn.lock().unwrap().inner.set_remote_settings(s);
+                    }
+                    (true, HttpFrame::Goaway(_)) => println!("GOAWAY frame ignored"),
+                    (true, HttpFrame::CancelPush(_)) => println!("CANCEL_PUSH frame ignored"),
+                    (true, HttpFrame::MaxPushId(_)) => println!("MAX_PUSH_ID frame ignored"),
+                    (_, frame) => match frame {
+                        HttpFrame::CancelPush(_)
+                        | HttpFrame::Goaway(_)
+                        | HttpFrame::MaxPushId(_) => {
+                            self.set_error(ErrorCode::MISSING_SETTINGS, "missing settings".into())
+                        }
+                        _ => self.set_error(
+                            ErrorCode::FRAME_UNEXPECTED,
+                            "unexpected frame type on control stream".into(),
+                        ),
+                    },
+                }
+            }
+            Poll::Pending => (),
+        }
     }
 }
 
@@ -26,17 +131,19 @@ impl Future for ConnectionDriver {
     type Output = Result<(), Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        match Pin::new(&mut self.incoming).poll_next(cx)? {
-            Poll::Ready(None) => return Poll::Ready(Ok(())),
-            Poll::Ready(Some((send, recv))) => {
-                let mut conn = self.conn.h3.lock().unwrap();
-                conn.requests.push_back((send, recv));
-                if let Some(t) = conn.requests_task.take() {
-                    t.wake();
-                }
-            }
-            _ => (),
+        if let Poll::Ready(Some(recv)) = Pin::new(&mut self.incoming_uni).poll_next(cx)? {
+            self.pending_uni.push_back(Some(RecvUni::new(recv)));
         }
+
+        if let Poll::Ready(Some((send, recv))) = Pin::new(&mut self.incoming_bi).poll_next(cx)? {
+            let mut conn = self.conn.h3.lock().unwrap();
+            conn.requests.push_back((send, recv));
+            if let Some(t) = conn.requests_task.take() {
+                t.wake();
+            }
+        }
+
+        self.poll_pending_uni(cx);
 
         Poll::Pending
     }

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -8,7 +8,10 @@ use quinn::{IncomingBiStreams, IncomingUniStreams, RecvStream, SendStream};
 
 use crate::{
     frame::FrameStream,
-    proto::connection::{Connection, Error as ProtoError},
+    proto::{
+        connection::{Connection, Error as ProtoError},
+        frame::HttpFrame,
+    },
     streams::{NewUni, RecvUni},
     Error, ErrorCode, Settings,
 };
@@ -23,10 +26,7 @@ pub struct ConnectionDriver {
 }
 
 impl ConnectionDriver {
-    pub(crate) fn new_client(
-        conn: ConnectionRef,
-        incoming_uni: IncomingUniStreams,
-    ) -> Self {
+    pub(crate) fn new_client(conn: ConnectionRef, incoming_uni: IncomingUniStreams) -> Self {
         Self {
             pending_uni: VecDeque::with_capacity(10),
             incoming_bi: None,
@@ -160,6 +160,7 @@ impl Future for ConnectionDriver {
         }
 
         self.poll_pending_uni(cx);
+        self.poll_control(cx);
 
         Poll::Pending
     }

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -20,6 +20,7 @@ pub mod qpack;
 pub mod server;
 
 mod frame;
+mod streams;
 
 use err_derive::Error;
 use quinn::VarInt;
@@ -55,6 +56,8 @@ pub enum Error {
     Internal(&'static str),
     #[error(display = "Incorrect peer behavior: {}", _0)]
     Peer(String),
+    #[error(display = "unknown stream type {}", _0)]
+    UnknownStream(u64),
     #[error(display = "IO error: {}", _0)]
     Io(std::io::Error),
     #[error(display = "Overflow max data size")]

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -25,24 +25,9 @@ mod streams;
 use err_derive::Error;
 use quinn::VarInt;
 
-#[derive(Clone, Debug)]
-pub struct Settings {
-    pub max_header_list_size: u64,
-    pub num_placeholders: u64,
-    pub qpack_max_table_capacity: u64,
-    pub qpack_blocked_streams: u64,
-}
+use proto::frame::SettingsFrame;
 
-impl Default for Settings {
-    fn default() -> Self {
-        Self {
-            max_header_list_size: u64::max_value(),
-            num_placeholders: 0,
-            qpack_max_table_capacity: 0,
-            qpack_blocked_streams: 0,
-        }
-    }
-}
+pub type Settings = SettingsFrame;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -139,3 +139,18 @@ impl From<ErrorCode> for VarInt {
         error.0.into()
     }
 }
+
+impl From<frame::Error> for (ErrorCode, String) {
+    fn from(err: frame::Error) -> Self {
+        match err {
+            frame::Error::Io(e) => (
+                ErrorCode::GENERAL_PROTOCOL_ERROR,
+                format!("IO Error: {:?}", e),
+            ),
+            frame::Error::Proto(e) => (
+                ErrorCode::FRAME_ERROR,
+                format!("Parse frame error: {:?}", e),
+            ),
+        }
+    }
+}

--- a/quinn-h3/src/proto/connection.rs
+++ b/quinn-h3/src/proto/connection.rs
@@ -72,6 +72,14 @@ impl Connection {
             }
         }
     }
+
+    pub fn remote_settings(&self) -> &Option<Settings> {
+        &self.remote_settings
+    }
+
+    pub fn set_remote_settings(&mut self, settings: Settings) {
+        self.remote_settings = Some(settings);
+    }
 }
 
 impl Default for Connection {

--- a/quinn-h3/src/proto/frame.rs
+++ b/quinn-h3/src/proto/frame.rs
@@ -353,7 +353,7 @@ impl Default for SettingsFrame {
 }
 
 impl SettingsFrame {
-    fn encode<T: BufMut>(&self, buf: &mut T) {
+    pub fn encode<T: BufMut>(&self, buf: &mut T) {
         self.encode_header(buf);
         SettingId::NUM_PLACEHOLDERS.encode(buf);
         buf.write_var(self.num_placeholders);

--- a/quinn-h3/src/proto/frame.rs
+++ b/quinn-h3/src/proto/frame.rs
@@ -333,7 +333,7 @@ impl FrameHeader for PriorityFrame {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct SettingsFrame {
     pub num_placeholders: u64,
     pub max_header_list_size: u64,

--- a/quinn-h3/src/proto/mod.rs
+++ b/quinn-h3/src/proto/mod.rs
@@ -1,5 +1,8 @@
-use bytes::{Buf, BufMut};
-use quinn_proto::coding::{BufExt, BufMutExt, UnexpectedEnd};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use quinn_proto::{
+    coding::{BufExt, BufMutExt, UnexpectedEnd},
+    VarInt,
+};
 
 pub mod connection;
 pub mod frame;
@@ -30,5 +33,12 @@ impl StreamType {
 
     pub fn decode<B: Buf>(buf: &mut B) -> Result<Self, UnexpectedEnd> {
         Ok(StreamType(buf.get_var()?))
+    }
+
+    pub fn encoded(&self) -> Bytes {
+        let var_int = VarInt::from(self.0 as u32);
+        let mut buf = BytesMut::with_capacity(var_int.size());
+        self.encode(&mut buf);
+        buf.freeze()
     }
 }

--- a/quinn-h3/src/proto/mod.rs
+++ b/quinn-h3/src/proto/mod.rs
@@ -1,11 +1,12 @@
-use bytes::BufMut;
-use quinn_proto::coding::BufMutExt;
+use bytes::{Buf, BufMut};
+use quinn_proto::coding::{BufExt, BufMutExt, UnexpectedEnd};
 
 pub mod connection;
 pub mod frame;
 pub mod headers;
 
-pub struct StreamType(u64);
+#[derive(Debug, PartialEq, Eq)]
+pub struct StreamType(pub u64);
 
 macro_rules! stream_types {
     {$($name:ident = $val:expr,)*} => {
@@ -25,5 +26,9 @@ stream_types! {
 impl StreamType {
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
         buf.write_var(self.0);
+    }
+
+    pub fn decode<B: Buf>(buf: &mut B) -> Result<Self, UnexpectedEnd> {
+        Ok(StreamType(buf.get_var()?))
     }
 }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -87,12 +87,13 @@ impl Future for Connecting {
             driver,
             connection,
             bi_streams,
+            uni_streams,
             ..
         } = ready!(Pin::new(&mut self.connecting).poll(cx))?;
         let conn_ref = ConnectionRef::new(connection, self.settings.clone())?;
         Poll::Ready(Ok((
             driver,
-            ConnectionDriver::new(conn_ref.clone(), bi_streams),
+            ConnectionDriver::new(conn_ref.clone(), uni_streams, bi_streams),
             IncomingRequest(conn_ref),
         )))
     }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -93,7 +93,7 @@ impl Future for Connecting {
         let conn_ref = ConnectionRef::new(connection, self.settings.clone())?;
         Poll::Ready(Ok((
             driver,
-            ConnectionDriver::new(conn_ref.clone(), uni_streams, bi_streams),
+            ConnectionDriver::new_server(conn_ref.clone(), uni_streams, bi_streams),
             IncomingRequest(conn_ref),
         )))
     }

--- a/quinn-h3/src/streams.rs
+++ b/quinn-h3/src/streams.rs
@@ -1,0 +1,82 @@
+use std::{convert::TryFrom, io, mem, pin::Pin, task::Context};
+
+use bytes::BytesMut;
+use futures::{io::AsyncRead, ready, Future, Poll};
+use quinn::RecvStream;
+use quinn_proto::VarInt;
+
+use crate::{
+    frame::{FrameDecoder, FrameStream},
+    proto::StreamType,
+    Error,
+};
+
+pub enum NewUni {
+    Control(ControlStream),
+    Push(PushStream),
+    Encoder(RecvStream),
+    Decoder(RecvStream),
+}
+
+impl TryFrom<(StreamType, RecvStream)> for NewUni {
+    type Error = Error;
+    fn try_from(value: (StreamType, RecvStream)) -> Result<Self, Self::Error> {
+        let (ty, recv) = value;
+        Ok(match ty {
+            StreamType::CONTROL => NewUni::Control(ControlStream(FrameDecoder::stream(recv))),
+            StreamType::PUSH => NewUni::Push(PushStream(FrameDecoder::stream(recv))),
+            StreamType::ENCODER => NewUni::Encoder(recv),
+            StreamType::DECODER => NewUni::Decoder(recv),
+            _ => return Err(Error::UnknownStream(ty.0)),
+        })
+    }
+}
+
+pub struct RecvUni {
+    inner: Option<(RecvStream, Vec<u8>, usize)>,
+}
+
+impl RecvUni {
+    pub fn new(recv: RecvStream) -> Self {
+        Self {
+            inner: Some((recv, vec![0u8; VarInt::MAX.size()], 0)),
+        }
+    }
+}
+
+impl Future for RecvUni {
+    type Output = Result<NewUni, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        loop {
+            match self.inner {
+                None => panic!("polled after resolved"),
+                Some((ref mut recv, ref mut buf, ref mut len)) => {
+                    match ready!(Pin::new(recv).poll_read(cx, &mut buf[..*len + 1]))? {
+                        0 => {
+                            return Poll::Ready(Err(Error::Peer(format!(
+                                "Uni stream closed before type received",
+                            ))))
+                        }
+                        _ => {
+                            *len += 1;
+                            let mut cur = io::Cursor::new(&buf);
+                            if let Ok(ty) = StreamType::decode(&mut cur) {
+                                match mem::replace(&mut self.inner, None) {
+                                    Some((recv, _, _)) => {
+                                        return Poll::Ready(NewUni::try_from((ty, recv)))
+                                    }
+                                    _ => unreachable!(),
+                                };
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub struct ControlStream(FrameStream);
+
+pub struct PushStream(FrameStream);

--- a/quinn-h3/src/streams.rs
+++ b/quinn-h3/src/streams.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub enum NewUni {
-    Control(ControlStream),
+    Control(FrameStream),
     Push(PushStream),
     Encoder(RecvStream),
     Decoder(RecvStream),
@@ -23,7 +23,7 @@ impl TryFrom<(StreamType, RecvStream)> for NewUni {
     fn try_from(value: (StreamType, RecvStream)) -> Result<Self, Self::Error> {
         let (ty, recv) = value;
         Ok(match ty {
-            StreamType::CONTROL => NewUni::Control(ControlStream(FrameDecoder::stream(recv))),
+            StreamType::CONTROL => NewUni::Control(FrameDecoder::stream(recv)),
             StreamType::PUSH => NewUni::Push(PushStream(FrameDecoder::stream(recv))),
             StreamType::ENCODER => NewUni::Encoder(recv),
             StreamType::DECODER => NewUni::Decoder(recv),
@@ -76,7 +76,5 @@ impl Future for RecvUni {
         }
     }
 }
-
-pub struct ControlStream(FrameStream);
 
 pub struct PushStream(FrameStream);


### PR DESCRIPTION
This PR adds `Uni` stream management and a partial `control stream` implementation (#358). Only `Settings` frames are handled for now, as other frame types will need more work to implement their respective behaviour:

- `GoAway`: Error management for a connection-wide scope and `StreamId` tracking.
- `CancelPush` and `MaxPushId`: PushStreams implementation.

`quinn-h3::Connection::set_error()` is only a stub function, waiting to be implemented in a future error management related PR.