### PR TITLE
Added 'pub (crate)' where possible quinn-proto.

### DIFF
--- a/quinn-proto/src/assembler.rs
+++ b/quinn-proto/src/assembler.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 
 /// Helper to assemble unordered stream frames into an ordered stream
 #[derive(Debug)]
-pub struct Assembler {
+pub(crate) struct Assembler {
     offset: u64,
     data: BinaryHeap<Chunk>,
 }
@@ -18,7 +18,7 @@ impl Assembler {
         }
     }
 
-    pub fn read(&mut self, buf: &mut [u8]) -> usize {
+    pub(crate) fn read(&mut self, buf: &mut [u8]) -> usize {
         let mut read = 0;
         loop {
             if self.consume(buf, &mut read) {
@@ -84,21 +84,21 @@ impl Assembler {
         }
     }
 
-    pub fn pop(&mut self) -> Option<(u64, Bytes)> {
+    pub(crate) fn pop(&mut self) -> Option<(u64, Bytes)> {
         self.data.pop().map(|x| (x.offset, x.bytes))
     }
 
-    pub fn insert(&mut self, offset: u64, bytes: Bytes) {
+    pub(crate) fn insert(&mut self, offset: u64, bytes: Bytes) {
         self.data.push(Chunk { offset, bytes });
     }
 
     /// Current position in the stream
-    pub fn offset(&self) -> u64 {
+    pub(crate) fn offset(&self) -> u64 {
         self.offset
     }
 
     /// Discard all buffered data
-    pub fn clear(&mut self) {
+    pub(crate) fn clear(&mut self) {
         self.data.clear();
     }
 }

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -40,7 +40,7 @@ impl coding::Codec for Type {
     }
 }
 
-pub trait FrameStruct {
+pub(crate) trait FrameStruct {
     /// Smallest number of bytes this type of frame is guaranteed to fit within.
     const SIZE_BOUND: usize;
 }

--- a/quinn-proto/src/spaces.rs
+++ b/quinn-proto/src/spaces.rs
@@ -9,56 +9,56 @@ use crate::range_set::RangeSet;
 use crate::shared::IssuedCid;
 use crate::{crypto, frame, StreamId, VarInt};
 
-pub struct PacketSpace<K>
+pub(crate) struct PacketSpace<K>
 where
     K: crypto::Keys,
 {
-    pub crypto: Option<CryptoSpace<K>>,
-    pub dedup: Dedup,
+    pub(crate) crypto: Option<CryptoSpace<K>>,
+    pub(crate) dedup: Dedup,
     /// Highest received packet number
-    pub rx_packet: u64,
+    pub(crate) rx_packet: u64,
     /// Time at which the above was received
-    pub rx_packet_time: Instant,
+    pub(crate) rx_packet_time: Instant,
 
     /// Data to send
-    pub pending: Retransmits,
+    pub(crate) pending: Retransmits,
     /// Packet numbers to acknowledge
-    pub pending_acks: RangeSet,
+    pub(crate) pending_acks: RangeSet,
     /// Set iff we have received a non-ack frame since the last ack-only packet we sent
-    pub permit_ack_only: bool,
+    pub(crate) permit_ack_only: bool,
 
     /// The packet number of the next packet that will be sent, if any.
-    pub next_packet_number: u64,
+    pub(crate) next_packet_number: u64,
     /// The largest packet number the remote peer acknowledged in an ACK frame.
-    pub largest_acked_packet: Option<u64>,
-    pub largest_acked_packet_sent: Instant,
+    pub(crate) largest_acked_packet: Option<u64>,
+    pub(crate) largest_acked_packet_sent: Instant,
     /// Transmitted but not acked
     // We use a BTreeMap here so we can efficiently query by range on ACK and for loss detection
-    pub sent_packets: BTreeMap<u64, SentPacket>,
+    pub(crate) sent_packets: BTreeMap<u64, SentPacket>,
     /// Recent ECN counters sent by the peer in ACK frames
     ///
     /// Updated (and inspected) whenever we receive an ACK with a new highest acked packet
     /// number. Stored per-space to simplify verification, which would otherwise have difficulty
     /// distinguishing between ECN bleaching and counts having been updated by a near-simultaneous
     /// ACK already processed in another space.
-    pub ecn_feedback: frame::EcnCounts,
+    pub(crate) ecn_feedback: frame::EcnCounts,
 
     /// Incoming cryptographic handshake stream
-    pub crypto_stream: Assembler,
+    pub(crate) crypto_stream: Assembler,
     /// Current offset of outgoing cryptographic handshake stream
-    pub crypto_offset: u64,
+    pub(crate) crypto_offset: u64,
 
     /// The time at which the earliest sent packet in this space will be considered lost based on
     /// exceeding the reordering window in time. Only set for packets numbered prior to a packet
     /// that has been acknowledged.
-    pub loss_time: Option<Instant>,
+    pub(crate) loss_time: Option<Instant>,
 }
 
 impl<K> PacketSpace<K>
 where
     K: crypto::Keys,
 {
-    pub fn new(now: Instant) -> Self {
+    pub(crate) fn new(now: Instant) -> Self {
         Self {
             crypto: None,
             dedup: Dedup::new(),
@@ -82,7 +82,7 @@ where
         }
     }
 
-    pub fn get_tx_number(&mut self) -> u64 {
+    pub(crate) fn get_tx_number(&mut self) -> u64 {
         // TODO: Handle packet number overflow gracefully
         assert!(self.next_packet_number < 2u64.pow(62));
         let x = self.next_packet_number;
@@ -90,12 +90,12 @@ where
         x
     }
 
-    pub fn can_send(&self) -> bool {
+    pub(crate) fn can_send(&self) -> bool {
         !self.pending.is_empty() || (self.permit_ack_only && !self.pending_acks.is_empty())
     }
 
     /// Verifies sanity of an ECN block and returns whether congestion was encountered.
-    pub fn detect_ecn(
+    pub(crate) fn detect_ecn(
         &mut self,
         newly_acked: u64,
         ecn: frame::EcnCounts,
@@ -127,7 +127,7 @@ where
         Ok(ce_increase != 0)
     }
 
-    pub fn finish_stream(&mut self, id: StreamId, offset: u64) {
+    pub(crate) fn finish_stream(&mut self, id: StreamId, offset: u64) {
         for frame in &mut self.pending.stream {
             if frame.id == id && frame.offset + frame.data.len() as u64 == offset {
                 frame.fin = true;
@@ -145,32 +145,32 @@ where
 
 /// Represents one or more packets subject to retransmission
 #[derive(Debug, Clone)]
-pub struct SentPacket {
+pub(crate) struct SentPacket {
     /// The time the packet was sent.
-    pub time_sent: Instant,
+    pub(crate) time_sent: Instant,
     /// The number of bytes sent in the packet, not including UDP or IP overhead, but including QUIC
     /// framing overhead. Zero if this packet is not counted towards congestion control, i.e. not an
     /// "in flight" packet.
-    pub size: u16,
+    pub(crate) size: u16,
     /// Whether an acknowledgement is expected directly in response to this packet.
-    pub ack_eliciting: bool,
-    pub acks: RangeSet,
-    pub retransmits: Retransmits,
+    pub(crate) ack_eliciting: bool,
+    pub(crate) acks: RangeSet,
+    pub(crate) retransmits: Retransmits,
 }
 
 /// Retransmittable data queue
 #[derive(Debug, Clone)]
 pub struct Retransmits {
-    pub max_data: bool,
-    pub max_uni_stream_id: bool,
-    pub max_bi_stream_id: bool,
-    pub stream: VecDeque<frame::Stream>,
-    pub rst_stream: Vec<(StreamId, VarInt)>,
-    pub stop_sending: Vec<frame::StopSending>,
-    pub max_stream_data: HashSet<StreamId>,
-    pub crypto: VecDeque<frame::Crypto>,
-    pub new_cids: Vec<IssuedCid>,
-    pub retire_cids: Vec<u64>,
+    pub(crate) max_data: bool,
+    pub(crate) max_uni_stream_id: bool,
+    pub(crate) max_bi_stream_id: bool,
+    pub(crate) stream: VecDeque<frame::Stream>,
+    pub(crate) rst_stream: Vec<(StreamId, VarInt)>,
+    pub(crate) stop_sending: Vec<frame::StopSending>,
+    pub(crate) max_stream_data: HashSet<StreamId>,
+    pub(crate) crypto: VecDeque<frame::Crypto>,
+    pub(crate) new_cids: Vec<IssuedCid>,
+    pub(crate) retire_cids: Vec<u64>,
 }
 
 impl Retransmits {

--- a/quinn-proto/src/streams.rs
+++ b/quinn-proto/src/streams.rs
@@ -9,23 +9,23 @@ use crate::frame;
 use crate::range_set::RangeSet;
 use crate::{Dir, Side, StreamId, TransportError, VarInt};
 
-pub struct Streams {
+pub(crate) struct Streams {
     // Set of streams that are currently open, or could be immediately opened by the peer
     send: HashMap<StreamId, Send>,
     recv: HashMap<StreamId, Recv>,
     next: [u64; 2],
     // Locally initiated
-    pub max: [u64; 2],
+    pub(crate) max: [u64; 2],
     // Maximum that can be remotely initiated
-    pub max_remote: [u64; 2],
+    pub(crate) max_remote: [u64; 2],
     // Lowest that hasn't actually been opened
-    pub next_remote: [u64; 2],
+    pub(crate) next_remote: [u64; 2],
     // Next to report to the application, once opened
     next_reported_remote: [u64; 2],
 }
 
 impl Streams {
-    pub fn new(side: Side, max_remote_uni: u64, max_remote_bi: u64) -> Self {
+    pub(crate) fn new(side: Side, max_remote_uni: u64, max_remote_bi: u64) -> Self {
         let mut this = Self {
             send: HashMap::default(),
             recv: HashMap::default(),
@@ -45,7 +45,7 @@ impl Streams {
         this
     }
 
-    pub fn open(&mut self, side: Side, dir: Dir) -> Option<StreamId> {
+    pub(crate) fn open(&mut self, side: Side, dir: Dir) -> Option<StreamId> {
         if self.next[dir as usize] >= self.max[dir as usize] {
             return None;
         }
@@ -56,13 +56,13 @@ impl Streams {
         Some(id)
     }
 
-    pub fn alloc_remote_stream(&mut self, side: Side, dir: Dir) {
+    pub(crate) fn alloc_remote_stream(&mut self, side: Side, dir: Dir) {
         self.max_remote[dir as usize] += 1;
         let id = StreamId::new(!side, dir, self.max_remote[dir as usize] - 1);
         self.insert(true, id);
     }
 
-    pub fn accept(&mut self, side: Side, dir: Dir) -> Option<StreamId> {
+    pub(crate) fn accept(&mut self, side: Side, dir: Dir) -> Option<StreamId> {
         if self.next_remote[dir as usize] == self.next_reported_remote[dir as usize] {
             return None;
         }
@@ -71,7 +71,7 @@ impl Streams {
         Some(StreamId::new(!side, dir, x))
     }
 
-    pub fn zero_rtt_rejected(&mut self, side: Side) {
+    pub(crate) fn zero_rtt_rejected(&mut self, side: Side) {
         // Revert to initial state for outgoing streams
         for dir in Dir::iter() {
             for i in 0..self.next[dir as usize] {
@@ -84,7 +84,7 @@ impl Streams {
         }
     }
 
-    pub fn read(
+    pub(crate) fn read(
         &mut self,
         id: StreamId,
         buf: &mut [u8],
@@ -104,7 +104,7 @@ impl Streams {
         }
     }
 
-    pub fn read_unordered(
+    pub(crate) fn read_unordered(
         &mut self,
         id: StreamId,
     ) -> Result<Option<(Bytes, u64, bool)>, ReadError> {
@@ -127,7 +127,7 @@ impl Streams {
     ///
     /// Similar to `recv_mut`, but with additional sanity-checks are performed to detect peer
     /// misbehavior.
-    pub fn recv_stream(
+    pub(crate) fn recv_stream(
         &mut self,
         side: Side,
         id: StreamId,
@@ -158,7 +158,7 @@ impl Streams {
     /// Discard state for a stream if it's fully closed.
     ///
     /// Called when one side of a stream transitions to a closed state
-    pub fn maybe_cleanup(&mut self, id: StreamId) {
+    pub(crate) fn maybe_cleanup(&mut self, id: StreamId) {
         match self.send.entry(id) {
             hash_map::Entry::Vacant(_) => {}
             hash_map::Entry::Occupied(e) => {
@@ -177,16 +177,16 @@ impl Streams {
         }
     }
 
-    pub fn recv_mut(&mut self, id: StreamId) -> Option<&mut Recv> {
+    pub(crate) fn recv_mut(&mut self, id: StreamId) -> Option<&mut Recv> {
         self.recv.get_mut(&id)
     }
 
-    pub fn send_mut(&mut self, id: StreamId) -> Option<&mut Send> {
+    pub(crate) fn send_mut(&mut self, id: StreamId) -> Option<&mut Send> {
         self.send.get_mut(&id)
     }
 
     /// Whether a locally initiated stream has never been open
-    pub fn is_local_unopened(&self, id: StreamId) -> bool {
+    pub(crate) fn is_local_unopened(&self, id: StreamId) -> bool {
         id.index() >= self.next[id.dir() as usize]
     }
 
@@ -202,16 +202,16 @@ impl Streams {
 }
 
 #[derive(Debug)]
-pub struct Send {
-    pub offset: u64,
-    pub max_data: u64,
-    pub state: SendState,
+pub(crate) struct Send {
+    pub(crate) offset: u64,
+    pub(crate) max_data: u64,
+    pub(crate) state: SendState,
     /// Number of bytes sent but unacked
-    pub bytes_in_flight: u64,
+    pub(crate) bytes_in_flight: u64,
 }
 
 impl Send {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             offset: 0,
             max_data: 0,
@@ -220,7 +220,7 @@ impl Send {
         }
     }
 
-    pub fn write_budget(&mut self) -> Result<u64, WriteError> {
+    pub(crate) fn write_budget(&mut self) -> Result<u64, WriteError> {
         if let Some(error_code) = self.take_stop_reason() {
             return Err(WriteError::Stopped { error_code });
         }
@@ -233,7 +233,7 @@ impl Send {
     }
 
     /// All data acknowledged and STOP_SENDING error code, if any, processed by application
-    pub fn is_closed(&self) -> bool {
+    pub(crate) fn is_closed(&self) -> bool {
         use self::SendState::*;
         match self.state {
             DataRecvd | ResetRecvd { stop_reason: None } => true,
@@ -241,7 +241,7 @@ impl Send {
         }
     }
 
-    pub fn finish(&mut self) -> Result<(), FinishError> {
+    pub(crate) fn finish(&mut self) -> Result<(), FinishError> {
         if self.state == SendState::Ready {
             self.state = SendState::DataSent;
             Ok(())
@@ -283,7 +283,7 @@ pub enum WriteError {
 }
 
 #[derive(Debug)]
-pub struct Recv {
+pub(crate) struct Recv {
     state: RecvState,
     recvd: RangeSet,
     /// Whether any unordered reads have been performed, making this stream unusable for ordered
@@ -292,11 +292,11 @@ pub struct Recv {
     assembler: Assembler,
     /// Number of bytes read by the application. Equal to assembler.offset when `unordered` is
     /// false.
-    pub bytes_read: u64,
+    pub(crate) bytes_read: u64,
 }
 
 impl Recv {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             state: RecvState::Recv { size: None },
             recvd: RangeSet::new(),
@@ -306,7 +306,7 @@ impl Recv {
         }
     }
 
-    pub fn ingest(
+    pub(crate) fn ingest(
         &mut self,
         frame: frame::Stream,
         received: u64,
@@ -349,7 +349,7 @@ impl Recv {
         Ok(new_bytes)
     }
 
-    pub fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, ReadError> {
+    pub(crate) fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, ReadError> {
         assert!(
             !self.unordered,
             "cannot perform ordered reads following unordered reads on a stream"
@@ -364,7 +364,7 @@ impl Recv {
         }
     }
 
-    pub fn read_unordered(&mut self) -> Result<Option<(Bytes, u64)>, ReadError> {
+    pub(crate) fn read_unordered(&mut self) -> Result<Option<(Bytes, u64)>, ReadError> {
         self.unordered = true;
 
         // Return data we already have buffered, regardless of state
@@ -391,7 +391,7 @@ impl Recv {
         }
     }
 
-    pub fn receiving_unknown_size(&self) -> bool {
+    pub(crate) fn receiving_unknown_size(&self) -> bool {
         match self.state {
             RecvState::Recv { size: None } => true,
             _ => false,
@@ -399,7 +399,7 @@ impl Recv {
     }
 
     /// No more data expected from peer
-    pub fn is_finished(&self) -> bool {
+    pub(crate) fn is_finished(&self) -> bool {
         match self.state {
             RecvState::Recv { .. } => false,
             _ => true,
@@ -407,16 +407,16 @@ impl Recv {
     }
 
     /// All data read by application
-    pub fn is_closed(&self) -> bool {
+    pub(crate) fn is_closed(&self) -> bool {
         self.state == self::RecvState::Closed
     }
 
     /// Offset after the largest byte received
-    pub fn limit(&self) -> u64 {
+    pub(crate) fn limit(&self) -> u64 {
         self.recvd.max().map_or(0, |x| x + 1)
     }
 
-    pub fn final_offset(&self) -> Option<u64> {
+    pub(crate) fn final_offset(&self) -> Option<u64> {
         match self.state {
             RecvState::Recv { size } => size,
             RecvState::ResetRecvd { size, .. } => Some(size),
@@ -425,7 +425,7 @@ impl Recv {
         }
     }
 
-    pub fn reset(&mut self, error_code: VarInt, final_offset: u64) {
+    pub(crate) fn reset(&mut self, error_code: VarInt, final_offset: u64) {
         if self.is_closed() {
             return;
         }
@@ -461,7 +461,7 @@ pub enum ReadError {
 /// `stop_reason` below should be set iff the stream was stopped and application has not yet been
 /// notified, as we never discard resources for a stream that has it set.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum SendState {
+pub(crate) enum SendState {
     Ready,
     DataSent,
     ResetSent { stop_reason: Option<VarInt> },
@@ -470,7 +470,7 @@ pub enum SendState {
 }
 
 impl SendState {
-    pub fn was_reset(self) -> bool {
+    pub(crate) fn was_reset(self) -> bool {
         use self::SendState::*;
         match self {
             ResetSent { .. } | ResetRecvd { .. } => true,
@@ -480,7 +480,7 @@ impl SendState {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum RecvState {
+pub(crate) enum RecvState {
     Recv { size: Option<u64> },
     DataRecvd { size: u64 },
     ResetRecvd { size: u64, error_code: VarInt },

--- a/quinn-proto/src/timer.rs
+++ b/quinn-proto/src/timer.rs
@@ -6,7 +6,7 @@ use std::slice;
 pub struct Timer(pub(crate) TimerKind);
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub enum TimerKind {
+pub(crate) enum TimerKind {
     /// When to send an ack-eliciting probe packet or declare unacked packets lost
     LossDetection = 0,
     /// When to close the connection after no activity


### PR DESCRIPTION
From the https://github.com/djc/quinn/issues/444 discussion, @Ralith said "I'm not necessarily opposed to it.", which was about improving encapsulation, therefore I decided to create this PR.

**Changes:**
- Added `pub(crate)` where possible `quinn-proto`. 

**Motivation:**
* I always prefer to limit the access and only expose public when needed. 
* All updated types are not used outside the crate and are not re-exported
* Reads cleaner, because the reader can know whether a type is used outside the crate or not
* Programmer does not expose types by accident.

**Prerequisites:**
* No breaking changes.
* Only updated quinn-proto

**Notice:**
* Structs with public fields can only be made `pub (crate)` when the struct it's self can also be `pub(crate)`. Please review and look for changes in encapsulation that do change the fields but not the struct its self.