### PR TITLE
 H3: Trivial fixes for driver bugs

### DIFF
--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -144,11 +144,8 @@ impl ReadToEnd {
 
     pub fn cancel(mut self) {
         let state = mem::replace(&mut self.state, ReadToEndState::Finished);
-        match state {
-            ReadToEndState::Receiving(recv, _, _) => {
-                recv.reset(ErrorCode::REQUEST_CANCELLED);
-            }
-            _ => (),
+        if let ReadToEndState::Receiving(recv, _, _) = state {
+            recv.reset(ErrorCode::REQUEST_CANCELLED);
         }
     }
 }

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -41,7 +41,7 @@ impl Builder {
 
     pub fn endpoint(self, endpoint: Endpoint) -> Client {
         Client {
-            endpoint: endpoint,
+            endpoint,
             settings: self.settings,
         }
     }

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -85,9 +85,11 @@ impl ConnectionDriver {
             .collect();
 
         let keep_going = !resolved.is_empty();
+        let mut removed = 0;
 
         for (i, res) in resolved {
-            self.pending_uni.remove(i);
+            self.pending_uni.remove(i - removed);
+            removed += 1;
             match res {
                 Err(Error::UnknownStream(ty)) => println!("unknown stream type {}", ty),
                 Err(e) => {

--- a/quinn-h3/src/frame.rs
+++ b/quinn-h3/src/frame.rs
@@ -48,7 +48,7 @@ impl Decoder for FrameDecoder {
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        if src.len() == 0 {
+        if src.is_empty() {
             return Ok(None);
         }
 
@@ -88,7 +88,7 @@ impl Decoder for FrameDecoder {
                 self.expected = Some(min);
                 Ok(None)
             }
-            Err(e) => Err(e)?,
+            Err(e) => return Err(e.into()),
             Ok(frame) => {
                 src.advance(pos);
                 self.expected = None;

--- a/quinn-h3/src/proto/connection.rs
+++ b/quinn-h3/src/proto/connection.rs
@@ -37,7 +37,7 @@ impl Connection {
             local_settings: settings,
             remote_settings: None,
             decoder_table,
-            pending_control: pending_control,
+            pending_control,
             encoder_table: DynamicTable::new(),
             pending_encoder: BytesMut::with_capacity(2048),
             pending_decoder: BytesMut::with_capacity(2048),

--- a/quinn-h3/src/qpack/dynamic.rs
+++ b/quinn-h3/src/qpack/dynamic.rs
@@ -208,7 +208,7 @@ impl<'a> DynamicTableEncoder<'a> {
                     self.find_name(&field.name),
                 ));
             }
-            Err(e) => Err(e)?,
+            Err(e) => return Err(e),
         };
         self.track_ref(index);
 

--- a/quinn-h3/src/streams.rs
+++ b/quinn-h3/src/streams.rs
@@ -56,11 +56,11 @@ impl Future for RecvUni {
             match self.inner {
                 None => panic!("polled after resolved"),
                 Some((ref mut recv, ref mut buf, ref mut len)) => {
-                    match ready!(Pin::new(recv).poll_read(cx, &mut buf[..*len + 1]))? {
+                    match ready!(Pin::new(recv).poll_read(cx, &mut buf[..=*len]))? {
                         0 => {
-                            return Poll::Ready(Err(Error::Peer(format!(
-                                "Uni stream closed before type received",
-                            ))))
+                            return Poll::Ready(Err(Error::Peer(
+                                "Uni stream closed before type received".into(),
+                            )))
                         }
                         _ => {
                             *len += 1;


### PR DESCRIPTION
These are quick fixes to make the current H3 implementation work in an acceptable way.

A lot more is to come, as I've been working on the Stateful QPACK encoding for #360. But I think a separate PR to make things reasonably functional is necessary, before applying bigger architectural changes in the H3 connection driving part.

I've got #360 figured out, in a messy research branch [here](https://github.com/stammw/quinn/tree/h3-qpack-integration) and I'm starting over from the code of this very PR to bring a clean and comprehensive patch.