### PR TITLE
Fix the hyper upstream repository

### DIFF
--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -27,7 +27,7 @@ bitlab = "0.8.1"
 bytes = "0.4.7"
 err-derive = "0.2"
 futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
-http = { git = "https://github.com/hyperium/http/", rev = "912534f1ef27d8a9050a4bd40d5ea0ee35136ea7" }
+http = { git = "https://github.com/hyperium/http", rev = "912534f1ef27d8a9050a4bd40d5ea0ee35136ea7" }
 lazy_static = "1"
 quinn-proto = { path = "../quinn-proto", version = "0.4.0" }
 quinn = { path = "../quinn", version = "0.4.0" }


### PR DESCRIPTION
Otherwise `cargo update` fails.

Fixes #514