### PR TITLE
H3 goaway implementation

### DIFF
--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -26,9 +26,10 @@ use crate::{
     proto::{
         frame::{DataFrame, HeadersFrame, HttpFrame},
         headers::Header,
+        ErrorCode,
     },
     streams::Reset,
-    try_take, Error, ErrorCode,
+    try_take, Error,
 };
 
 pub enum Body {
@@ -278,7 +279,10 @@ impl RecvBodyStream {
     }
 
     pub fn cancel(mut self) {
-        self.recv.take().unwrap().reset(ErrorCode::REQUEST_CANCELLED);
+        self.recv
+            .take()
+            .unwrap()
+            .reset(ErrorCode::REQUEST_CANCELLED);
     }
 }
 

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -16,9 +16,10 @@ use crate::{
     proto::{
         frame::{DataFrame, HttpFrame},
         headers::Header,
+        ErrorCode,
     },
     streams::Reset,
-    try_take, Error, ErrorCode, Settings,
+    try_take, Error, Settings,
 };
 
 #[derive(Clone, Debug, Default)]

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -94,12 +94,13 @@ impl Future for Connecting {
             driver,
             connection,
             uni_streams,
+            bi_streams,
             ..
         } = ready!(Pin::new(&mut self.connecting).poll(cx))?;
         let conn_ref = ConnectionRef::new(connection, self.settings.clone())?;
         Poll::Ready(Ok((
             driver,
-            ConnectionDriver::new_client(conn_ref.clone(), uni_streams),
+            ConnectionDriver::new_client(conn_ref.clone(), uni_streams, bi_streams),
             Connection(conn_ref),
         )))
     }

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -14,9 +14,10 @@ use crate::{
     proto::{
         connection::{Connection, Error as ProtoError},
         frame::HttpFrame,
+        ErrorCode,
     },
     streams::{NewUni, RecvUni, SendControlStream},
-    Error, ErrorCode, Settings,
+    Error, Settings,
 };
 
 pub struct ConnectionDriver {

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -116,7 +116,7 @@ impl ConnectionDriver {
 
         match Pin::new(&mut control).poll_next(cx) {
             Poll::Ready(None) => {
-                self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "control closed")
+                self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "control in closed")
             }
             Poll::Ready(Some(Err(e))) => {
                 let (code, msg) = e.into();
@@ -160,7 +160,7 @@ impl Future for ConnectionDriver {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         if let Poll::Ready(Err(_err)) = Pin::new(&mut self.send_control).poll(cx) {
-            self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "control stream closed");
+            self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "control out stream");
         }
 
         if let Poll::Ready(Some(recv)) = Pin::new(&mut self.incoming_uni).poll_next(cx)? {

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -180,6 +180,7 @@ impl Future for ConnectionDriver {
                     conn.requests.push_back((send, recv));
                     if let Some(t) = conn.requests_task.take() {
                         t.wake();
+                    conn.inner.request_initiated(send.id());
                     }
                 }
             }

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -180,7 +180,10 @@ impl Future for ConnectionDriver {
                 ),
                 Side::Server => {
                     let mut conn = self.conn.h3.lock().unwrap();
-                    if !conn.inner.is_closing() {
+                    if conn.inner.is_closing() {
+                        send.reset(ErrorCode::REQUEST_REJECTED.into());
+                        let _ = recv.stop(ErrorCode::REQUEST_REJECTED.into());
+                    } else {
                         conn.inner.request_initiated(send.id());
                         conn.requests.push_back((send, recv));
                         if let Some(t) = conn.requests_task.take() {

--- a/quinn-h3/src/frame.rs
+++ b/quinn-h3/src/frame.rs
@@ -7,7 +7,7 @@ use tokio_codec::{Decoder, FramedRead};
 use tokio_io::AsyncRead;
 
 use super::proto::frame::{self, FrameHeader, HttpFrame, IntoPayload, PartialData};
-use crate::{streams::Reset, ErrorCode};
+use crate::{proto::ErrorCode, streams::Reset};
 
 pub type FrameStream = FramedRead<RecvStream, FrameDecoder>;
 

--- a/quinn-h3/src/frame.rs
+++ b/quinn-h3/src/frame.rs
@@ -122,6 +122,12 @@ impl WriteFrame {
             state: WriteFrameState::Header(send, buf.into()),
         }
     }
+
+    pub fn reset(self, err_code: ErrorCode) {
+        if let WriteFrameState::Header(mut s, _) | WriteFrameState::Payload(mut s, _) = self.state {
+            s.reset(err_code.into());
+        }
+    }
 }
 
 impl Future for WriteFrame {

--- a/quinn-h3/src/headers.rs
+++ b/quinn-h3/src/headers.rs
@@ -8,8 +8,8 @@ use quinn_proto::StreamId;
 use crate::{
     connection::ConnectionRef,
     frame::WriteFrame,
-    proto::{frame::HeadersFrame, headers::Header},
-    Error, ErrorCode,
+    proto::{frame::HeadersFrame, headers::Header, ErrorCode},
+    Error,
 };
 
 pub struct DecodeHeaders {

--- a/quinn-h3/src/headers.rs
+++ b/quinn-h3/src/headers.rs
@@ -9,7 +9,7 @@ use crate::{
     connection::ConnectionRef,
     frame::WriteFrame,
     proto::{frame::HeadersFrame, headers::Header},
-    Error,
+    Error, ErrorCode,
 };
 
 pub struct DecodeHeaders {
@@ -70,6 +70,10 @@ impl SendHeaders {
         };
 
         Ok(Self(WriteFrame::new(send, frame)))
+    }
+
+    pub fn reset(self, err_code: ErrorCode) {
+        self.0.reset(err_code);
     }
 }
 

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -23,9 +23,8 @@ mod frame;
 mod streams;
 
 use err_derive::Error;
-use quinn::VarInt;
 
-use proto::frame::SettingsFrame;
+use proto::{frame::SettingsFrame, ErrorCode};
 
 pub type Settings = SettingsFrame;
 
@@ -104,43 +103,6 @@ fn try_take<T>(item: &mut Option<T>, msg: &'static str) -> Result<T, Error> {
 
 /// TLS ALPN value for H3
 pub const ALPN: &[u8] = b"h3-20";
-
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct ErrorCode(u32);
-
-macro_rules! error_codes {
-    {$($name:ident = $val:expr,)*} => {
-        impl ErrorCode {
-            $(pub const $name: ErrorCode = ErrorCode($val);)*
-        }
-    }
-}
-
-error_codes! {
-    NO_ERROR = 0x100,
-    GENERAL_PROTOCOL_ERROR = 0x101,
-    INTERNAL_ERROR = 0x102,
-    STREAM_CREATION_ERROR = 0x103,
-    CLOSED_CRITICAL_STREAM = 0x104,
-    FRAME_UNEXPECTED = 0x105,
-    FRAME_ERROR = 0x106,
-    EXCESSIVE_LOAD = 0x107,
-    ID_ERROR = 0x108,
-    SETTINGS_ERROR = 0x109,
-    MISSING_SETTINGS = 0x10A,
-    REQUEST_REJECTED = 0x10B,
-    REQUEST_CANCELLED = 0x10C,
-    REQUEST_INCOMPLETE = 0x10D,
-    EARLY_RESPONSE = 0x10E,
-    CONNECT_ERROR = 0x10F,
-    VERSION_FALLBACK = 0x110,
-}
-
-impl From<ErrorCode> for VarInt {
-    fn from(error: ErrorCode) -> VarInt {
-        error.0.into()
-    }
-}
 
 impl From<frame::Error> for (ErrorCode, String) {
     fn from(err: frame::Error) -> Self {

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -31,6 +31,8 @@ pub type Settings = SettingsFrame;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error(display = "Connection is closing, resquest aborted")]
+    Aborted,
     #[error(display = "H3 protocol error: {:?}", _0)]
     Proto(proto::connection::Error),
     #[error(display = "QUIC protocol error: {}", _0)]

--- a/quinn-h3/src/proto/mod.rs
+++ b/quinn-h3/src/proto/mod.rs
@@ -42,3 +42,40 @@ impl StreamType {
         buf.freeze()
     }
 }
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct ErrorCode(pub(super) u32);
+
+macro_rules! error_codes {
+    {$($name:ident = $val:expr,)*} => {
+        impl ErrorCode {
+            $(pub const $name: ErrorCode = ErrorCode($val);)*
+        }
+    }
+}
+
+error_codes! {
+    NO_ERROR = 0x100,
+    GENERAL_PROTOCOL_ERROR = 0x101,
+    INTERNAL_ERROR = 0x102,
+    STREAM_CREATION_ERROR = 0x103,
+    CLOSED_CRITICAL_STREAM = 0x104,
+    FRAME_UNEXPECTED = 0x105,
+    FRAME_ERROR = 0x106,
+    EXCESSIVE_LOAD = 0x107,
+    ID_ERROR = 0x108,
+    SETTINGS_ERROR = 0x109,
+    MISSING_SETTINGS = 0x10A,
+    REQUEST_REJECTED = 0x10B,
+    REQUEST_CANCELLED = 0x10C,
+    REQUEST_INCOMPLETE = 0x10D,
+    EARLY_RESPONSE = 0x10E,
+    CONNECT_ERROR = 0x10F,
+    VERSION_FALLBACK = 0x110,
+}
+
+impl From<ErrorCode> for VarInt {
+    fn from(error: ErrorCode) -> VarInt {
+        error.0.into()
+    }
+}

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -215,8 +215,8 @@ pub struct Sender {
 }
 
 impl Sender {
-    pub fn response<T>(self, response: Response<T>) -> ResonsepBuilder<T> {
-        ResonsepBuilder {
+    pub fn response<T>(self, response: Response<T>) -> ResponseBuilder<T> {
+        ResponseBuilder {
             response,
             sender: self,
             trailers: None,
@@ -224,13 +224,13 @@ impl Sender {
     }
 }
 
-pub struct ResonsepBuilder<T> {
+pub struct ResponseBuilder<T> {
     sender: Sender,
     response: Response<T>,
     trailers: Option<HeaderMap>,
 }
 
-impl<T> ResonsepBuilder<T>
+impl<T> ResponseBuilder<T>
 where
     T: Into<Body>,
 {

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -16,9 +16,10 @@ use crate::{
     proto::{
         frame::{DataFrame, HttpFrame},
         headers::Header,
+        ErrorCode,
     },
     streams::Reset,
-    try_take, Error, ErrorCode, Settings,
+    try_take, Error, Settings,
 };
 
 pub struct Builder {

--- a/quinn-h3/src/streams.rs
+++ b/quinn-h3/src/streams.rs
@@ -11,8 +11,8 @@ use quinn_proto::VarInt;
 use crate::{
     connection::ConnectionRef,
     frame::{FrameDecoder, FrameStream},
-    proto::StreamType,
-    Error, ErrorCode,
+    proto::{ErrorCode, StreamType},
+    Error,
 };
 
 pub enum NewUni {

--- a/quinn-h3/src/streams.rs
+++ b/quinn-h3/src/streams.rs
@@ -12,7 +12,7 @@ use crate::{
     connection::ConnectionRef,
     frame::{FrameDecoder, FrameStream},
     proto::StreamType,
-    Error,
+    Error, ErrorCode,
 };
 
 pub enum NewUni {
@@ -136,4 +136,8 @@ impl Future for SendControlStream {
             }
         }
     }
+}
+
+pub trait Reset {
+    fn reset(self, code: ErrorCode);
 }


### PR DESCRIPTION
This PR addresses connection and stream abrupt closures and errors. It contains the implementation of Goaway graceful shutdown from the server.

It also includes stream reset features, part of Goaway procedure. Every stream reset cases have been changed to use them as well, according to the specification. 

Lastly, this introduce an API to let a client or server application cancel a request at any step.

