### PR TITLE
Application datagram improvements

### DIFF
--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -87,7 +87,7 @@ pub struct TransportConfig {
     /// The RTT used before an RTT sample is taken (μs)
     pub initial_rtt: u64,
 
-    /// The sender’s maximum payload size. Does not include UDP or IP overhead.
+    /// The sender’s maximum UDP payload size. Does not include UDP or IP overhead.
     ///
     /// Used for calculating initial and minimum congestion windows.
     pub max_datagram_size: u64,
@@ -124,13 +124,13 @@ pub struct TransportConfig {
     /// The peer is forbidden to send single datagrams larger than this size. If the aggregate size
     /// of all datagrams that have been received from the peer but not consumed by the application
     /// exceeds this value, old datagrams are dropped until it is no longer exceeded.
-    pub datagram_receive_window: Option<usize>,
+    pub datagram_receive_buffer_size: Option<usize>,
     /// Maximum number of outgoing application datagram bytes to buffer
     ///
     /// While datagrams are sent ASAP, it is possible for an application to generate data faster
     /// than the link, or even the underlying hardware, can transmit them. This limits the amount of
     /// memory that may be consumed in that case.
-    pub datagram_send_window: usize,
+    pub datagram_send_buffer_size: usize,
 }
 
 impl Default for TransportConfig {
@@ -167,8 +167,8 @@ impl Default for TransportConfig {
             keep_alive_interval: 0,
             crypto_buffer_size: 16 * 1024,
             allow_spin: true,
-            datagram_receive_window: Some(STREAM_RWND as usize),
-            datagram_send_window: 1 * 1024 * 1024,
+            datagram_receive_buffer_size: Some(STREAM_RWND as usize),
+            datagram_send_buffer_size: 1 * 1024 * 1024,
         }
     }
 }

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -118,12 +118,19 @@ pub struct TransportConfig {
     /// This allows passive observers to easily judge the round trip time of a connection, which can
     /// be useful for network administration but sacrifices a small amount of privacy.
     pub allow_spin: bool,
-    /// Maximum number of application datagram bytes to buffer, or None to disable datagrams
+    /// Maximum number of incoming application datagram bytes to buffer, or None to disable
+    /// datagrams
     ///
     /// The peer is forbidden to send single datagrams larger than this size. If the aggregate size
     /// of all datagrams that have been received from the peer but not consumed by the application
     /// exceeds this value, old datagrams are dropped until it is no longer exceeded.
-    pub datagram_window: Option<usize>,
+    pub datagram_receive_window: Option<usize>,
+    /// Maximum number of outgoing application datagram bytes to buffer
+    ///
+    /// While datagrams are sent ASAP, it is possible for an application to generate data faster
+    /// than the link, or even the underlying hardware, can transmit them. This limits the amount of
+    /// memory that may be consumed in that case.
+    pub datagram_send_window: usize,
 }
 
 impl Default for TransportConfig {
@@ -160,7 +167,8 @@ impl Default for TransportConfig {
             keep_alive_interval: 0,
             crypto_buffer_size: 16 * 1024,
             allow_spin: true,
-            datagram_window: Some(STREAM_RWND as usize),
+            datagram_receive_window: Some(STREAM_RWND as usize),
+            datagram_send_window: 1 * 1024 * 1024,
         }
     }
 }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1175,7 +1175,7 @@ fn datagram_window() {
     const WINDOW: usize = 100;
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            datagram_receive_window: Some(WINDOW),
+            datagram_receive_buffer_size: Some(WINDOW),
             ..TransportConfig::default()
         }),
         ..server_config()
@@ -1238,7 +1238,7 @@ fn datagram_window() {
 fn datagram_unsupported() {
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            datagram_receive_window: None,
+            datagram_receive_buffer_size: None,
             ..TransportConfig::default()
         }),
         ..server_config()

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1175,7 +1175,7 @@ fn datagram_window() {
     const WINDOW: usize = 100;
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            datagram_window: Some(WINDOW),
+            datagram_receive_window: Some(WINDOW),
             ..TransportConfig::default()
         }),
         ..server_config()
@@ -1238,7 +1238,7 @@ fn datagram_window() {
 fn datagram_unsupported() {
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            datagram_window: None,
+            datagram_receive_window: None,
             ..TransportConfig::default()
         }),
         ..server_config()

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -89,7 +89,7 @@ impl TransportParameters {
             disable_active_migration: server_config.map_or(false, |c| !c.migration),
             active_connection_id_limit: REM_CID_COUNT,
             max_datagram_frame_size: config
-                .datagram_receive_window
+                .datagram_receive_buffer_size
                 .map(|x| (x.min(u16::max_value().into()) as u16).into()),
             ..Self::default()
         }

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -89,7 +89,7 @@ impl TransportParameters {
             disable_active_migration: server_config.map_or(false, |c| !c.migration),
             active_connection_id_limit: REM_CID_COUNT,
             max_datagram_frame_size: config
-                .datagram_window
+                .datagram_receive_window
                 .map(|x| (x.min(u16::max_value().into()) as u16).into()),
             ..Self::default()
         }

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -40,7 +40,7 @@ fn throughput(c: &mut Criterion) {
         let (client, mut runtime) = ctx.make_client(addr);
         const DATA: &[u8] = &[0xAB; 32];
         group.throughput(Throughput::Elements(1));
-        group.bench_function("small streams", |b| {
+        group.bench_function("small streams unpipelined", |b| {
             b.iter(|| {
                 runtime.block_on(async {
                     let mut stream = client.open_uni().await.unwrap();


### PR DESCRIPTION
I get about 2M datagrams per second. This is much larger than the number of small streams per second, almost entirely because the small streams benchmark waits for each stream to be acknowledged before sending the next, which forces each stream to be sent in a separate packet and waits for acknowledgement before sending the next.

Same irrelevant CI breakage as last time.