### PR TITLE
Remove fnv hash

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -23,7 +23,6 @@ tls-rustls = ["rustls", "webpki", "ring"]
 [dependencies]
 bytes = "0.4.7"
 err-derive = "0.2"
-fnv = "1.0.6"
 lazy_static = "1"
 rand = "0.7"
 ring = { version = "0.16.7", optional = true }

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -6,7 +6,6 @@ use std::{cmp, fmt, io, mem};
 
 use bytes::{Bytes, BytesMut};
 use err_derive::Error;
-use fnv::FnvHashSet;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use tracing::{debug, error, info, trace, trace_span, warn};
 
@@ -66,7 +65,7 @@ where
     /// Transport parameters set by the peer
     params: TransportParameters,
     /// Streams on which writing was blocked on *connection-level* flow or congestion control
-    blocked_streams: FnvHashSet<StreamId>,
+    blocked_streams: HashSet<StreamId>,
     /// Limit on outgoing data, dictated by peer
     max_data: u64,
     /// Sum of current offsets of all send streams.
@@ -213,7 +212,7 @@ where
             zero_rtt_crypto: None,
             key_phase: false,
             params: TransportParameters::default(),
-            blocked_streams: FnvHashSet::default(),
+            blocked_streams: HashSet::new(),
             max_data: 0,
             data_sent: 0,
             data_recvd: 0,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -8,7 +8,6 @@ use std::time::{Duration, Instant, SystemTime};
 
 use bytes::{BufMut, BytesMut};
 use err_derive::Error;
-use fnv::FnvHashMap;
 use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
 use slab::Slab;
 use tracing::{debug, trace, warn};
@@ -40,10 +39,10 @@ where
 {
     rng: StdRng,
     transmits: VecDeque<Transmit>,
-    connection_ids_initial: FnvHashMap<ConnectionId, ConnectionHandle>,
-    connection_ids: FnvHashMap<ConnectionId, ConnectionHandle>,
+    connection_ids_initial: HashMap<ConnectionId, ConnectionHandle>,
+    connection_ids: HashMap<ConnectionId, ConnectionHandle>,
     /// Identifies connections with zero-length CIDs
-    connection_remotes: FnvHashMap<SocketAddr, ConnectionHandle>,
+    connection_remotes: HashMap<SocketAddr, ConnectionHandle>,
     /// Reset tokens provided by the peer for the CID each connection is currently sending to
     ///
     /// Incoming stateless resets do not have correct CIDs, so we need this to identify the correct
@@ -76,9 +75,9 @@ where
         Ok(Self {
             rng: StdRng::from_entropy(),
             transmits: VecDeque::new(),
-            connection_ids_initial: FnvHashMap::default(),
-            connection_ids: FnvHashMap::default(),
-            connection_remotes: FnvHashMap::default(),
+            connection_ids_initial: HashMap::new(),
+            connection_ids: HashMap::new(),
+            connection_remotes: HashMap::new(),
             connection_reset_tokens: HashMap::new(),
             connections: Slab::new(),
             incoming_handshakes: 0,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -205,24 +205,30 @@ where
             } else {
                 None
             };
-            ch.or_else(|| self.connection_ids_initial.get(&dst_cid))
-                .or_else(|| {
-                    if self.config.local_cid_len == 0 {
-                        self.connection_remotes.get(&remote)
-                    } else {
-                        None
-                    }
-                })
-                .or_else(|| {
-                    let data = first_decode.data();
-                    if data.len() >= RESET_TOKEN_SIZE {
-                        self.connection_reset_tokens
-                            .get(&data[data.len() - RESET_TOKEN_SIZE..])
-                    } else {
-                        None
-                    }
-                })
-                .cloned()
+            ch.or_else(|| {
+                if first_decode.is_initial() {
+                    self.connection_ids_initial.get(&dst_cid)
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                if self.config.local_cid_len == 0 {
+                    self.connection_remotes.get(&remote)
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                let data = first_decode.data();
+                if data.len() >= RESET_TOKEN_SIZE {
+                    self.connection_reset_tokens
+                        .get(&data[data.len() - RESET_TOKEN_SIZE..])
+                } else {
+                    None
+                }
+            })
+            .cloned()
         };
         if let Some(ch) = known_ch {
             return Some((

--- a/quinn-proto/src/spaces.rs
+++ b/quinn-proto/src/spaces.rs
@@ -1,9 +1,8 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::time::Instant;
 use std::{cmp, mem};
 
 use bytes::Bytes;
-use fnv::FnvHashSet;
 
 use crate::assembler::Assembler;
 use crate::range_set::RangeSet;
@@ -168,7 +167,7 @@ pub struct Retransmits {
     pub stream: VecDeque<frame::Stream>,
     pub rst_stream: Vec<(StreamId, VarInt)>,
     pub stop_sending: Vec<frame::StopSending>,
-    pub max_stream_data: FnvHashSet<StreamId>,
+    pub max_stream_data: HashSet<StreamId>,
     pub crypto: VecDeque<frame::Crypto>,
     pub new_cids: Vec<IssuedCid>,
     pub retire_cids: Vec<u64>,
@@ -198,7 +197,7 @@ impl Default for Retransmits {
             stream: VecDeque::new(),
             rst_stream: Vec::new(),
             stop_sending: Vec::new(),
-            max_stream_data: FnvHashSet::default(),
+            max_stream_data: HashSet::new(),
             crypto: VecDeque::new(),
             new_cids: Vec::new(),
             retire_cids: Vec::new(),

--- a/quinn-proto/src/streams.rs
+++ b/quinn-proto/src/streams.rs
@@ -1,8 +1,7 @@
-use std::collections::hash_map;
+use std::collections::{hash_map, HashMap};
 
 use bytes::Bytes;
 use err_derive::Error;
-use fnv::FnvHashMap;
 use tracing::debug;
 
 use crate::assembler::Assembler;
@@ -12,8 +11,8 @@ use crate::{Dir, Side, StreamId, TransportError, VarInt};
 
 pub struct Streams {
     // Set of streams that are currently open, or could be immediately opened by the peer
-    send: FnvHashMap<StreamId, Send>,
-    recv: FnvHashMap<StreamId, Recv>,
+    send: HashMap<StreamId, Send>,
+    recv: HashMap<StreamId, Recv>,
     next: [u64; 2],
     // Locally initiated
     pub max: [u64; 2],
@@ -28,8 +27,8 @@ pub struct Streams {
 impl Streams {
     pub fn new(side: Side, max_remote_uni: u64, max_remote_bi: u64) -> Self {
         let mut this = Self {
-            send: FnvHashMap::default(),
-            recv: FnvHashMap::default(),
+            send: HashMap::default(),
+            recv: HashMap::default(),
             next: [0, 0],
             max: [0, 0],
             max_remote: [max_remote_bi, max_remote_uni],

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::io::{self, Write};
 use std::net::{Ipv6Addr, SocketAddr, UdpSocket};
 use std::ops::RangeFrom;
@@ -6,7 +6,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{cmp, env, mem, str};
 
-use fnv::FnvHashMap;
 use lazy_static::lazy_static;
 use rustls::KeyLogFile;
 use tracing::{info_span, trace};
@@ -173,8 +172,8 @@ pub struct TestEndpoint {
     delayed: VecDeque<Transmit>,
     pub inbound: VecDeque<(Instant, Option<EcnCodepoint>, Box<[u8]>)>,
     accepted: Option<ConnectionHandle>,
-    pub connections: FnvHashMap<ConnectionHandle, Connection>,
-    conn_events: FnvHashMap<ConnectionHandle, VecDeque<ConnectionEvent>>,
+    pub connections: HashMap<ConnectionHandle, Connection>,
+    conn_events: HashMap<ConnectionHandle, VecDeque<ConnectionEvent>>,
 }
 
 impl TestEndpoint {
@@ -197,8 +196,8 @@ impl TestEndpoint {
             delayed: VecDeque::new(),
             inbound: VecDeque::new(),
             accepted: None,
-            connections: FnvHashMap::default(),
-            conn_events: FnvHashMap::default(),
+            connections: HashMap::default(),
+            conn_events: HashMap::default(),
         }
     }
 


### PR DESCRIPTION
This had no visible performance benefit and may have created a HashDoS vulnerability.

Fixes #88.