### PR TITLE
Drop truncated UDP packets

### DIFF
--- a/quinn/src/platform/unix.rs
+++ b/quinn/src/platform/unix.rs
@@ -151,6 +151,9 @@ impl super::UdpExt for UdpSocket {
                 }
                 return Err(e);
             }
+            if hdr.msg_flags & libc::MSG_TRUNC != 0 {
+                continue;
+            }
             break n;
         };
         let name = unsafe { name.assume_init() };


### PR DESCRIPTION
These would fail decryption anyway, so this saves us some CPU.