### PR TITLE
Expose the peer address of a `Connecting`

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -107,10 +107,10 @@ impl Future for Connecting {
 }
 
 impl Connecting {
-    /// Get the peer address of a `Connecting`.
+    /// The peer's UDP address.
     ///
-    /// This must not be called after `poll` has returned `Ready`, or it will panic.
-    pub fn peer_address(&self) -> SocketAddr {
+    /// Will panic if called after `poll` has returned `Ready`.
+    pub fn remote_address(&self) -> SocketAddr {
         let conn_ref: &ConnectionRef = &self.0.as_ref().expect("used after yielding Ready").0;
         conn_ref.lock().unwrap().inner.remote()
     }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -106,6 +106,16 @@ impl Future for Connecting {
     }
 }
 
+impl Connecting {
+    /// Get the peer address of a `Connecting`.
+    ///
+    /// This must not be called after `poll` has returned `Ready`, or it will panic.
+    pub fn peer_address(&self) -> SocketAddr {
+        let conn_ref: &ConnectionRef = &self.0.as_ref().expect("used after yielding Ready").0;
+        conn_ref.lock().unwrap().inner.remote()
+    }
+}
+
 /// Future that completes when a connection is fully established
 ///
 /// For clients, the resulting value indicates if 0-RTT was accepted. For servers, the resulting


### PR DESCRIPTION
This is the same PR as #512, which I accidentally closed.