### PR TITLE
Added access modifiers to config types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 
-/target/
+**/target/
 **/*.rs.bk
 Cargo.lock

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeRunConfigurationManager" shouldGenerate="true" shouldDeleteObsolete="true">
+    <generated />
+  </component>
+  <component name="CMakeSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
+    </configurations>
+  </component>
+  <component name="CargoProjects">
+    <cargoProject FILE="$PROJECT_DIR$/Cargo.toml" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="2240bd58-b5b0-442f-a9c2-c9da36b990ba" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/quinn-proto/src/shared.rs" beforeDir="false" afterPath="$PROJECT_DIR$/quinn-proto/src/shared.rs" afterDir="false" />
+    </list>
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileEditorManager">
+    <leaf>
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/quinn/src/builders.rs">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="430">
+              <caret line="159" column="28" selection-start-line="159" selection-start-column="28" selection-end-line="159" selection-end-column="28" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/quinn-proto/src/shared.rs">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="476">
+              <caret line="282" column="7" selection-start-line="282" selection-start-column="7" selection-end-line="282" selection-end-column="7" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+    </leaf>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="IdeDocumentHistory">
+    <option name="CHANGED_PATHS">
+      <list>
+        <option value="$PROJECT_DIR$/quinn/src/builders.rs" />
+        <option value="$PROJECT_DIR$/quinn-proto/src/shared.rs" />
+      </list>
+    </option>
+  </component>
+  <component name="MacroExpansionManager">
+<<<<<<< HEAD
+    <option name="directoryName" value="ISEsDZdC" />
+=======
+    <option name="directoryName" value="zXrUlTVL" />
+>>>>>>> 35182ee... Added access modifiers to config types.
+  </component>
+  <component name="ProjectFrameBounds" extendedState="6">
+    <option name="x" value="-8" />
+    <option name="y" value="-8" />
+    <option name="width" value="2576" />
+    <option name="height" value="1096" />
+  </component>
+  <component name="ProjectView">
+    <navigator proportions="" version="1">
+      <foldersAlwaysOnTop value="true" />
+    </navigator>
+    <panes>
+      <pane id="Scope" />
+      <pane id="ProjectPane">
+        <subPane>
+          <expand>
+            <path>
+              <item name="quinn" type="b2602c69:ProjectViewProjectNode" />
+              <item name="quinn" type="462c0819:PsiDirectoryNode" />
+            </path>
+          </expand>
+          <select />
+        </subPane>
+      </pane>
+    </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="WebServerToolWindowFactoryState" value="false" />
+    <property name="nodejs_interpreter_path.stuck_in_default_project" value="undefined stuck path" />
+    <property name="nodejs_npm_path_reset_for_default_project" value="true" />
+    <property name="org.rust.cargo.project.model.PROJECT_DISCOVERY" value="true" />
+    <property name="settings.editor.selected.configurable" value="preferences.pluginManager" />
+  </component>
+  <component name="RunDashboard">
+    <option name="ruleStates">
+      <list>
+        <RuleState>
+          <option name="name" value="ConfigurationTypeDashboardGroupingRule" />
+        </RuleState>
+        <RuleState>
+          <option name="name" value="StatusDashboardGroupingRule" />
+        </RuleState>
+      </list>
+    </option>
+  </component>
+  <component name="RustProjectSettings">
+    <option name="toolchainHomeDirectory" value="$USER_HOME$/.cargo/bin" />
+  </component>
+  <component name="SvnConfiguration">
+    <configuration />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="2240bd58-b5b0-442f-a9c2-c9da36b990ba" name="Default Changelist" comment="" />
+      <created>1573889879640</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1573889879640</updated>
+      <workItem from="1573889880992" duration="716000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TimeTrackingManager">
+    <option name="totallyTimeSpent" value="716000" />
+  </component>
+  <component name="ToolWindowManager">
+    <frame x="-8" y="-8" width="2576" height="1096" extended-state="6" />
+    <editor active="true" />
+    <layout>
+      <window_info id="Favorites" side_tool="true" />
+      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.25" />
+      <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
+      <window_info anchor="bottom" id="Database Changes" />
+      <window_info anchor="bottom" id="Version Control" />
+      <window_info anchor="bottom" id="Terminal" />
+      <window_info anchor="bottom" id="Event Log" side_tool="true" />
+      <window_info anchor="bottom" id="Message" order="0" />
+      <window_info anchor="bottom" id="Find" order="1" />
+      <window_info anchor="bottom" id="Run" order="2" />
+      <window_info anchor="bottom" id="Debug" order="3" weight="0.4" />
+      <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
+      <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
+      <window_info anchor="bottom" id="TODO" order="6" />
+      <window_info anchor="right" id="Cargo" />
+      <window_info anchor="right" id="Database" />
+      <window_info anchor="right" id="Commander" internal_type="SLIDING" order="0" type="SLIDING" weight="0.4" />
+      <window_info anchor="right" id="Ant Build" order="1" weight="0.25" />
+      <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25" />
+    </layout>
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="1" />
+  </component>
+  <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/quinn/src/builders.rs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="430">
+          <caret line="159" column="28" selection-start-line="159" selection-start-column="28" selection-end-line="159" selection-end-column="28" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/quinn-proto/src/shared.rs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="476">
+          <caret line="282" column="7" selection-start-line="282" selection-start-column="7" selection-end-line="282" selection-end-column="7" />
+        </state>
+      </provider>
+    </entry>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ can require a larger UDP buffer than is configured by default in most
 environments. If you observe erratic latency and/or throughput over a stable
 network link, consider increasing the buffer sizes used. For example, you could
 adjust the `SO_SNDBUF` and `SO_RCVBUF` options of the UDP socket to be used
-before passing it in to Quinn. Note that some platforms (e.g. Linux) require
+before passing it into Quinn. Note that some platforms (e.g. Linux) require
 elevated privileges or modified system configuration for a process to increase
 its UDP buffer sizes.
 
@@ -68,7 +68,7 @@ this can be accomplished by using certificates from [Let's Encrypt][letsencrypt]
 for servers, and relying on the default configuration for clients.
 
 For some cases, including peer-to-peer, trust-on-first-use, deliberately
-insecure applications, or any case where servers are not identified by domain
+insecure applications, or any case where servers are not identified by a domain
 name, this isn't practical. Arbitrary certificate validation logic can be
 implemented by enabling the `dangerous_configuration` feature of `rustls` and
 constructing a Quinn `ClientConfig` with an overridden certificate verifier by
@@ -95,7 +95,7 @@ client will automatically find and trust it.
 ## Development
 
 The quinn-proto test suite uses simulated IO for reproducibility and to avoid
-long sleeps in certain timing-sensitive tests. If the `SSLKEYLOGFILE`
+long periods of sleep in certain timing-sensitive tests. If the `SSLKEYLOGFILE`
 environment variable is set, the tests will emit UDP packets for inspection
 using external protocol analyzers like Wireshark, and NSS-compatible key logs
 for the client side of each connection will be written to the path specified in

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -10,16 +10,16 @@ quinn = { path = "../quinn" }
 quinn-h3 = { path = "../quinn-h3" }
 quinn-proto = { path = "../quinn-proto" }
 http = { git = "https://github.com/hyperium/http/", rev = "912534f1ef27d8a9050a4bd40d5ea0ee35136ea7" }
-slog-term = "2"
 bytes = "0.4.7"
 structopt = "0.3.0"
 tokio = "0.2.0-alpha.5"
 tokio-net = "0.2.0-alpha.5" # tokio doesn't reexport everything we use
 rustls = { version = "0.16", features = ["dangerous_configuration"] }
 failure = "0.1"
-slog = "2.2"
 futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
 webpki = "0.21"
+tracing = "0.1.10"
+tracing-subscriber = "0.1.5"
 
 [[bin]]
 name = "main"

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -25,14 +25,12 @@ travis-ci = { repository = "djc/quinn" }
 [dependencies]
 bitlab = "0.8.1"
 bytes = "0.4.7"
-err-derive = "0.1.5"
+err-derive = "0.2"
 futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
 http = { git = "https://github.com/hyperium/http/", rev = "912534f1ef27d8a9050a4bd40d5ea0ee35136ea7" }
 lazy_static = "1"
 quinn-proto = { path = "../quinn-proto", version = "0.4.0" }
 quinn = { path = "../quinn", version = "0.4.0" }
-# slog = { version = "2.1", features = ["max_level_trace", "release_max_level_warn"]}
-slog = { version = "2.1" }
 string = "0.2"
 tokio = "0.2.0-alpha.5"
 tokio-io = "0.2.0-alpha.5"
@@ -45,9 +43,10 @@ failure = "0.1"
 proptest = "0.9.1"
 rand = "0.7.0"
 rcgen = "0.7"
-slog-term = "2"
 structopt = "0.3.0"
 url = "2"
+tracing = "0.1.10"
+tracing-subscriber = "0.1.5"
 
 [[example]]
 name = "h3"

--- a/quinn-h3/examples/h3.rs
+++ b/quinn-h3/examples/h3.rs
@@ -1,13 +1,11 @@
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Instant;
 
 use failure::{format_err, Error};
 use futures::{StreamExt, TryFutureExt};
 use http::{header::HeaderValue, method::Method, HeaderMap, Request, Response, StatusCode};
-use slog::{o, Logger};
 use structopt::{self, StructOpt};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use url::Url;
@@ -24,7 +22,7 @@ use quinn_h3::{
 use quinn_proto::crypto::rustls::{Certificate, CertificateChain, PrivateKey};
 
 mod shared;
-use shared::{build_certs, logger};
+use shared::build_certs;
 
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(name = "h3")]
@@ -44,19 +42,19 @@ struct Opt {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let opt = Opt::from_args();
-    let log = logger("h3".into());
-    let certs = build_certs(log.clone(), &opt.key, &opt.cert).expect("failed to build certs");
-
-    let server = server(
-        log.new(o!("server" => "")),
-        opt.clone(),
-        (certs.0.clone(), certs.2.clone()),
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .finish(),
     )
-    .expect("init server failed");
+    .unwrap();
+    let opt = Opt::from_args();
+    let certs = build_certs(&opt.key, &opt.cert).expect("failed to build certs");
 
-    let (client, client_driver) =
-        build_client(log.new(o!("client" => "")), certs.1).expect("build client failed");
+    let server =
+        server(opt.clone(), (certs.0.clone(), certs.2.clone())).expect("init server failed");
+
+    let (client, client_driver) = build_client(certs.1).expect("build client failed");
 
     tokio::spawn(async move {
         println!("server running");
@@ -87,23 +85,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn server(
-    log: Logger,
     options: Opt,
     certs: (CertificateChain, PrivateKey),
 ) -> Result<quinn::EndpointDriver, Error> {
-    let server_config = quinn::ServerConfig {
-        transport: Arc::new(quinn::TransportConfig {
-            stream_window_uni: 513,
-            ..Default::default()
-        }),
+    let mut server_config = quinn::ServerConfig::default();
+    server_config.with_transport(quinn::TransportConfig {
+        stream_window_uni: 513,
         ..Default::default()
-    };
+    });
+
     let mut server_config = quinn::ServerConfigBuilder::new(server_config);
     server_config.protocols(&[quinn_h3::ALPN]);
     server_config.certificate(certs.0, certs.1)?;
 
     let mut endpoint = quinn::Endpoint::builder();
-    endpoint.logger(log.clone());
     endpoint.listen(server_config.build());
 
     let server = ServerBuilder::new(endpoint);
@@ -195,11 +190,10 @@ async fn handle_request(request: Request<RecvBody>, sender: Sender) -> Result<()
     Ok(())
 }
 
-fn build_client(log: Logger, cert: Certificate) -> Result<(Client, quinn::EndpointDriver), Error> {
+fn build_client(cert: Certificate) -> Result<(Client, quinn::EndpointDriver), Error> {
     let mut endpoint = quinn::Endpoint::builder();
     let mut client_config = quinn::ClientConfigBuilder::default();
     client_config.protocols(&[quinn_h3::ALPN]);
-    endpoint.logger(log.clone());
 
     client_config.add_certificate_authority(cert)?;
     endpoint.default_client_config(client_config.build());

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -1,8 +1,10 @@
+use quinn_proto::StreamId;
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Waker};
 
+use bytes::Bytes;
 use futures::{Future, Poll, Stream};
 use quinn::{IncomingBiStreams, IncomingUniStreams, RecvStream, SendStream};
 use quinn_proto::Side;
@@ -12,33 +14,36 @@ use crate::{
     proto::{
         connection::{Connection, Error as ProtoError},
         frame::HttpFrame,
+        ErrorCode,
     },
     streams::{NewUni, RecvUni, SendControlStream},
-    Error, ErrorCode, Settings,
+    Error, Settings,
 };
 
 pub struct ConnectionDriver {
     conn: ConnectionRef,
     side: Side,
-    incoming_bi: Option<IncomingBiStreams>,
+    incoming_bi: IncomingBiStreams,
     incoming_uni: IncomingUniStreams,
     pending_uni: VecDeque<Option<RecvUni>>,
     control: Option<FrameStream>,
     send_control: SendControlStream,
-    error: Option<(ErrorCode, String)>,
 }
 
 impl ConnectionDriver {
-    pub(crate) fn new_client(conn: ConnectionRef, incoming_uni: IncomingUniStreams) -> Self {
+    pub(crate) fn new_client(
+        conn: ConnectionRef,
+        incoming_uni: IncomingUniStreams,
+        incoming_bi: IncomingBiStreams,
+    ) -> Self {
         Self {
             pending_uni: VecDeque::with_capacity(10),
             send_control: SendControlStream::new(conn.clone()),
             side: Side::Client,
-            incoming_bi: None,
             control: None,
-            error: None,
             conn,
             incoming_uni,
+            incoming_bi,
         }
     }
 
@@ -50,17 +55,16 @@ impl ConnectionDriver {
         Self {
             pending_uni: VecDeque::with_capacity(10),
             send_control: SendControlStream::new(conn.clone()),
-            incoming_bi: Some(incoming_bi),
             side: Side::Server,
             control: None,
-            error: None,
             conn,
             incoming_uni,
+            incoming_bi,
         }
     }
 
-    fn set_error(&mut self, code: ErrorCode, msg: String) {
-        self.error = Some((code, msg.into()));
+    fn set_error<T: Into<Bytes>>(&mut self, code: ErrorCode, reason: T) {
+        self.conn.quic.close(code.into(), &reason.into());
     }
 
     fn poll_pending_uni(&mut self, cx: &mut Context) {
@@ -93,7 +97,7 @@ impl ConnectionDriver {
                         Some(_) => {
                             self.set_error(
                                 ErrorCode::STREAM_CREATION_ERROR,
-                                "control stream already open".into(),
+                                "control stream already open",
                             );
                         }
                     },
@@ -113,7 +117,7 @@ impl ConnectionDriver {
 
         match Pin::new(&mut control).poll_next(cx) {
             Poll::Ready(None) => {
-                self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "control closed".into())
+                self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "control in closed")
             }
             Poll::Ready(Some(Err(e))) => {
                 let (code, msg) = e.into();
@@ -127,7 +131,9 @@ impl ConnectionDriver {
                     (_, _, HttpFrame::Settings(s)) => {
                         conn.lock().unwrap().inner.set_remote_settings(s);
                     }
-                    (true, Side::Client, HttpFrame::Goaway(_)) => println!("GOAWAY frame ignored"),
+                    (true, Side::Client, HttpFrame::Goaway(id)) => {
+                        self.conn.h3.lock().unwrap().inner.leave(StreamId(id));
+                    }
                     (true, Side::Server, HttpFrame::CancelPush(_)) => {
                         println!("CANCEL_PUSH frame ignored")
                     }
@@ -137,11 +143,11 @@ impl ConnectionDriver {
                     (false, Side::Server, HttpFrame::CancelPush(_))
                     | (false, Side::Server, HttpFrame::MaxPushId(_))
                     | (false, Side::Client, HttpFrame::Goaway(_)) => {
-                        self.set_error(ErrorCode::MISSING_SETTINGS, "missing settings".into())
+                        self.set_error(ErrorCode::MISSING_SETTINGS, "missing settings")
                     }
                     _ => self.set_error(
                         ErrorCode::FRAME_UNEXPECTED,
-                        "unexpected frame type on control stream".into(),
+                        "unexpected frame type on control stream",
                     ),
                 }
             }
@@ -155,7 +161,7 @@ impl Future for ConnectionDriver {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         if let Poll::Ready(Err(_err)) = Pin::new(&mut self.send_control).poll(cx) {
-            self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "TODO".into());
+            self.set_error(ErrorCode::CLOSED_CRITICAL_STREAM, "control out stream");
         }
 
         if let Poll::Ready(Some(recv)) = Pin::new(&mut self.incoming_uni).poll_next(cx)? {
@@ -165,14 +171,37 @@ impl Future for ConnectionDriver {
         self.poll_pending_uni(cx);
         self.poll_control(cx);
 
-        if let Some(ref mut incoming_bi) = self.incoming_bi {
-            if let Poll::Ready(Some((send, recv))) = Pin::new(incoming_bi).poll_next(cx)? {
-                let mut conn = self.conn.h3.lock().unwrap();
-                conn.requests.push_back((send, recv));
-                if let Some(t) = conn.requests_task.take() {
-                    t.wake();
+        if let Poll::Ready(Some((mut send, mut recv))) =
+            Pin::new(&mut self.incoming_bi).poll_next(cx)?
+        {
+            match self.side {
+                Side::Client => self.set_error(
+                    ErrorCode::STREAM_CREATION_ERROR,
+                    "client does not accept bidirectional streams",
+                ),
+                Side::Server => {
+                    let mut conn = self.conn.h3.lock().unwrap();
+                    if conn.inner.is_closing() {
+                        send.reset(ErrorCode::REQUEST_REJECTED.into());
+                        let _ = recv.stop(ErrorCode::REQUEST_REJECTED.into());
+                    } else {
+                        conn.inner.request_initiated(send.id());
+                        conn.requests.push_back((send, recv));
+                        if let Some(t) = conn.requests_task.take() {
+                            t.wake();
+                        }
+                    }
                 }
             }
+        }
+
+        let (is_closing, requests_in_flight) = {
+            let conn = &self.conn.h3.lock().unwrap().inner;
+            (conn.is_closing(), conn.requests_in_flight())
+        };
+
+        if is_closing && requests_in_flight == 0 {
+            return Poll::Ready(Ok(()));
         }
 
         Poll::Pending

--- a/quinn-h3/src/headers.rs
+++ b/quinn-h3/src/headers.rs
@@ -8,7 +8,7 @@ use quinn_proto::StreamId;
 use crate::{
     connection::ConnectionRef,
     frame::WriteFrame,
-    proto::{frame::HeadersFrame, headers::Header},
+    proto::{frame::HeadersFrame, headers::Header, ErrorCode},
     Error,
 };
 
@@ -70,6 +70,10 @@ impl SendHeaders {
         };
 
         Ok(Self(WriteFrame::new(send, frame)))
+    }
+
+    pub fn reset(self, err_code: ErrorCode) {
+        self.0.reset(err_code);
     }
 }
 

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -23,14 +23,15 @@ mod frame;
 mod streams;
 
 use err_derive::Error;
-use quinn::VarInt;
 
-use proto::frame::SettingsFrame;
+use proto::{frame::SettingsFrame, ErrorCode};
 
 pub type Settings = SettingsFrame;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error(display = "Connection is closing, resquest aborted")]
+    Aborted,
     #[error(display = "H3 protocol error: {:?}", _0)]
     Proto(proto::connection::Error),
     #[error(display = "QUIC protocol error: {}", _0)]
@@ -102,43 +103,6 @@ fn try_take<T>(item: &mut Option<T>, msg: &'static str) -> Result<T, Error> {
 
 /// TLS ALPN value for H3
 pub const ALPN: &[u8] = b"h3-20";
-
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct ErrorCode(u32);
-
-macro_rules! error_codes {
-    {$($name:ident = $val:expr,)*} => {
-        impl ErrorCode {
-            $(pub const $name: ErrorCode = ErrorCode($val);)*
-        }
-    }
-}
-
-error_codes! {
-    NO_ERROR = 0x100,
-    GENERAL_PROTOCOL_ERROR = 0x101,
-    INTERNAL_ERROR = 0x102,
-    STREAM_CREATION_ERROR = 0x103,
-    CLOSED_CRITICAL_STREAM = 0x104,
-    FRAME_UNEXPECTED = 0x105,
-    FRAME_ERROR = 0x106,
-    EXCESSIVE_LOAD = 0x107,
-    ID_ERROR = 0x108,
-    SETTINGS_ERROR = 0x109,
-    MISSING_SETTINGS = 0x10A,
-    REQUEST_REJECTED = 0x10B,
-    REQUEST_CANCELLED = 0x10C,
-    REQUEST_INCOMPLETE = 0x10D,
-    EARLY_RESPONSE = 0x10E,
-    CONNECT_ERROR = 0x10F,
-    VERSION_FALLBACK = 0x110,
-}
-
-impl From<ErrorCode> for VarInt {
-    fn from(error: ErrorCode) -> VarInt {
-        error.0.into()
-    }
-}
 
 impl From<frame::Error> for (ErrorCode, String) {
     fn from(err: frame::Error) -> Self {

--- a/quinn-h3/src/proto/connection.rs
+++ b/quinn-h3/src/proto/connection.rs
@@ -1,8 +1,10 @@
+use std::collections::VecDeque;
+
 use bytes::{Bytes, BytesMut};
 use quinn_proto::StreamId;
 use std::convert::TryFrom;
 
-use crate::proto::frame::HeadersFrame;
+use crate::proto::frame::{HeadersFrame, HttpFrame};
 use crate::proto::headers::{self, Header};
 use crate::qpack::{self, DecoderError, DynamicTable, EncoderError, HeaderField};
 use crate::Settings;
@@ -16,6 +18,8 @@ pub struct Connection {
     pending_encoder: BytesMut,
     pending_decoder: BytesMut,
     pending_control: BytesMut,
+    requests_in_flight: VecDeque<StreamId>,
+    go_away: bool,
 }
 
 impl Connection {
@@ -37,6 +41,8 @@ impl Connection {
             encoder_table: DynamicTable::new(),
             pending_encoder: BytesMut::with_capacity(2048),
             pending_decoder: BytesMut::with_capacity(2048),
+            requests_in_flight: VecDeque::with_capacity(32),
+            go_away: false,
         })
     }
 
@@ -92,6 +98,39 @@ impl Connection {
         }
         Some(self.pending_control.take().freeze())
     }
+
+    pub fn request_initiated(&mut self, id: StreamId) {
+        if !self.go_away {
+            self.requests_in_flight.push_back(id);
+        }
+    }
+
+    pub fn request_finished(&mut self, id: StreamId) {
+        if !self.go_away {
+            self.requests_in_flight.push_back(id);
+        }
+    }
+
+    pub fn requests_in_flight(&self) -> usize {
+        self.requests_in_flight.len()
+    }
+
+    pub fn go_away(&mut self) {
+        if !self.go_away {
+            self.go_away = true;
+            let id = self.requests_in_flight.back().map(|i| i.0).unwrap_or(0) + 1;
+            HttpFrame::Goaway(id).encode(&mut self.pending_control);
+        }
+    }
+
+    pub fn leave(&mut self, id: StreamId) {
+        self.go_away = true;
+        self.requests_in_flight.retain(|i| i.0 <= id.0);
+    }
+
+    pub fn is_closing(&self) -> bool {
+        self.go_away
+    }
 }
 
 impl Default for Connection {
@@ -104,6 +143,8 @@ impl Default for Connection {
             pending_encoder: BytesMut::with_capacity(2048),
             pending_decoder: BytesMut::with_capacity(2048),
             pending_control: BytesMut::with_capacity(128),
+            requests_in_flight: VecDeque::with_capacity(32),
+            go_away: false,
         }
     }
 }

--- a/quinn-h3/src/proto/mod.rs
+++ b/quinn-h3/src/proto/mod.rs
@@ -42,3 +42,40 @@ impl StreamType {
         buf.freeze()
     }
 }
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct ErrorCode(pub(super) u32);
+
+macro_rules! error_codes {
+    {$($name:ident = $val:expr,)*} => {
+        impl ErrorCode {
+            $(pub const $name: ErrorCode = ErrorCode($val);)*
+        }
+    }
+}
+
+error_codes! {
+    NO_ERROR = 0x100,
+    GENERAL_PROTOCOL_ERROR = 0x101,
+    INTERNAL_ERROR = 0x102,
+    STREAM_CREATION_ERROR = 0x103,
+    CLOSED_CRITICAL_STREAM = 0x104,
+    FRAME_UNEXPECTED = 0x105,
+    FRAME_ERROR = 0x106,
+    EXCESSIVE_LOAD = 0x107,
+    ID_ERROR = 0x108,
+    SETTINGS_ERROR = 0x109,
+    MISSING_SETTINGS = 0x10A,
+    REQUEST_REJECTED = 0x10B,
+    REQUEST_CANCELLED = 0x10C,
+    REQUEST_INCOMPLETE = 0x10D,
+    EARLY_RESPONSE = 0x10E,
+    CONNECT_ERROR = 0x10F,
+    VERSION_FALLBACK = 0x110,
+}
+
+impl From<ErrorCode> for VarInt {
+    fn from(error: ErrorCode) -> VarInt {
+        error.0.into()
+    }
+}

--- a/quinn-h3/src/streams.rs
+++ b/quinn-h3/src/streams.rs
@@ -11,7 +11,7 @@ use quinn_proto::VarInt;
 use crate::{
     connection::ConnectionRef,
     frame::{FrameDecoder, FrameStream},
-    proto::StreamType,
+    proto::{ErrorCode, StreamType},
     Error,
 };
 
@@ -136,4 +136,8 @@ impl Future for SendControlStream {
             }
         }
     }
+}
+
+pub trait Reset {
+    fn reset(self, code: ErrorCode);
 }

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -22,18 +22,17 @@ tls-rustls = ["rustls", "webpki", "ring"]
 
 [dependencies]
 bytes = "0.4.7"
-err-derive = "0.1.5"
-fnv = "1.0.6"
+err-derive = "0.2"
 lazy_static = "1"
 rand = "0.7"
 ring = { version = "0.16.7", optional = true }
 rustls = { version = "0.16", features = ["quic"], optional = true }
 slab = "0.4"
-slog = "2.2"
+tracing = "0.1.10"
 webpki = { version = "0.21", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"
 hex-literal = "0.2.0"
 rcgen = "0.7"
-#slog = { version = "2.2", features = ["max_level_trace"] } # For debugging
+tracing-subscriber = "0.1.5"

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -40,18 +40,7 @@ impl coding::Codec for Type {
     }
 }
 
-impl slog::Value for Type {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
-    }
-}
-
-pub trait FrameStruct {
+pub(crate) trait FrameStruct {
     /// Smallest number of bytes this type of frame is guaranteed to fit within.
     const SIZE_BOUND: usize;
 }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -15,9 +15,6 @@
 #![warn(missing_docs)]
 #![cfg_attr(test, allow(dead_code))]
 
-#[macro_use]
-extern crate slog;
-
 use std::fmt;
 use std::net::SocketAddr;
 use std::ops;
@@ -126,17 +123,6 @@ impl ops::Not for Side {
     }
 }
 
-impl slog::Value for Side {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
-    }
-}
-
 /// Whether a stream communicates data in both directions or only from the initiator
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Dir {
@@ -162,17 +148,6 @@ impl fmt::Display for Dir {
     }
 }
 
-impl slog::Value for Dir {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
-    }
-}
-
 /// Identifier for a stream within a particular connection
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct StreamId(#[doc(hidden)] pub u64);
@@ -194,17 +169,6 @@ impl fmt::Display for StreamId {
             dir,
             self.index()
         )
-    }
-}
-
-impl slog::Value for StreamId {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
     }
 }
 

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -2,7 +2,6 @@ use std::{cmp::Ordering, io, ops::Range, str};
 
 use bytes::{BigEndian, Buf, BufMut, ByteOrder, Bytes, BytesMut};
 use err_derive::Error;
-use slog;
 
 use crate::coding::{self, BufExt, BufMutExt};
 use crate::shared::ConnectionId;
@@ -19,13 +18,13 @@ use crate::{crypto, MAX_CID_SIZE, VERSION};
 // to inspect the version and packet type (which depends on the version).
 // This information allows us to fully decode and decrypt the packet.
 #[derive(Debug)]
-pub struct PartialDecode {
+pub(crate) struct PartialDecode {
     plain_header: PlainHeader,
     buf: io::Cursor<BytesMut>,
 }
 
 impl PartialDecode {
-    pub fn new(
+    pub(crate) fn new(
         bytes: BytesMut,
         local_cid_len: usize,
     ) -> Result<(Self, Option<BytesMut>), PacketDecodeError> {
@@ -49,11 +48,11 @@ impl PartialDecode {
     }
 
     /// The underlying partially-decoded packet data
-    pub fn data(&self) -> &[u8] {
+    pub(crate) fn data(&self) -> &[u8] {
         &self.buf.get_ref()
     }
 
-    pub fn has_long_header(&self) -> bool {
+    pub(crate) fn has_long_header(&self) -> bool {
         use self::PlainHeader::*;
         match self.plain_header {
             Short { .. } => false,
@@ -61,11 +60,11 @@ impl PartialDecode {
         }
     }
 
-    pub fn is_initial(&self) -> bool {
+    pub(crate) fn is_initial(&self) -> bool {
         self.space() == Some(SpaceId::Initial)
     }
 
-    pub fn space(&self) -> Option<SpaceId> {
+    pub(crate) fn space(&self) -> Option<SpaceId> {
         use self::PlainHeader::*;
         match self.plain_header {
             Initial { .. } => Some(SpaceId::Initial),
@@ -82,23 +81,23 @@ impl PartialDecode {
         }
     }
 
-    pub fn is_0rtt(&self) -> bool {
+    pub(crate) fn is_0rtt(&self) -> bool {
         match self.plain_header {
             PlainHeader::Long { ty, .. } => ty == LongType::ZeroRtt,
             _ => false,
         }
     }
 
-    pub fn dst_cid(&self) -> ConnectionId {
+    pub(crate) fn dst_cid(&self) -> ConnectionId {
         self.plain_header.dst_cid()
     }
 
     /// Length of QUIC packet being decoded
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.buf.get_ref().len()
     }
 
-    pub fn finish<H>(self, header_crypto: Option<&H>) -> Result<Packet, PacketDecodeError>
+    pub(crate) fn finish<H>(self, header_crypto: Option<&H>) -> Result<Packet, PacketDecodeError>
     where
         H: crypto::HeaderKeys,
     {
@@ -185,7 +184,7 @@ impl PartialDecode {
         })
     }
 
-    fn decrypt_header<H>(
+    pub(crate) fn decrypt_header<H>(
         buf: &mut io::Cursor<BytesMut>,
         header_crypto: &H,
     ) -> Result<PacketNumber, PacketDecodeError>
@@ -207,14 +206,14 @@ impl PartialDecode {
     }
 }
 
-pub struct Packet {
-    pub header: Header,
-    pub header_data: Bytes,
-    pub payload: BytesMut,
+pub(crate) struct Packet {
+    pub(crate) header: Header,
+    pub(crate) header_data: Bytes,
+    pub(crate) payload: BytesMut,
 }
 
 #[derive(Debug, Clone)]
-pub enum Header {
+pub(crate) enum Header {
     Initial {
         dst_cid: ConnectionId,
         src_cid: ConnectionId,
@@ -246,7 +245,7 @@ pub enum Header {
 }
 
 impl Header {
-    pub fn encode(&self, w: &mut Vec<u8>) -> PartialEncode {
+    pub(crate) fn encode(&self, w: &mut Vec<u8>) -> PartialEncode {
         use self::Header::*;
         let start = w.len();
         match *self {
@@ -347,14 +346,14 @@ impl Header {
     }
 
     /// Whether the packet is encrypted on the wire
-    pub fn is_protected(&self) -> bool {
+    pub(crate) fn is_protected(&self) -> bool {
         match *self {
             Header::Retry { .. } | Header::VersionNegotiate { .. } => false,
             _ => true,
         }
     }
 
-    pub fn number(&self) -> Option<PacketNumber> {
+    pub(crate) fn number(&self) -> Option<PacketNumber> {
         use self::Header::*;
         Some(match *self {
             Initial { number, .. } => number,
@@ -366,7 +365,7 @@ impl Header {
         })
     }
 
-    pub fn space(&self) -> SpaceId {
+    pub(crate) fn space(&self) -> SpaceId {
         use self::Header::*;
         match *self {
             Short { .. } => SpaceId::Data,
@@ -382,25 +381,25 @@ impl Header {
         }
     }
 
-    pub fn key_phase(&self) -> bool {
+    pub(crate) fn key_phase(&self) -> bool {
         match *self {
             Header::Short { key_phase, .. } => key_phase,
             _ => false,
         }
     }
 
-    pub fn is_short(&self) -> bool {
+    pub(crate) fn is_short(&self) -> bool {
         match *self {
             Header::Short { .. } => true,
             _ => false,
         }
     }
 
-    pub fn is_1rtt(&self) -> bool {
+    pub(crate) fn is_1rtt(&self) -> bool {
         self.is_short()
     }
 
-    pub fn is_0rtt(&self) -> bool {
+    pub(crate) fn is_0rtt(&self) -> bool {
         match *self {
             Header::Long {
                 ty: LongType::ZeroRtt,
@@ -410,7 +409,7 @@ impl Header {
         }
     }
 
-    pub fn dst_cid(&self) -> &ConnectionId {
+    pub(crate) fn dst_cid(&self) -> &ConnectionId {
         use self::Header::*;
         match *self {
             Initial { ref dst_cid, .. } => dst_cid,
@@ -422,9 +421,9 @@ impl Header {
     }
 }
 
-pub struct PartialEncode {
-    pub start: usize,
-    pub header_len: usize,
+pub(crate) struct PartialEncode {
+    pub(crate) start: usize,
+    pub(crate) header_len: usize,
     // Packet number length, payload length needed
     pn: Option<(usize, bool)>,
 }
@@ -462,7 +461,7 @@ impl PartialEncode {
 }
 
 #[derive(Debug)]
-pub enum PlainHeader {
+pub(crate) enum PlainHeader {
     Initial {
         dst_cid: ConnectionId,
         src_cid: ConnectionId,
@@ -605,7 +604,7 @@ impl PlainHeader {
 
 // An encoded packet number
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum PacketNumber {
+pub(crate) enum PacketNumber {
     U8(u8),
     U16(u16),
     U24(u32),
@@ -613,7 +612,7 @@ pub enum PacketNumber {
 }
 
 impl PacketNumber {
-    pub fn new(n: u64, largest_acked: u64) -> Self {
+    pub(crate) fn new(n: u64, largest_acked: u64) -> Self {
         let range = (n - largest_acked) * 2;
         if range < 1 << 8 {
             PacketNumber::U8(n as u8)
@@ -628,7 +627,7 @@ impl PacketNumber {
         }
     }
 
-    pub fn len(self) -> usize {
+    pub(crate) fn len(self) -> usize {
         use self::PacketNumber::*;
         match self {
             U8(_) => 1,
@@ -638,7 +637,7 @@ impl PacketNumber {
         }
     }
 
-    pub fn encode<W: BufMut>(self, w: &mut W) {
+    pub(crate) fn encode<W: BufMut>(self, w: &mut W) {
         use self::PacketNumber::*;
         match self {
             U8(x) => w.write(x),
@@ -648,7 +647,7 @@ impl PacketNumber {
         }
     }
 
-    pub fn decode<R: Buf>(len: usize, r: &mut R) -> Result<PacketNumber, PacketDecodeError> {
+    pub(crate) fn decode<R: Buf>(len: usize, r: &mut R) -> Result<PacketNumber, PacketDecodeError> {
         use self::PacketNumber::*;
         let pn = match len {
             1 => U8(r.get()?),
@@ -660,7 +659,7 @@ impl PacketNumber {
         Ok(pn)
     }
 
-    pub fn decode_len(tag: u8) -> usize {
+    pub(crate) fn decode_len(tag: u8) -> usize {
         1 + (tag & 0x03) as usize
     }
 
@@ -674,7 +673,7 @@ impl PacketNumber {
         }
     }
 
-    pub fn expand(self, expected: u64) -> u64 {
+    pub(crate) fn expand(self, expected: u64) -> u64 {
         // From Appendix A
         use self::PacketNumber::*;
         let truncated = match self {
@@ -708,7 +707,7 @@ impl PacketNumber {
 
 /// Long packet type including non-uniform cases
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum LongHeaderType {
+pub(crate) enum LongHeaderType {
     Initial,
     Retry,
     Standard(LongType),
@@ -743,37 +742,15 @@ impl From<LongHeaderType> for u8 {
     }
 }
 
-impl slog::Value for LongHeaderType {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
-    }
-}
-
 /// Long packet types with uniform header structure
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum LongType {
+pub(crate) enum LongType {
     Handshake,
     ZeroRtt,
 }
 
-impl slog::Value for LongType {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
-    }
-}
-
 #[derive(Debug, Error, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum PacketDecodeError {
+pub(crate) enum PacketDecodeError {
     #[error(display = "unsupported version")]
     UnsupportedVersion {
         source: ConnectionId,
@@ -789,11 +766,11 @@ impl From<coding::UnexpectedEnd> for PacketDecodeError {
     }
 }
 
-pub const LONG_HEADER_FORM: u8 = 0x80;
+pub(crate) const LONG_HEADER_FORM: u8 = 0x80;
 const FIXED_BIT: u8 = 0x40;
-pub const SPIN_BIT: u8 = 0x20;
-pub const SHORT_RESERVED_BITS: u8 = 0x18;
-pub const LONG_RESERVED_BITS: u8 = 0x0c;
+pub(crate) const SPIN_BIT: u8 = 0x20;
+pub(crate) const SHORT_RESERVED_BITS: u8 = 0x18;
+pub(crate) const LONG_RESERVED_BITS: u8 = 0x0c;
 const KEY_PHASE_BIT: u8 = 0x04;
 
 /// Packet number space identifiers
@@ -811,17 +788,6 @@ impl SpaceId {
         [SpaceId::Initial, SpaceId::Handshake, SpaceId::Data]
             .iter()
             .cloned()
-    }
-}
-
-impl slog::Value for SpaceId {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
     }
 }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use hex_literal::hex;
 use rand::RngCore;
 use rustls::internal::msgs::enums::AlertDescription;
+use tracing::info;
 
 use super::*;
 mod util;
@@ -15,14 +16,9 @@ use util::*;
 
 #[test]
 fn version_negotiate_server() {
-    let log = logger();
+    let _guard = subscribe();
     let client_addr = "[::2]:7890".parse().unwrap();
-    let mut server = Endpoint::new(
-        log.new(o!("peer" => "server")),
-        Default::default(),
-        Some(Arc::new(server_config())),
-    )
-    .unwrap();
+    let mut server = Endpoint::new(Default::default(), Some(Arc::new(server_config()))).unwrap();
     let now = Instant::now();
     let event = server.handle(
         now,
@@ -47,10 +43,9 @@ fn version_negotiate_server() {
 
 #[test]
 fn version_negotiate_client() {
-    let log = logger();
+    let _guard = subscribe();
     let server_addr = "[::2]:7890".parse().unwrap();
     let mut client = Endpoint::new(
-        log.new(o!("peer" => "client")),
         Arc::new(EndpointConfig {
             local_cid_len: 0,
             ..Default::default()
@@ -86,6 +81,7 @@ fn version_negotiate_client() {
 
 #[test]
 fn lifecycle() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
@@ -93,7 +89,7 @@ fn lifecycle() {
     assert!(pair.server_conn_mut(server_ch).using_ecn());
 
     const REASON: &[u8] = b"whee";
-    info!(pair.log, "closing");
+    info!("closing");
     pair.client.connections.get_mut(&client_ch).unwrap().close(
         pair.time,
         VarInt(42),
@@ -113,6 +109,7 @@ fn lifecycle() {
 
 #[test]
 fn stateless_retry() {
+    let _guard = subscribe();
     let mut pair = Pair::new(
         Default::default(),
         ServerConfig {
@@ -125,6 +122,7 @@ fn stateless_retry() {
 
 #[test]
 fn server_stateless_reset() {
+    let _guard = subscribe();
     let mut reset_key = vec![0; 64];
     let mut rng = rand::thread_rng();
     rng.fill_bytes(&mut reset_key);
@@ -136,19 +134,14 @@ fn server_stateless_reset() {
 
     let mut pair = Pair::new(endpoint_config.clone(), server_config());
     let (client_ch, _) = pair.connect();
-    pair.server.endpoint = Endpoint::new(
-        pair.log.new(o!("side" => "Server")),
-        endpoint_config,
-        Some(Arc::new(server_config())),
-    )
-    .unwrap();
+    pair.server.endpoint = Endpoint::new(endpoint_config, Some(Arc::new(server_config()))).unwrap();
     // Send something big enough to allow room for a smaller stateless reset.
     pair.client.connections.get_mut(&client_ch).unwrap().close(
         pair.time,
         VarInt(42),
         (&[0xab; 128][..]).into(),
     );
-    info!(pair.log, "resetting");
+    info!("resetting");
     pair.drive();
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
@@ -160,6 +153,7 @@ fn server_stateless_reset() {
 
 #[test]
 fn client_stateless_reset() {
+    let _guard = subscribe();
     let mut reset_key = vec![0; 64];
     let mut rng = rand::thread_rng();
     rng.fill_bytes(&mut reset_key);
@@ -171,19 +165,14 @@ fn client_stateless_reset() {
 
     let mut pair = Pair::new(endpoint_config.clone(), server_config());
     let (_, server_ch) = pair.connect();
-    pair.client.endpoint = Endpoint::new(
-        pair.log.new(o!("side" => "Client")),
-        endpoint_config,
-        Some(Arc::new(server_config())),
-    )
-    .unwrap();
+    pair.client.endpoint = Endpoint::new(endpoint_config, Some(Arc::new(server_config()))).unwrap();
     // Send something big enough to allow room for a smaller stateless reset.
     pair.server.connections.get_mut(&server_ch).unwrap().close(
         pair.time,
         VarInt(42),
         (&[0xab; 128][..]).into(),
     );
-    info!(pair.log, "resetting");
+    info!("resetting");
     pair.drive();
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
@@ -195,6 +184,7 @@ fn client_stateless_reset() {
 
 #[test]
 fn finish_stream() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
@@ -225,6 +215,7 @@ fn finish_stream() {
 
 #[test]
 fn reset_stream() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
@@ -234,7 +225,7 @@ fn reset_stream() {
     pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive();
 
-    info!(pair.log, "resetting stream");
+    info!("resetting stream");
     const ERROR: VarInt = VarInt(42);
     pair.client_conn_mut(client_ch).reset(s, ERROR);
     pair.drive();
@@ -253,6 +244,7 @@ fn reset_stream() {
 
 #[test]
 fn stop_stream() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
@@ -261,7 +253,7 @@ fn stop_stream() {
     pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive();
 
-    info!(pair.log, "stopping stream");
+    info!("stopping stream");
     const ERROR: VarInt = VarInt(42);
     pair.server_conn_mut(server_ch)
         .stop_sending(s, ERROR)
@@ -290,8 +282,9 @@ fn stop_stream() {
 
 #[test]
 fn reject_self_signed_cert() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
-    info!(pair.log, "connecting");
+    info!("connecting");
     let client_ch = pair.begin_connect(ClientConfig::default());
     pair.drive();
     assert_matches!(pair.client_conn_mut(client_ch).poll(),
@@ -301,6 +294,7 @@ fn reject_self_signed_cert() {
 
 #[test]
 fn congestion() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, _) = pair.connect();
 
@@ -329,6 +323,7 @@ fn congestion() {
 
 #[test]
 fn high_latency_handshake() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     pair.latency = Duration::from_micros(200 * 1000);
     let (client_ch, server_ch) = pair.connect();
@@ -340,6 +335,7 @@ fn high_latency_handshake() {
 
 #[test]
 fn zero_rtt_happypath() {
+    let _guard = subscribe();
     let mut pair = Pair::new(
         Default::default(),
         ServerConfig {
@@ -364,7 +360,7 @@ fn zero_rtt_happypath() {
         Ipv6Addr::LOCALHOST.into(),
         CLIENT_PORTS.lock().unwrap().next().unwrap(),
     );
-    info!(pair.log, "resuming session");
+    info!("resuming session");
     let client_ch = pair.begin_connect(config.clone());
     assert!(pair.client_conn_mut(client_ch).has_0rtt());
     let s = pair.client_conn_mut(client_ch).open(Dir::Uni).unwrap();
@@ -382,6 +378,7 @@ fn zero_rtt_happypath() {
 
 #[test]
 fn zero_rtt_rejection() {
+    let _guard = subscribe();
     let mut server_config = server_config();
     Arc::get_mut(&mut server_config.crypto)
         .unwrap()
@@ -419,7 +416,7 @@ fn zero_rtt_rejection() {
     Arc::get_mut(&mut client_config.crypto)
         .unwrap()
         .set_protocols(&["bar".into()]);
-    info!(pair.log, "resuming session");
+    info!("resuming session");
     let client_ch = pair.begin_connect(client_config);
     assert!(pair.client_conn_mut(client_ch).has_0rtt());
     let s = pair.client_conn_mut(client_ch).open(Dir::Uni).unwrap();
@@ -444,6 +441,7 @@ fn zero_rtt_rejection() {
 
 #[test]
 fn alpn_success() {
+    let _guard = subscribe();
     let mut server_config = server_config();
     Arc::get_mut(&mut server_config.crypto)
         .unwrap()
@@ -470,6 +468,7 @@ fn alpn_success() {
 
 #[test]
 fn stream_id_backpressure() {
+    let _guard = subscribe();
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
             stream_window_uni: 1,
@@ -536,6 +535,7 @@ fn stream_id_backpressure() {
 
 #[test]
 fn key_update() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
     let s = pair
@@ -580,6 +580,7 @@ fn key_update() {
 
 #[test]
 fn key_update_reordered() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
     let s = pair
@@ -592,16 +593,16 @@ fn key_update_reordered() {
 
     const MSG1: &[u8] = b"1";
     pair.client_conn_mut(client_ch).write(s, MSG1).unwrap();
-    pair.client.drive(&pair.log, pair.time, pair.server.addr);
+    pair.client.drive(pair.time, pair.server.addr);
     assert!(!pair.client.outbound.is_empty());
     pair.client.delay_outbound();
 
     pair.client_conn_mut(client_ch).initiate_key_update();
-    info!(pair.log, "updated keys");
+    info!("updated keys");
 
     const MSG2: &[u8] = b"two";
     pair.client_conn_mut(client_ch).write(s, MSG2).unwrap();
-    pair.client.drive(&pair.log, pair.time, pair.server.addr);
+    pair.client.drive(pair.time, pair.server.addr);
     pair.client.finish_delay();
     pair.drive();
 
@@ -623,9 +624,10 @@ fn key_update_reordered() {
 
 #[test]
 fn initial_retransmit() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let client_ch = pair.begin_connect(client_config());
-    pair.client.drive(&pair.log, pair.time, pair.server.addr);
+    pair.client.drive(pair.time, pair.server.addr);
     pair.client.outbound.clear(); // Drop initial
     pair.drive();
     assert_matches!(
@@ -636,8 +638,9 @@ fn initial_retransmit() {
 
 #[test]
 fn instant_close() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
-    info!(pair.log, "connecting");
+    info!("connecting");
     let client_ch = pair.begin_connect(client_config());
     pair.client
         .connections
@@ -656,8 +659,9 @@ fn instant_close() {
 
 #[test]
 fn instant_close_2() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
-    info!(pair.log, "connecting");
+    info!("connecting");
     let client_ch = pair.begin_connect(client_config());
     // Unlike `instant_close`, the server sees a valid Initial packet first.
     pair.drive_client();
@@ -678,6 +682,7 @@ fn instant_close_2() {
 
 #[test]
 fn idle_timeout() {
+    let _guard = subscribe();
     const IDLE_TIMEOUT: u64 = 10;
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
@@ -719,6 +724,7 @@ fn idle_timeout() {
 
 #[test]
 fn server_busy() {
+    let _guard = subscribe();
     let mut pair = Pair::new(
         Default::default(),
         ServerConfig {
@@ -748,6 +754,7 @@ fn server_busy() {
 
 #[test]
 fn server_hs_retransmit() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let client_ch = pair.begin_connect(client_config());
     pair.step();
@@ -762,6 +769,7 @@ fn server_hs_retransmit() {
 
 #[test]
 fn migration() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
     pair.client.addr = SocketAddr::new(
@@ -775,6 +783,7 @@ fn migration() {
 }
 
 fn test_flow_control(config: TransportConfig, window_size: usize) {
+    let _guard = subscribe();
     let mut pair = Pair::new(
         Default::default(),
         ServerConfig {
@@ -898,6 +907,7 @@ fn conn_flow_control() {
 
 #[test]
 fn stop_opens_bidi() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_conn, server_conn) = pair.connect();
     let s = pair.client_conn_mut(client_conn).open(Dir::Bi).unwrap();
@@ -927,6 +937,7 @@ fn stop_opens_bidi() {
 
 #[test]
 fn implicit_open() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_conn, server_conn) = pair.connect();
     let s1 = pair.client_conn_mut(client_conn).open(Dir::Uni).unwrap();
@@ -946,6 +957,7 @@ fn implicit_open() {
 
 #[test]
 fn zero_length_cid() {
+    let _guard = subscribe();
     let mut pair = Pair::new(
         Arc::new(EndpointConfig {
             local_cid_len: 0,
@@ -955,7 +967,7 @@ fn zero_length_cid() {
     );
     let (client_ch, server_ch) = pair.connect();
     // Ensure we can reconnect after a previous connection is cleaned up
-    info!(pair.log, "closing");
+    info!("closing");
     pair.client
         .connections
         .get_mut(&client_ch)
@@ -972,6 +984,7 @@ fn zero_length_cid() {
 
 #[test]
 fn keep_alive() {
+    let _guard = subscribe();
     const IDLE_TIMEOUT: u64 = 10_000;
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
@@ -998,6 +1011,7 @@ fn keep_alive() {
 
 #[test]
 fn finish_stream_flow_control_reordered() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
@@ -1006,19 +1020,19 @@ fn finish_stream_flow_control_reordered() {
     const MSG: &[u8] = b"hello";
     pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive_client(); // Send stream data
-    pair.server.drive(&pair.log, pair.time, pair.client.addr); // Receive
+    pair.server.drive(pair.time, pair.client.addr); // Receive
 
     // Issue flow control credit
     assert_matches!(
         pair.server_conn_mut(server_ch).read_unordered(s),
         Ok(Some((ref data, 0))) if data == MSG
     );
-    pair.server.drive(&pair.log, pair.time, pair.client.addr);
+    pair.server.drive(pair.time, pair.client.addr);
     pair.server.delay_outbound(); // Delay it
 
     pair.client_conn_mut(client_ch).finish(s).unwrap();
     pair.drive_client(); // Send FIN
-    pair.server.drive(&pair.log, pair.time, pair.client.addr); // Acknowledge
+    pair.server.drive(pair.time, pair.client.addr); // Acknowledge
     pair.server.finish_delay(); // Add flow control packets after
     pair.drive();
 
@@ -1037,6 +1051,7 @@ fn finish_stream_flow_control_reordered() {
 
 #[test]
 fn handshake_1rtt_handling() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let client_ch = pair.begin_connect(client_config());
     pair.drive_client();
@@ -1044,7 +1059,7 @@ fn handshake_1rtt_handling() {
     let server_ch = pair.server.assert_accept();
     // Server now has 1-RTT keys, but remains in Handshake state until the TLS CFIN has
     // authenticated the client. Delay the final client handshake flight so that doesn't happen yet.
-    pair.client.drive(&pair.log, pair.time, pair.server.addr);
+    pair.client.drive(pair.time, pair.server.addr);
     pair.client.delay_outbound();
 
     // Send some 1-RTT data which will be received first.
@@ -1052,7 +1067,7 @@ fn handshake_1rtt_handling() {
     const MSG: &[u8] = b"hello";
     pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.client_conn_mut(client_ch).finish(s).unwrap();
-    pair.client.drive(&pair.log, pair.time, pair.server.addr);
+    pair.client.drive(pair.time, pair.server.addr);
 
     // Add the handshake flight back on.
     pair.client.finish_delay();
@@ -1068,6 +1083,7 @@ fn handshake_1rtt_handling() {
 
 #[test]
 fn stop_before_finish() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
@@ -1076,7 +1092,7 @@ fn stop_before_finish() {
     pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
     pair.drive();
 
-    info!(pair.log, "stopping stream");
+    info!("stopping stream");
     const ERROR: VarInt = VarInt(42);
     pair.server_conn_mut(server_ch)
         .stop_sending(s, ERROR)
@@ -1091,6 +1107,7 @@ fn stop_before_finish() {
 
 #[test]
 fn stop_during_finish() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
@@ -1100,7 +1117,7 @@ fn stop_during_finish() {
     pair.drive();
 
     assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
-    info!(pair.log, "stopping and finishing stream");
+    info!("stopping and finishing stream");
     const ERROR: VarInt = VarInt(42);
     pair.server_conn_mut(server_ch)
         .stop_sending(s, ERROR)
@@ -1117,6 +1134,7 @@ fn stop_during_finish() {
 // Ensure we can recover from loss of tail packets when the congestion window is full
 #[test]
 fn congested_tail_loss() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, _) = pair.connect();
 
@@ -1147,6 +1165,7 @@ fn congested_tail_loss() {
 
 #[test]
 fn datagram_send_recv() {
+    let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
@@ -1172,10 +1191,11 @@ fn datagram_send_recv() {
 
 #[test]
 fn datagram_window() {
+    let _guard = subscribe();
     const WINDOW: usize = 100;
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            datagram_window: Some(WINDOW),
+            datagram_receive_buffer_size: Some(WINDOW),
             ..TransportConfig::default()
         }),
         ..server_config()
@@ -1236,9 +1256,10 @@ fn datagram_window() {
 
 #[test]
 fn datagram_unsupported() {
+    let _guard = subscribe();
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            datagram_window: None,
+            datagram_receive_buffer_size: None,
             ..TransportConfig::default()
         }),
         ..server_config()

--- a/quinn-proto/src/timer.rs
+++ b/quinn-proto/src/timer.rs
@@ -6,7 +6,7 @@ use std::slice;
 pub struct Timer(pub(crate) TimerKind);
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub enum TimerKind {
+pub(crate) enum TimerKind {
     /// When to send an ack-eliciting probe packet or declare unacked packets lost
     LossDetection = 0,
     /// When to close the connection after no activity
@@ -134,16 +134,5 @@ impl<T> Index<Timer> for TimerTable<T> {
 impl<T> IndexMut<Timer> for TimerTable<T> {
     fn index_mut(&mut self, index: Timer) -> &mut T {
         &mut self.data[index.0 as usize]
-    }
-}
-
-impl slog::Value for Timer {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self.0))
     }
 }

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use bytes::{Buf, BufMut};
-use slog;
 
 use crate::coding::{self, BufExt, BufMutExt};
 use crate::frame;
@@ -30,6 +29,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 impl From<Code> for Error {
     fn from(x: Code) -> Self {
         Self {
@@ -37,17 +38,6 @@ impl From<Code> for Error {
             frame: None,
             reason: "".to_string(),
         }
-    }
-}
-
-impl slog::Value for Error {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
     }
 }
 
@@ -116,17 +106,6 @@ macro_rules! errors {
                 f.write_str(x)
             }
         }
-    }
-}
-
-impl slog::Value for Code {
-    fn serialize(
-        &self,
-        _: &slog::Record<'_>,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{:?}", self))
     }
 }
 

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -89,7 +89,7 @@ impl TransportParameters {
             disable_active_migration: server_config.map_or(false, |c| !c.migration),
             active_connection_id_limit: REM_CID_COUNT,
             max_datagram_frame_size: config
-                .datagram_window
+                .datagram_receive_buffer_size
                 .map(|x| (x.min(u16::max_value().into()) as u16).into()),
             ..Self::default()
         }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -22,19 +22,19 @@ azure-devops = { project = "dochtman/Projects", pipeline = "Quinn", build = "1" 
 [dependencies]
 bytes = "0.4.7"
 ct-logs = "0.6"
-err-derive = "0.1.5"
+err-derive = "0.2"
 fnv = "1.0.6"
 futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
 libc = "0.2.49"
 mio = "0.6"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.4.0" }
 rustls = { version = "0.16", features = ["quic"] }
-slog = "2.1"
+tracing = "0.1.10"
 tokio-net = { version = "0.2.0-alpha.5", default-features = false }
 tokio-timer = "0.3.0-alpha.5"
 tokio-io = "0.2.0-alpha.5"
 webpki = "0.21"
-webpki-roots = "0.17"
+webpki-roots = "0.18"
 
 [dev-dependencies]
 crc = "1.8.1"
@@ -43,7 +43,8 @@ directories = "2.0.0"
 failure = "0.1"
 rand = "0.7"
 rcgen = "0.7"
-slog-term = "2"
+tracing-subscriber = "0.1.5"
+tracing-futures = { version = "0.1.0", default-features = false, features = ["std-future"] }
 structopt = "0.3.0"
 tokio = "0.2.0-alpha.5"
 unwrap = "1.2.1"

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -1,150 +1,181 @@
-use std::cell::RefCell;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, UdpSocket};
-use std::rc::Rc;
+use std::sync::Arc;
+use std::thread;
 
-use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion, Throughput};
-use futures::{StreamExt, TryFutureExt};
-use tokio;
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use futures::StreamExt;
+use tokio::runtime::current_thread::Runtime;
+use tracing::error_span;
+use tracing_futures::Instrument as _;
 
-use quinn::{ClientConfigBuilder, Endpoint, ReadError, RecvStream, ServerConfigBuilder};
+use quinn::{ClientConfigBuilder, Endpoint, ServerConfigBuilder};
 
 criterion_group!(benches, throughput);
 criterion_main!(benches);
 
 fn throughput(c: &mut Criterion) {
-    let mut server_config = ServerConfigBuilder::default();
-    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-    let key = quinn::PrivateKey::from_der(&cert.serialize_private_key_der()).unwrap();
-    let cert = quinn::Certificate::from_der(&cert.serialize_der().unwrap()).unwrap();
-    let cert_chain = quinn::CertificateChain::from_certs(vec![cert.clone()]);
-    server_config.certificate(cert_chain, key).unwrap();
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .finish(),
+    )
+    .unwrap();
 
-    let mut server = Endpoint::builder();
-    server.listen(server_config.build());
-    let server_sock = UdpSocket::bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0)).unwrap();
-    let server_addr = server_sock.local_addr().unwrap();
-    let (server_driver, _, mut server_incoming) = server.with_socket(server_sock).unwrap();
-
-    let mut client_config = ClientConfigBuilder::default();
-    client_config.add_certificate_authority(cert).unwrap();
-    client_config.enable_keylog();
-    let mut client = Endpoint::builder();
-    client.default_client_config(client_config.build());
-    let (client_driver, client, _) = client
-        .bind(&SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0))
-        .unwrap();
-
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-    runtime.spawn(server_driver.unwrap_or_else(|e| panic!("server driver failed: {}", e)));
-    runtime.spawn(client_driver.unwrap_or_else(|e| panic!("client driver failed: {}", e)));
-
-    let runtime = Rc::new(RefCell::new(runtime));
-    runtime.borrow_mut().spawn(async move {
-        while let Some(connecting) = server_incoming.next().await {
-            let mut new_conn = connecting.await.unwrap();
-            tokio::runtime::current_thread::spawn(
-                new_conn
-                    .driver
-                    .unwrap_or_else(|e| ignore_timeout("server connection driver", e)),
-            );
-            while let Some(Ok(stream)) = new_conn.uni_streams.next().await {
-                read_all(stream).await.unwrap();
-            }
-        }
-    });
-
-    let new_conn = runtime
-        .borrow_mut()
-        .block_on(client.connect(&server_addr, "localhost").unwrap())
-        .unwrap();
-    let driver = new_conn.driver;
-    let connection = new_conn.connection;
-
-    runtime
-        .borrow_mut()
-        .spawn(driver.unwrap_or_else(|e| ignore_timeout("client connection driver", e)));
+    let ctx = Context::new();
+    let mut group = c.benchmark_group("throughput");
+    {
+        let (addr, thread) = ctx.spawn_server();
+        let (client, mut runtime) = ctx.make_client(addr);
+        const DATA: &[u8] = &[0xAB; 128 * 1024];
+        group.throughput(Throughput::Bytes(DATA.len() as u64));
+        group.bench_function("large streams", |b| {
+            b.iter(|| {
+                runtime.block_on(async {
+                    let mut stream = client.open_uni().await.unwrap();
+                    stream.write_all(DATA).await.unwrap();
+                    stream.finish().await.unwrap();
+                });
+            })
+        });
+        drop(client);
+        runtime.run().unwrap();
+        thread.join().unwrap();
+    }
 
     {
-        const DATA: &[u8] = &[0xAB; 128 * 1024];
-        let runtime = runtime.clone();
-        c.bench(
-            "throughput",
-            Benchmark::new("128kB", move |b| {
-                b.iter_batched(
-                    || {
-                        runtime
-                            .borrow_mut()
-                            .block_on(connection.open_uni())
-                            .expect("failed opening stream")
-                    },
-                    |mut stream| {
-                        runtime.borrow_mut().block_on(async move {
-                            stream.write_all(DATA).await.expect("write failed");
-                            stream.finish().await.unwrap();
-                        })
-                    },
-                    BatchSize::PerIteration,
-                )
+        let (addr, thread) = ctx.spawn_server();
+        let (client, mut runtime) = ctx.make_client(addr);
+        const DATA: &[u8] = &[0xAB; 1];
+        group.throughput(Throughput::Elements(1));
+        group.bench_function("small streams", |b| {
+            b.iter(|| {
+                runtime.block_on(async {
+                    let mut stream = client.open_uni().await.unwrap();
+                    stream.write_all(DATA).await.unwrap();
+                });
             })
-            .throughput(Throughput::Bytes(DATA.len() as u64)),
-        );
+        });
+        drop(client);
+        runtime.run().unwrap();
+        thread.join().unwrap();
     }
 
-    /*
-        let (driver, connection, _) = runtime
-            .borrow_mut()
-            .block_on(client.connect(&server_addr, "localhost").unwrap())
-            .unwrap();
+    {
+        let (addr, thread) = ctx.spawn_server();
+        let (client, mut runtime) = ctx.make_client(addr);
+        let data = Bytes::from(&[0xAB; 1][..]);
+        group.throughput(Throughput::Elements(1));
+        group.bench_function("small datagrams", |b| {
+            b.iter(|| {
+                runtime.block_on(async {
+                    client.send_datagram(data.clone()).await.unwrap();
+                });
+            })
+        });
+        drop(client);
+        runtime.run().unwrap();
+        thread.join().unwrap();
+    }
 
-        runtime
-            .borrow_mut()
-            .spawn(driver.map_err(|e| ignore_timeout("client connection driver", e)));
+    group.finish();
+}
 
-        {
-            const DATA: &[u8] = &[0xAB; 32];
-            let runtime = runtime.clone();
-            c.bench(
-                "throughput",
-                Benchmark::new("32B", move |b| {
-                    b.iter_batched(
-                        || {
-                            runtime
-                                .borrow_mut()
-                                .block_on(connection.open_uni())
-                                .expect("failed opening stream")
-                        },
-                        |stream| {
-                            runtime
-                                .borrow_mut()
-                                .block_on(
-                                    tokio::io::write_all(stream, DATA)
-                                        .map_err(|e| panic!("write to stream failed: {}", e))
-                                        .and_then(|(stream, _)| {
-                                            tokio::io::shutdown(stream).map_err(|e| {
-                                                panic!("send stream shutdown failed: {}", e)
-                                            })
-                                        }),
-                                )
-                                .expect("failed writing data")
-                        },
-                        BatchSize::PerIteration,
-                    )
-                })
-                .throughput(Throughput::Bytes(DATA.len() as u32)),
-            );
+struct Context {
+    server_config: quinn::ServerConfig,
+    client_config: quinn::ClientConfig,
+}
+
+impl Context {
+    fn new() -> Self {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        let key = quinn::PrivateKey::from_der(&cert.serialize_private_key_der()).unwrap();
+        let cert = quinn::Certificate::from_der(&cert.serialize_der().unwrap()).unwrap();
+        let cert_chain = quinn::CertificateChain::from_certs(vec![cert.clone()]);
+
+        let server_config = quinn::ServerConfig {
+            transport: Arc::new(quinn::TransportConfig {
+                stream_window_uni: 1024,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut server_config = ServerConfigBuilder::new(server_config);
+        server_config.certificate(cert_chain, key).unwrap();
+
+        let mut client_config = ClientConfigBuilder::default();
+        client_config.add_certificate_authority(cert).unwrap();
+
+        Self {
+            server_config: server_config.build(),
+            client_config: client_config.build(),
         }
-    */
-}
-
-fn ignore_timeout(ty: &'static str, e: quinn::ConnectionError) {
-    use quinn::ConnectionError::*;
-    match e {
-        TimedOut => (),
-        e => panic!("{} failed: {:?}", ty, e),
     }
-}
 
-async fn read_all(mut stream: RecvStream) -> Result<(), ReadError> {
-    while let Some(_) = stream.read_unordered().await? {}
-    Ok(())
+    pub fn spawn_server(&self) -> (SocketAddr, thread::JoinHandle<()>) {
+        let sock = UdpSocket::bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0)).unwrap();
+        let addr = sock.local_addr().unwrap();
+        let config = self.server_config.clone();
+        let handle = thread::spawn(move || {
+            let mut endpoint = Endpoint::builder();
+            endpoint.listen(config);
+            let (driver, _, mut incoming) = endpoint.with_socket(sock).unwrap();
+            let mut runtime = Runtime::new().unwrap();
+            runtime.spawn(async { driver.instrument(error_span!("server")).await.unwrap() });
+            runtime.spawn(
+                async move {
+                    let quinn::NewConnection {
+                        driver,
+                        mut uni_streams,
+                        ..
+                    } = incoming
+                        .next()
+                        .await
+                        .expect("accept")
+                        .await
+                        .expect("connect");
+                    tokio::spawn(async move {
+                        match driver.instrument(error_span!("server")).await {
+                            Ok(()) => panic!("unexpected success"),
+                            Err(quinn::ConnectionError::ApplicationClosed { .. }) => {}
+                            Err(e) => panic!("connection lost: {}", e),
+                        }
+                    });
+                    while let Some(Ok(mut stream)) = uni_streams.next().await {
+                        while let Some(_) = stream.read_unordered().await.unwrap() {}
+                    }
+                }
+                    .instrument(error_span!("server")),
+            );
+            runtime.run().unwrap();
+        });
+        (addr, handle)
+    }
+
+    pub fn make_client(&self, server_addr: SocketAddr) -> (quinn::Connection, Runtime) {
+        let (endpoint_driver, endpoint, _) = Endpoint::builder()
+            .bind(&SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0))
+            .unwrap();
+        let mut runtime = Runtime::new().unwrap();
+        runtime.spawn(async move {
+            endpoint_driver
+                .instrument(error_span!("client"))
+                .await
+                .unwrap();
+        });
+        let quinn::NewConnection {
+            driver, connection, ..
+        } = runtime
+            .block_on(
+                endpoint
+                    .connect_with(self.client_config.clone(), &server_addr, "localhost")
+                    .unwrap()
+                    .instrument(error_span!("client")),
+            )
+            .unwrap();
+        runtime.spawn(async move {
+            driver.instrument(error_span!("client")).await.unwrap();
+        });
+        (connection, runtime)
+    }
 }

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -6,7 +6,6 @@ use quinn::{
 };
 use std::error::Error;
 use std::net::ToSocketAddrs;
-use std::sync::Arc;
 
 /// Constructs a QUIC endpoint configured for use a client only.
 ///
@@ -66,13 +65,12 @@ fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
     let priv_key = cert.serialize_private_key_der();
     let priv_key = PrivateKey::from_der(&priv_key)?;
 
-    let server_config = ServerConfig {
-        transport: Arc::new(TransportConfig {
-            stream_window_uni: 0,
-            ..Default::default()
-        }),
+    let mut server_config = ServerConfig::default();
+    server_config.with_transport(TransportConfig {
+        stream_window_uni: 0,
         ..Default::default()
-    };
+    });
+
     let mut cfg_builder = ServerConfigBuilder::new(server_config);
     let cert = Certificate::from_der(&cert_der)?;
     cfg_builder.certificate(CertificateChain::from_certs(vec![cert]), priv_key)?;

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -7,7 +7,6 @@ use err_derive::Error;
 use proto::crypto::rustls::{Certificate, CertificateChain, PrivateKey};
 use proto::{ClientConfig, EndpointConfig, ServerConfig};
 use rustls::TLSError;
-use slog::Logger;
 
 use crate::endpoint::{Endpoint, EndpointDriver, EndpointRef, Incoming};
 use crate::udp::UdpSocket;
@@ -16,7 +15,6 @@ use crate::udp::UdpSocket;
 #[derive(Clone, Debug)]
 pub struct EndpointBuilder {
     reactor: Option<tokio_net::driver::Handle>,
-    logger: Logger,
     server_config: Option<ServerConfig>,
     config: EndpointConfig,
     client_config: ClientConfig,
@@ -54,13 +52,8 @@ impl EndpointBuilder {
         let addr = socket.local_addr().map_err(EndpointError::Socket)?;
         let socket = UdpSocket::from_std(socket, &reactor).map_err(EndpointError::Socket)?;
         let rc = EndpointRef::new(
-            self.logger.clone(),
             socket,
-            proto::Endpoint::new(
-                self.logger,
-                Arc::new(self.config),
-                self.server_config.map(Arc::new),
-            )?,
+            proto::Endpoint::new(Arc::new(self.config), self.server_config.map(Arc::new))?,
             addr.is_ipv6(),
         );
         Ok((
@@ -83,10 +76,6 @@ impl EndpointBuilder {
         self.reactor = Some(handle);
         self
     }
-    pub fn logger(&mut self, logger: Logger) -> &mut Self {
-        self.logger = logger;
-        self
-    }
 
     /// Set the default configuration used for outgoing connections.
     ///
@@ -101,7 +90,6 @@ impl Default for EndpointBuilder {
     fn default() -> Self {
         Self {
             reactor: None,
-            logger: Logger::root(slog::Discard, o!()),
             server_config: None,
             config: EndpointConfig::default(),
             client_config: ClientConfig::default(),
@@ -117,13 +105,7 @@ pub enum EndpointError {
     Socket(io::Error),
     /// An error in the Quinn transport configuration
     #[error(display = "configuration error: {:?}", _0)]
-    Config(proto::ConfigError),
-}
-
-impl From<proto::ConfigError> for EndpointError {
-    fn from(x: proto::ConfigError) -> Self {
-        EndpointError::Config(x)
-    }
+    Config(#[source] proto::ConfigError),
 }
 
 /// Helper for constructing a `ServerConfig` to be passed to `EndpointBuilder::listen` to enable
@@ -229,12 +211,6 @@ impl ClientConfigBuilder {
     /// [registry]: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
     pub fn protocols(&mut self, protocols: &[&[u8]]) -> &mut Self {
         self.config.crypto.set_protocols(protocols);
-        self
-    }
-
-    /// Set the logger to use
-    pub fn logger(&mut self, logger: Logger) -> &mut Self {
-        self.config.log = Some(logger);
         self
     }
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -45,9 +45,6 @@
 //! encryption alone.
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate slog;
-
 mod broadcast;
 mod builders;
 mod platform;
@@ -81,6 +78,7 @@ pub use streams::{
 #[cfg(test)]
 mod tests;
 
+#[derive(Debug)]
 enum ConnectionEvent {
     Close {
         error_code: VarInt,
@@ -89,6 +87,7 @@ enum ConnectionEvent {
     Proto(proto::ConnectionEvent),
 }
 
+#[derive(Debug)]
 enum EndpointEvent {
     Proto(proto::EndpointEvent),
     Transmit(proto::Transmit),

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -17,6 +17,7 @@ use crate::VarInt;
 ///
 /// If dropped, streams that haven't been explicitly `reset` will continue to (re)transmit
 /// previously written data until it has been fully acknowledged or the connection is closed.
+#[derive(Debug)]
 pub struct SendStream {
     conn: ConnectionRef,
     stream: StreamId,
@@ -191,6 +192,7 @@ impl Future for Finish<'_> {
 /// `stop(0)` is implicitly called on drop unless:
 /// - `ReadError::Finished` has been emitted, or
 /// - `stop` was called explicitly
+#[derive(Debug)]
 pub struct RecvStream {
     conn: ConnectionRef,
     stream: StreamId,
@@ -396,16 +398,10 @@ impl Future for ReadToEnd {
 pub enum ReadToEndError {
     /// An error occurred during reading
     #[error(display = "read error")]
-    Read(ReadError),
+    Read(#[source] ReadError),
     /// The stream is larger than the user-supplied limit
     #[error(display = "stream too long")]
     TooLong,
-}
-
-impl From<ReadError> for ReadToEndError {
-    fn from(e: ReadError) -> ReadToEndError {
-        ReadToEndError::Read(e)
-    }
 }
 
 impl AsyncRead for RecvStream {

--- a/quinn/src/udp.rs
+++ b/quinn/src/udp.rs
@@ -16,6 +16,7 @@ use crate::platform::UdpExt;
 ///
 /// Unlike a standard tokio UDP socket, this allows ECN bits to be read and written on some
 /// platforms.
+#[derive(Debug)]
 pub struct UdpSocket {
     io: PollEvented<mio::net::UdpSocket>,
 }


### PR DESCRIPTION
Partially fixed #444 

Refactored: `ServerConfig`, `EndpointConfig` and `ClientConfig`.

- Changed `pub` definition into `pub (crate)`. 
- Added set fields. `fn with_xxx() -> Self { }`
- Added get fields for transport config
- Updated code that used those config types

Use can create and modifie the config as follows: 

```rust
let endpoint = EndpointConfig::default()
     .with_reset_key(vec![])
     .with_local_cid_len(10);
....
```
