### PR TITLE
Fix stream ID leak when stream opening futures are dropped

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{cmp, io, mem, fmt};
+use std::{cmp, fmt, io, mem};
 
 use bytes::{Bytes, BytesMut};
 use err_derive::Error;
@@ -3176,7 +3176,10 @@ where
     }
 }
 
-impl<S> fmt::Debug for Connection<S> where S: crypto::Session {
+impl<S> fmt::Debug for Connection<S>
+where
+    S: crypto::Session,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Connection")
             .field("handshake_cid", &self.handshake_cid)


### PR DESCRIPTION
By deferring allocation of the stream ID until the futures synchronously completes, we guarantee that either no ID is allocated or ownership is successfully taken by the Send/RecvStream struct(s).

Thanks to @stammw for noticing that the semantics here were poorly thought out!