### PR TITLE
Update `tokio`, `futures` and `bytes`.

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 quinn = { path = "../quinn" }
 tokio = { version = "0.2.1", features = ["macros"] }
-tracing = "0.1.9"
+tracing = "0.1.10"
 tracing-subscriber = "0.1.5"
 anyhow = "1.0.22"
 rcgen = "0.7"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 quinn = { path = "../quinn" }
-tokio = "0.2.1"
+tokio = { version = "0.2.1", features = ["macros"] }
 tracing = "0.1.9"
 tracing-subscriber = "0.1.5"
 anyhow = "1.0.22"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,12 +8,12 @@ publish = false
 
 [dependencies]
 quinn = { path = "../quinn" }
-tokio = { version = "0.2.0-alpha.6", default-features = false, features = ["rt-current-thread"] }
-tracing = "0.1.10"
+tokio = "0.2.1"
+tracing = "0.1.9"
 tracing-subscriber = "0.1.5"
 anyhow = "1.0.22"
 rcgen = "0.7"
-futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
+futures = "0.3.1"
 rustls = "0.16"
 
 [[bin]]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 quinn = { path = "../quinn" }
-tokio = { version = "0.2.1", features = ["macros"] }
+tokio = { version = "0.2.2", features = ["macros", "rt-threaded"] }
 tracing = "0.1.10"
 tracing-subscriber = "0.1.5"
 anyhow = "1.0.22"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 quinn = { path = "../quinn" }
-tokio = { version = "0.2.2", features = ["macros", "rt-threaded"] }
+tokio = { version = "0.2.2", features = ["rt-core"] }
 tracing = "0.1.10"
 tracing-subscriber = "0.1.5"
 anyhow = "1.0.22"

--- a/bench/src/bulk.rs
+++ b/bench/src/bulk.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Context, Result};
 use futures::StreamExt;
 use tracing::trace;
 
-#[tokio::main]
+#[tokio::main(threaded_scheduler)]
 async fn main() {
     tracing::subscriber::set_global_default(
         tracing_subscriber::FmtSubscriber::builder()
@@ -33,13 +33,13 @@ async fn main() {
         let driver = tokio::spawn(async {
             driver.await.expect("server endpoint driver");
         });
-        if let Err(e) = tokio::spawn(server(incoming)).await {
+        if let Err(e) = server(incoming).await {
             eprintln!("server failed: {:#}", e);
         }
         driver.await.expect("server run");
     });
 
-    if let Err(e) = tokio::spawn(client(server_addr, cert)).await {
+    if let Err(e) = client(server_addr, cert).await {
         eprintln!("client failed: {:#}", e);
     }
 

--- a/bench/src/bulk.rs
+++ b/bench/src/bulk.rs
@@ -29,21 +29,21 @@ async fn main() {
         .unwrap();
     let server_addr = endpoint.local_addr().unwrap();
     drop(endpoint); // Ensure server shuts down when finished
-    let thread = tokio::spawn(async {
+    let server = tokio::spawn(async {
         let driver = tokio::spawn(async {
             driver.await.expect("server endpoint driver");
         });
         if let Err(e) = server(incoming).await {
             eprintln!("server failed: {:#}", e);
         }
-        driver.await.expect("server run");
+        driver.await.expect("server run")
     });
 
-    if let Err(e) = client(server_addr, cert).await {
+    if let Err(e) = tokio::spawn(client(server_addr, cert)).await {
         eprintln!("client failed: {:#}", e);
     }
 
-    thread.await.expect("server thread");
+    server.await.expect("server thread");
 }
 
 async fn server(mut incoming: quinn::Incoming) -> Result<()> {

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -10,13 +10,13 @@ quinn = { path = "../quinn" }
 quinn-h3 = { path = "../quinn-h3" }
 quinn-proto = { path = "../quinn-proto" }
 http = { git = "https://github.com/hyperium/http/", rev = "43dffa1eb79f6801e5e07f3338fa56191dc454bb" }
-bytes = "0.5.1"
+bytes = "0.5.2"
 structopt = "0.3.0"
-tokio = { version = "0.2.1", features = ["macros", "rt-threaded"] }
+tokio = { version = "0.2.1", features = ["macros"] }
 rustls = { version = "0.16", features = ["dangerous_configuration"] }
 futures = "0.3.1"
 webpki = "0.21"
-tracing = "0.1.9"
+tracing = "0.1.10"
 tracing-subscriber = "0.1.5"
 anyhow = "1.0.22"
 

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -12,7 +12,7 @@ quinn-proto = { path = "../quinn-proto" }
 http = { git = "https://github.com/hyperium/http/", rev = "43dffa1eb79f6801e5e07f3338fa56191dc454bb" }
 bytes = "0.5.2"
 structopt = "0.3.0"
-tokio = { version = "0.2.2", features = ["macros", "rt-core"] }
+tokio = { version = "0.2.2", features = ["rt-core"] }
 rustls = { version = "0.16", features = ["dangerous_configuration"] }
 futures = "0.3.1"
 webpki = "0.21"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -9,15 +9,14 @@ default-run = "main"
 quinn = { path = "../quinn" }
 quinn-h3 = { path = "../quinn-h3" }
 quinn-proto = { path = "../quinn-proto" }
-http = { git = "https://github.com/hyperium/http/", rev = "a3a8fcb213bc456e0b7a42cf0e2bd57afa49851b" }
-bytes = "0.4.7"
+http = { git = "https://github.com/hyperium/http/", rev = "43dffa1eb79f6801e5e07f3338fa56191dc454bb" }
+bytes = "0.5.1"
 structopt = "0.3.0"
-tokio = "0.2.0-alpha.5"
-tokio-net = "0.2.0-alpha.5" # tokio doesn't reexport everything we use
+tokio = { version = "0.2.1", features = ["macros", "rt-threaded"] }
 rustls = { version = "0.16", features = ["dangerous_configuration"] }
-futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
+futures = "0.3.1"
 webpki = "0.21"
-tracing = "0.1.10"
+tracing = "0.1.9"
 tracing-subscriber = "0.1.5"
 anyhow = "1.0.22"
 

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -12,7 +12,7 @@ quinn-proto = { path = "../quinn-proto" }
 http = { git = "https://github.com/hyperium/http/", rev = "43dffa1eb79f6801e5e07f3338fa56191dc454bb" }
 bytes = "0.5.2"
 structopt = "0.3.0"
-tokio = { version = "0.2.1", features = ["macros"] }
+tokio = { version = "0.2.2", features = ["macros", "rt-core"] }
 rustls = { version = "0.16", features = ["dangerous_configuration"] }
 futures = "0.3.1"
 webpki = "0.21"

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -165,9 +165,7 @@ impl State {
     async fn rebind(self: Arc<Self>) -> Result<()> {
         let (endpoint_driver, endpoint, _) =
             quinn::Endpoint::builder().bind(&"[::]:0".parse().unwrap())?;
-        tokio::spawn(
-            endpoint_driver.unwrap_or_else(|e| eprintln!("IO error: {}", e)),
-        );
+        tokio::spawn(endpoint_driver.unwrap_or_else(|e| eprintln!("IO error: {}", e)));
 
         let new_conn = endpoint
             .connect_with(self.client_config.clone(), &self.remote, &self.host)?

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -31,7 +31,7 @@ http = { git = "https://github.com/hyperium/http", rev = "43dffa1eb79f6801e5e07f
 lazy_static = "1"
 quinn-proto = { path = "../quinn-proto", version = "0.4.0" }
 quinn = { path = "../quinn", version = "0.4.0" }
-string = { git = "https://github.com/carllerche/string/", branch = "bytes-up" }
+string = { git = "https://github.com/carllerche/string" }
 tokio = "0.2.1"
 tokio-util = { version = "0.2.0", features = ["codec"] }
 
@@ -44,7 +44,7 @@ rand = "0.7.0"
 rcgen = "0.7"
 structopt = "0.3.0"
 url = "2"
-tracing = "0.1.9"
+tracing = "0.1.10"
 tracing-subscriber = "0.1.5"
 
 [[example]]

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -46,7 +46,7 @@ structopt = "0.3.0"
 url = "2"
 tracing = "0.1.10"
 tracing-subscriber = "0.1.5"
-tokio = { version = "0.2.2", features = ["io-util"] }
+tokio = { version = "0.2.2", features = ["io-util", "macros", "rt-threaded"] }
 
 [[example]]
 name = "h3"

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -24,17 +24,16 @@ travis-ci = { repository = "djc/quinn" }
 
 [dependencies]
 bitlab = "0.8.1"
-bytes = "0.4.7"
+bytes = "0.5.1"
 err-derive = "0.2"
-futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
-http = { git = "https://github.com/hyperium/http", rev = "a3a8fcb213bc456e0b7a42cf0e2bd57afa49851b" }
+futures = "0.3.1"
+http = { git = "https://github.com/hyperium/http", rev = "43dffa1eb79f6801e5e07f3338fa56191dc454bb" }
 lazy_static = "1"
 quinn-proto = { path = "../quinn-proto", version = "0.4.0" }
 quinn = { path = "../quinn", version = "0.4.0" }
-string = "0.2"
-tokio = "0.2.0-alpha.5"
-tokio-io = "0.2.0-alpha.5"
-tokio-codec = "0.2.0-alpha.5"
+string = { git = "https://github.com/carllerche/string/", branch = "bytes-up" }
+tokio = "0.2.1"
+tokio-util = { version = "0.2.0", features = ["codec"] }
 
 [dev-dependencies]
 assert_matches = "1.1"
@@ -45,7 +44,7 @@ rand = "0.7.0"
 rcgen = "0.7"
 structopt = "0.3.0"
 url = "2"
-tracing = "0.1.10"
+tracing = "0.1.9"
 tracing-subscriber = "0.1.5"
 
 [[example]]

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -24,7 +24,7 @@ travis-ci = { repository = "djc/quinn" }
 
 [dependencies]
 bitlab = "0.8.1"
-bytes = "0.5.1"
+bytes = "0.5.2"
 err-derive = "0.2"
 futures = "0.3.1"
 http = { git = "https://github.com/hyperium/http", rev = "43dffa1eb79f6801e5e07f3338fa56191dc454bb" }
@@ -32,7 +32,7 @@ lazy_static = "1"
 quinn-proto = { path = "../quinn-proto", version = "0.4.0" }
 quinn = { path = "../quinn", version = "0.4.0" }
 string = { git = "https://github.com/carllerche/string" }
-tokio = "0.2.1"
+tokio = "0.2.2"
 tokio-util = { version = "0.2.0", features = ["codec"] }
 
 [dev-dependencies]
@@ -46,6 +46,7 @@ structopt = "0.3.0"
 url = "2"
 tracing = "0.1.10"
 tracing-subscriber = "0.1.5"
+tokio = { version = "0.2.2", features = ["io-util"] }
 
 [[example]]
 name = "h3"

--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -49,7 +49,7 @@ impl From<Bytes> for Body {
 
 impl From<&str> for Body {
     fn from(buf: &str) -> Self {
-        Body::Buf(Bytes::copy_from_slice(buf.as_bytes()))
+        Body::Buf(Bytes::copy_from_slice(buf.as_ref()))
     }
 }
 

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -1,6 +1,12 @@
-use std::{mem, net::SocketAddr, pin::Pin, task::Context};
+use std::{
+    future::Future,
+    mem,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use futures::{ready, stream::Stream, Future, Poll};
+use futures::{ready, Stream};
 use http::{request, HeaderMap, Request, Response};
 use quinn::{Endpoint, OpenBi};
 use quinn_proto::{Side, StreamId};

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -1,14 +1,15 @@
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
+    future::Future,
     io::{self, Cursor},
     mem,
     pin::Pin,
     sync::{Arc, Mutex},
-    task::{Context, Waker},
+    task::{Context, Poll, Waker},
 };
 
 use bytes::BytesMut;
-use futures::{AsyncRead, Future, Poll, Stream};
+use futures::Stream;
 use quinn::{IncomingBiStreams, IncomingUniStreams, RecvStream, SendStream};
 use quinn_proto::{Side, StreamId};
 

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use bytes::BytesMut;
-use futures::Stream;
+use futures::{io::AsyncRead, Stream};
 use quinn::{IncomingBiStreams, IncomingUniStreams, RecvStream, SendStream};
 use quinn_proto::{Side, StreamId};
 

--- a/quinn-h3/src/frame.rs
+++ b/quinn-h3/src/frame.rs
@@ -1,10 +1,15 @@
-use std::{io, mem, pin::Pin, task::Context};
+use std::{
+    future::Future,
+    io, mem,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use bytes::{Bytes, BytesMut};
-use futures::{io::AsyncWrite, ready, Future, Poll};
+use bytes::{Buf, Bytes, BytesMut};
+use futures::{io::AsyncWrite, ready};
 use quinn::{RecvStream, SendStream, VarInt};
-use tokio_codec::{Decoder, FramedRead};
-use tokio_io::AsyncRead;
+use tokio::io::AsyncRead;
+use tokio_util::codec::{Decoder, FramedRead};
 
 use super::proto::frame::{self, FrameHeader, HttpFrame, IntoPayload, PartialData};
 use crate::{proto::ErrorCode, streams::Reset};

--- a/quinn-h3/src/headers.rs
+++ b/quinn-h3/src/headers.rs
@@ -1,6 +1,9 @@
-use std::{pin::Pin, task::Context};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use futures::{Future, Poll};
 use quinn::SendStream;
 use quinn_proto::StreamId;
 

--- a/quinn-h3/src/proto/connection.rs
+++ b/quinn-h3/src/proto/connection.rs
@@ -90,7 +90,7 @@ impl Connection {
         )?;
 
         Ok(HeadersFrame {
-            encoded: block.into(),
+            encoded: block.freeze(),
         })
     }
 
@@ -146,7 +146,7 @@ impl Connection {
         if self.pending_streams[ty as usize].is_empty() {
             return None;
         }
-        Some(self.pending_streams[ty as usize].take().freeze())
+        Some(self.pending_streams[ty as usize].split().freeze())
     }
 
     pub fn pending_stream_release(&mut self, ty: PendingStreamType) {

--- a/quinn-h3/src/proto/headers.rs
+++ b/quinn-h3/src/proto/headers.rs
@@ -48,15 +48,15 @@ impl Header {
         let mut uri = Uri::builder();
 
         if let Some(path) = self.pseudo.path {
-            uri.path_and_query(path.as_bytes());
+            uri = uri.path_and_query(path.as_bytes());
         }
 
         if let Some(scheme) = self.pseudo.scheme {
-            uri.scheme(scheme.as_bytes());
+            uri = uri.scheme(scheme.as_bytes());
         }
 
         if let Some(authority) = self.pseudo.authority {
-            uri.authority(authority.as_bytes());
+            uri = uri.authority(authority.as_bytes());
         }
 
         Ok((
@@ -226,7 +226,7 @@ where
     N: AsRef<[u8]>,
     V: AsRef<[u8]>,
 {
-    string::TryFrom::<Bytes>::try_from(Bytes::from(value.as_ref()))
+    string::TryFrom::<Bytes>::try_from(Bytes::from(value.as_ref().to_owned()))
         .or_else(|_| Err(Error::invalid_value(name, value)))
 }
 
@@ -363,7 +363,7 @@ impl Error {
     {
         Error::InvalidHeaderValue(format!(
             "{:?} {:?}",
-            to_string(name.as_ref().into()),
+            to_string(Bytes::from(name.as_ref().to_owned())),
             value.as_ref()
         ))
     }

--- a/quinn-h3/src/qpack/encoder.rs
+++ b/quinn-h3/src/qpack/encoder.rs
@@ -63,7 +63,7 @@ where
         table.max_size(),
     )
     .encode(block);
-    block.put(block_buf);
+    block.put(block_buf.as_slice());
 
     table.commit(required_ref);
 

--- a/quinn-h3/src/qpack/prefix_string/mod.rs
+++ b/quinn-h3/src/qpack/prefix_string/mod.rs
@@ -10,7 +10,7 @@ pub use self::{
 };
 
 use crate::qpack::prefix_int::{self, Error as IntegerError};
-use bytes::{Buf, BufMut};
+use bytes::{buf::ext::BufExt, Buf, BufMut};
 use quinn_proto::coding::BufMutExt;
 
 #[derive(Debug, PartialEq)]
@@ -27,12 +27,12 @@ pub fn decode<B: Buf>(size: u8, buf: &mut B) -> Result<Vec<u8>, Error> {
         return Err(Error::UnexpectedEnd);
     }
 
-    let payload = buf.take(len);
+    let payload = buf.take(len).to_bytes();
     let value = if flags & 1 == 0 {
-        payload.collect()
+        payload.into_iter().collect()
     } else {
         let mut decoded = Vec::new();
-        for byte in payload.collect::<Vec<u8>>().hpack_decode() {
+        for byte in payload.into_iter().collect::<Vec<u8>>().hpack_decode() {
             decoded.push(byte?);
         }
         decoded

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -1,6 +1,12 @@
-use std::{mem, net::SocketAddr, pin::Pin, task::Context};
+use std::{
+    future::Future,
+    mem,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use futures::{ready, Future, Poll, Stream};
+use futures::{ready, Stream};
 use http::{response, HeaderMap, Request, Response};
 use quinn::{EndpointBuilder, EndpointDriver, EndpointError, RecvStream, SendStream};
 use quinn_proto::{Side, StreamId};

--- a/quinn-h3/src/streams.rs
+++ b/quinn-h3/src/streams.rs
@@ -1,9 +1,16 @@
-use std::{collections::VecDeque, convert::TryFrom, io, mem, pin::Pin, task::Context};
+use std::{
+    collections::VecDeque,
+    convert::TryFrom,
+    future::Future,
+    io, mem,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use futures::{
     io::{AsyncRead, AsyncWrite},
-    ready, Future, Poll,
+    ready,
 };
 use quinn::{OpenUni, RecvStream, SendStream};
 use quinn_proto::VarInt;

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -21,14 +21,14 @@ default = ["tls-rustls"]
 tls-rustls = ["rustls", "webpki", "ring"]
 
 [dependencies]
-bytes = "0.5.1"
+bytes = "0.5.2"
 err-derive = "0.2"
 lazy_static = "1"
 rand = "0.7"
 ring = { version = "0.16.7", optional = true }
 rustls = { version = "0.16", features = ["quic"], optional = true }
 slab = "0.4"
-tracing = "0.1.9"
+tracing = "0.1.10"
 webpki = { version = "0.21", optional = true }
 
 [dev-dependencies]

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -21,14 +21,14 @@ default = ["tls-rustls"]
 tls-rustls = ["rustls", "webpki", "ring"]
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5.1"
 err-derive = "0.2"
 lazy_static = "1"
 rand = "0.7"
 ring = { version = "0.16.7", optional = true }
 rustls = { version = "0.16", features = ["quic"], optional = true }
 slab = "0.4"
-tracing = "0.1.10"
+tracing = "0.1.9"
 webpki = { version = "0.21", optional = true }
 
 [dev-dependencies]

--- a/quinn-proto/src/assembler.rs
+++ b/quinn-proto/src/assembler.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, collections::BinaryHeap};
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 
 /// Helper to assemble unordered stream frames into an ordered stream
 #[derive(Debug)]

--- a/quinn-proto/src/coding.rs
+++ b/quinn-proto/src/coding.rs
@@ -33,10 +33,10 @@ impl Codec for u16 {
         if buf.remaining() < 2 {
             return Err(UnexpectedEnd);
         }
-        Ok(buf.get_u16_be())
+        Ok(buf.get_u16())
     }
     fn encode<B: BufMut>(&self, buf: &mut B) {
-        buf.put_u16_be(*self);
+        buf.put_u16(*self);
     }
 }
 
@@ -45,10 +45,10 @@ impl Codec for u32 {
         if buf.remaining() < 4 {
             return Err(UnexpectedEnd);
         }
-        Ok(buf.get_u32_be())
+        Ok(buf.get_u32())
     }
     fn encode<B: BufMut>(&self, buf: &mut B) {
-        buf.put_u32_be(*self);
+        buf.put_u32(*self);
     }
 }
 
@@ -57,10 +57,10 @@ impl Codec for u64 {
         if buf.remaining() < 8 {
             return Err(UnexpectedEnd);
         }
-        Ok(buf.get_u64_be())
+        Ok(buf.get_u64())
     }
     fn encode<B: BufMut>(&self, buf: &mut B) {
-        buf.put_u64_be(*self);
+        buf.put_u64(*self);
     }
 }
 

--- a/quinn-proto/src/crypto/ring.rs
+++ b/quinn-proto/src/crypto/ring.rs
@@ -48,8 +48,8 @@ impl Crypto {
     fn write_nonce(&self, iv: &Iv, number: u64, out: &mut [u8]) {
         let out = {
             let mut write = io::Cursor::new(out);
-            write.put_u32_be(0);
-            write.put_u64_be(number);
+            write.get_mut().put_u32(0);
+            write.get_mut().put_u64(number);
             debug_assert_eq!(write.remaining(), 0);
             write.into_inner()
         };
@@ -300,7 +300,7 @@ mod test {
         buf.resize(buf.len() + client.tag_len(), 0);
         client.encrypt(0, &mut buf, 6);
 
-        let mut header = BytesMut::from(buf);
+        let mut header = BytesMut::from(buf.as_slice());
         let mut payload = header.split_off(6);
         server.decrypt(0, &header, &mut payload).unwrap();
         assert_eq!(&*payload, b"payload");

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -504,7 +504,7 @@ impl Iter {
         }
         let start = self.bytes.position() as usize;
         self.bytes.advance(len as usize);
-        Ok(self.bytes.get_ref().slice(start, start + len as usize))
+        Ok(self.bytes.get_ref().slice(start..(start + len as usize)))
     }
 
     fn try_next(&mut self) -> Result<Frame, IterErr> {
@@ -580,7 +580,7 @@ impl Iter {
                 Frame::Ack(Ack {
                     delay,
                     largest,
-                    additional: self.bytes.get_ref().slice(start, start + len),
+                    additional: self.bytes.get_ref().slice(start..(start + len)),
                     ecn: if ty != Type::ACK_ECN {
                         None
                     } else {

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -457,7 +457,8 @@ impl PartialEncode {
         if write_len {
             let len = buf.len() - header_len + pn_len;
             assert!(len < 2usize.pow(14)); // Fits in reserved space
-            (&mut &mut buf[pn_pos - 2..pn_pos]).put_u16(len as u16 | 0b01 << 14);
+            let mut slice = &mut buf[pn_pos - 2..pn_pos];
+            slice.put_u16(len as u16 | 0b01 << 14);
         }
 
         if let Some((number, crypto)) = crypto {

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -219,7 +219,7 @@ impl TestEndpoint {
             let (_, ecn, packet) = self.inbound.pop_front().unwrap();
             if let Some((ch, event)) =
                 self.endpoint
-                    .handle(now, remote, ecn, Vec::from(packet).into())
+                    .handle(now, remote, ecn, Vec::from(packet).as_slice().into())
             {
                 match event {
                     DatagramEvent::NewConnection(conn) => {

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -1,6 +1,6 @@
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
-use bytes::{Buf, BufMut};
+use bytes::{buf::ext::BufExt as _, Buf, BufMut};
 use err_derive::Error;
 
 use crate::{
@@ -363,7 +363,7 @@ impl TransportParameters {
 #[cfg(test)]
 mod test {
     use super::*;
-    use bytes::IntoBuf;
+    use bytes::Bytes;
 
     #[test]
     fn coding() {
@@ -383,7 +383,7 @@ mod test {
         };
         params.write(&mut buf);
         assert_eq!(
-            TransportParameters::read(Side::Client, &mut buf.into_buf()).unwrap(),
+            TransportParameters::read(Side::Client, &mut Bytes::from(buf)).unwrap(),
             params
         );
     }

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -363,7 +363,6 @@ impl TransportParameters {
 #[cfg(test)]
 mod test {
     use super::*;
-    use bytes::Bytes;
 
     #[test]
     fn coding() {
@@ -383,7 +382,7 @@ mod test {
         };
         params.write(&mut buf);
         assert_eq!(
-            TransportParameters::read(Side::Client, &mut Bytes::from(buf)).unwrap(),
+            TransportParameters::read(Side::Client, &mut buf.as_slice()).unwrap(),
             params
         );
     }

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -168,11 +168,11 @@ impl Codec for VarInt {
         if x < 2u64.pow(6) {
             w.put_u8(x as u8);
         } else if x < 2u64.pow(14) {
-            w.put_u16_be(0b01 << 14 | x as u16);
+            w.put_u16(0b01 << 14 | x as u16);
         } else if x < 2u64.pow(30) {
-            w.put_u32_be(0b10 << 30 | x as u32);
+            w.put_u32(0b10 << 30 | x as u32);
         } else if x < 2u64.pow(62) {
-            w.put_u64_be(0b11 << 62 | x);
+            w.put_u64(0b11 << 62 | x);
         } else {
             unreachable!("malformed VarInt")
         }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -50,7 +50,7 @@ tracing-futures = { version = "0.1.0", default-features = false, features = ["st
 structopt = "0.3.0"
 unwrap = "1.2.1"
 url = "2"
-anyhow = "1.0.23"
+anyhow = "1.0.22"
 
 [[example]]
 name = "server"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -25,18 +25,16 @@ maintenance = { status = "experimental" }
 azure-devops = { project = "dochtman/Projects", pipeline = "Quinn", build = "1" }
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5.1"
 ct-logs = { version = "0.6", optional = true }
 err-derive = "0.2"
-futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
+futures = "0.3.1"
 libc = "0.2.49"
 mio = "0.6"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.4.0" }
 rustls = { version = "0.16", features = ["quic"] }
-tracing = "0.1.10"
-tokio-net = { version = "0.2.0-alpha.5", default-features = false }
-tokio-timer = "0.3.0-alpha.5"
-tokio-io = "0.2.0-alpha.5"
+tracing = "0.1.9"
+tokio = { version = "0.2.1", features = ["io-driver", "time"] }
 webpki = "0.21"
 rustls-native-certs = { version = "0.1.0", optional = true }
 
@@ -46,13 +44,13 @@ criterion = "0.3"
 directories = "2.0.0"
 rand = "0.7"
 rcgen = "0.7"
+tokio = { version = "0.2.1", features = ["rt-core", "rt-util"] }
 tracing-subscriber = "0.1.5"
 tracing-futures = { version = "0.1.0", default-features = false, features = ["std-future"] }
 structopt = "0.3.0"
-tokio = "0.2.0-alpha.5"
 unwrap = "1.2.1"
 url = "2"
-anyhow = "1.0.22"
+anyhow = "1.0.23"
 
 [[example]]
 name = "server"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "experimental" }
 azure-devops = { project = "dochtman/Projects", pipeline = "Quinn", build = "1" }
 
 [dependencies]
-bytes = "0.5.1"
+bytes = "0.5.2"
 ct-logs = { version = "0.6", optional = true }
 err-derive = "0.2"
 futures = "0.3.1"
@@ -33,7 +33,7 @@ libc = "0.2.49"
 mio = "0.6"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.4.0" }
 rustls = { version = "0.16", features = ["quic"] }
-tracing = "0.1.9"
+tracing = "0.1.10"
 tokio = { version = "0.2.1", features = ["io-driver", "time"] }
 webpki = "0.21"
 rustls-native-certs = { version = "0.1.0", optional = true }
@@ -44,7 +44,7 @@ criterion = "0.3"
 directories = "2.0.0"
 rand = "0.7"
 rcgen = "0.7"
-tokio = { version = "0.2.1", features = ["rt-core", "rt-util"] }
+tokio = { version = "0.2.1", features = ["macros", "rt-core"] }
 tracing-subscriber = "0.1.5"
 tracing-futures = { version = "0.1.0", default-features = false, features = ["std-future"] }
 structopt = "0.3.0"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -44,7 +44,7 @@ criterion = "0.3"
 directories = "2.0.0"
 rand = "0.7"
 rcgen = "0.7"
-tokio = { version = "0.2.1", features = ["macros", "rt-core"] }
+tokio = { version = "0.2.2", features = ["macros", "rt-core", "rt-threaded", "time"] }
 tracing-subscriber = "0.1.5"
 tracing-futures = { version = "0.1.0", default-features = false, features = ["std-future"] }
 structopt = "0.3.0"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -47,7 +47,7 @@ rcgen = "0.7"
 tracing-subscriber = "0.1.5"
 tracing-futures = { version = "0.1.0", default-features = false, features = ["std-future"] }
 structopt = "0.3.0"
-tokio = { version = "0.2.2", features = ["macros", "rt-core", "rt-threaded", "time"] }
+tokio = { version = "0.2.2", features = ["rt-core", "rt-threaded", "time"] }
 unwrap = "1.2.1"
 url = "2"
 anyhow = "1.0.22"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -44,10 +44,10 @@ criterion = "0.3"
 directories = "2.0.0"
 rand = "0.7"
 rcgen = "0.7"
-tokio = { version = "0.2.2", features = ["macros", "rt-core", "rt-threaded", "time"] }
 tracing-subscriber = "0.1.5"
 tracing-futures = { version = "0.1.0", default-features = false, features = ["std-future"] }
 structopt = "0.3.0"
+tokio = { version = "0.2.2", features = ["macros", "rt-core", "rt-threaded", "time"] }
 unwrap = "1.2.1"
 url = "2"
 anyhow = "1.0.22"

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -167,7 +167,7 @@ impl Context {
                         while let Some(_) = stream.read_unordered().await.unwrap() {}
                     }
                 }
-                .instrument(error_span!("server")),
+                    .instrument(error_span!("server")),
             );
             runtime.block_on(handle).unwrap();
         });

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -7,7 +7,10 @@ use std::{
 use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use futures::StreamExt;
-use tokio::runtime::{Builder, Runtime};
+use tokio::{
+    runtime::{Builder, Runtime},
+    task::JoinHandle,
+};
 use tracing::error_span;
 use tracing_futures::Instrument as _;
 
@@ -28,7 +31,7 @@ fn throughput(c: &mut Criterion) {
     let mut group = c.benchmark_group("throughput");
     {
         let (addr, thread) = ctx.spawn_server();
-        let (client, mut runtime) = ctx.make_client(addr);
+        let (client, mut runtime, handle) = ctx.make_client(addr);
         const DATA: &[u8] = &[0xAB; 128 * 1024];
         group.throughput(Throughput::Bytes(DATA.len() as u64));
         group.bench_function("large streams", |b| {
@@ -41,13 +44,13 @@ fn throughput(c: &mut Criterion) {
             })
         });
         drop(client);
-        runtime.run().unwrap();
+        runtime.block_on(handle).unwrap();
         thread.join().unwrap();
     }
 
     {
         let (addr, thread) = ctx.spawn_server();
-        let (client, mut runtime) = ctx.make_client(addr);
+        let (client, mut runtime, handle) = ctx.make_client(addr);
         const DATA: &[u8] = &[0xAB; 1];
         group.throughput(Throughput::Elements(1));
         group.bench_function("small streams", |b| {
@@ -59,13 +62,13 @@ fn throughput(c: &mut Criterion) {
             })
         });
         drop(client);
-        runtime.run().unwrap();
+        runtime.block_on(handle).unwrap();
         thread.join().unwrap();
     }
 
     {
         let (addr, thread) = ctx.spawn_server();
-        let (client, mut runtime) = ctx.make_client(addr);
+        let (client, mut runtime, handle) = ctx.make_client(addr);
         let data = Bytes::from(&[0xAB; 1][..]);
         group.throughput(Throughput::Elements(1));
         group.bench_function("small datagrams", |b| {
@@ -76,13 +79,13 @@ fn throughput(c: &mut Criterion) {
             })
         });
         drop(client);
-        runtime.run().unwrap();
+        runtime.block_on(handle).unwrap();
         thread.join().unwrap();
     }
 
     {
         let (addr, thread) = ctx.spawn_server();
-        let (client, mut runtime) = ctx.make_client(addr);
+        let (client, mut runtime, handle) = ctx.make_client(addr);
         let data = Bytes::from(&[0xAB; 1182][..]);
         group.throughput(Throughput::Bytes(data.len() as u64));
         group.bench_function("medium datagrams", |b| {
@@ -93,7 +96,7 @@ fn throughput(c: &mut Criterion) {
             })
         });
         drop(client);
-        runtime.run().unwrap();
+        runtime.block_on(handle).unwrap();
         thread.join().unwrap();
     }
 
@@ -138,10 +141,14 @@ impl Context {
         let handle = thread::spawn(move || {
             let mut endpoint = Endpoint::builder();
             endpoint.listen(config);
-            let (driver, _, mut incoming) = endpoint.with_socket(sock).unwrap();
-            let mut runtime = Builder::new().basic_scheduler().build().unwrap();
+            let mut runtime = Builder::new()
+                .basic_scheduler()
+                .enable_all()
+                .build()
+                .unwrap();
+            let (driver, _, mut incoming) = runtime.enter(|| endpoint.with_socket(sock).unwrap());
             runtime.spawn(async { driver.instrument(error_span!("server")).await.unwrap() });
-            runtime.block_on(
+            let handle = runtime.spawn(
                 async move {
                     let quinn::NewConnection {
                         driver,
@@ -166,15 +173,25 @@ impl Context {
                 }
                 .instrument(error_span!("server")),
             );
+            runtime.block_on(handle).unwrap();
         });
         (addr, handle)
     }
 
-    pub fn make_client(&self, server_addr: SocketAddr) -> (quinn::Connection, Runtime) {
-        let (endpoint_driver, endpoint, _) = Endpoint::builder()
-            .bind(&SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0))
+    pub fn make_client(
+        &self,
+        server_addr: SocketAddr,
+    ) -> (quinn::Connection, Runtime, JoinHandle<()>) {
+        let mut runtime = Builder::new()
+            .basic_scheduler()
+            .enable_all()
+            .build()
             .unwrap();
-        let mut runtime = Builder::new().basic_scheduler().build().unwrap();
+        let (endpoint_driver, endpoint, _) = runtime.enter(|| {
+            Endpoint::builder()
+                .bind(&SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0))
+                .unwrap()
+        });
         runtime.spawn(async move {
             endpoint_driver
                 .instrument(error_span!("client"))
@@ -191,9 +208,9 @@ impl Context {
                     .instrument(error_span!("client")),
             )
             .unwrap();
-        runtime.spawn(async move {
+        let handle = runtime.spawn(async move {
             driver.instrument(error_span!("client")).await.unwrap();
         });
-        (connection, runtime)
+        (connection, runtime, handle)
     }
 }

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -103,7 +103,7 @@ async fn run(options: Opt) -> Result<()> {
         .ok_or(anyhow!("no hostname specified"))?
         .to_owned();
 
-    let r: Result<()> = async {
+    let r: Result<()> = {
         let new_conn = endpoint
             .connect(&remote, &host)?
             .await
@@ -148,8 +148,7 @@ async fn run(options: Opt) -> Result<()> {
         io::stdout().flush().unwrap();
         conn.close(0u32.into(), b"done");
         Ok(())
-    }
-    .await;
+    };
     r?;
 
     // Allow the endpoint driver to automatically shut down

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -185,8 +185,8 @@ async fn handle_connection(root: Arc<Path>, conn: quinn::Connecting) -> Result<(
         }
         Ok(())
     }
-    .instrument(span)
-    .await?;
+        .instrument(span)
+        .await?;
     Ok(())
 }
 

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -37,7 +37,7 @@ struct Opt {
     listen: SocketAddr,
 }
 
-#[tokio::main]
+#[tokio::main(threaded_scheduler)]
 async fn main() {
     tracing::subscriber::set_global_default(
         tracing_subscriber::FmtSubscriber::builder()
@@ -183,8 +183,8 @@ async fn handle_connection(root: Arc<Path>, conn: quinn::Connecting) -> Result<(
         }
         Ok(())
     }
-        .instrument(span)
-        .await?;
+    .instrument(span)
+    .await?;
     Ok(())
 }
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -9,10 +9,10 @@
 //! ```
 //! # use futures::TryFutureExt;
 //! # fn main() {
-//! let mut runtime = tokio::runtime::Runtime::new().unwrap();
+//! let mut runtime = tokio::runtime::Builder::new().basic_scheduler().enable_all().build().unwrap();
 //! let mut builder = quinn::Endpoint::builder();
 //! // <configure builder>
-//! let (endpoint_driver, endpoint, _) = builder.bind(&"[::]:0".parse().unwrap()).unwrap();
+//! let (endpoint_driver, endpoint, _) = runtime.enter(|| builder.bind(&"[::]:0".parse().unwrap()).unwrap());
 //! runtime.spawn(endpoint_driver.unwrap_or_else(|e| panic!("I/O error: {}", e)));
 //! // <use endpoint>
 //! # }

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -1,13 +1,18 @@
-use std::{io, pin::Pin, str};
+use std::{
+    future::Future,
+    io,
+    mem::MaybeUninit,
+    pin::Pin,
+    str,
+    task::{Context, Poll},
+};
 
 use bytes::Bytes;
 use err_derive::Error;
 use futures::{
     channel::oneshot,
     io::{AsyncRead, AsyncWrite},
-    ready,
-    task::Context,
-    Future, FutureExt, Poll,
+    ready, FutureExt,
 };
 use proto::{ConnectionError, StreamId};
 
@@ -141,7 +146,7 @@ impl AsyncWrite for SendStream {
     }
 }
 
-impl tokio_io::AsyncWrite for SendStream {
+impl tokio::io::AsyncWrite for SendStream {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -419,8 +424,8 @@ impl AsyncRead for RecvStream {
     }
 }
 
-impl tokio_io::AsyncRead for RecvStream {
-    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
+impl tokio::io::AsyncRead for RecvStream {
+    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [MaybeUninit<u8>]) -> bool {
         false
     }
 

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -3,11 +3,11 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     str,
     sync::Arc,
-    time::{Duration, Instant},
 };
 
 use futures::{future, FutureExt, StreamExt, TryFutureExt};
-use tokio;
+use tokio::runtime::Builder;
+use tokio::time::{Duration, Instant};
 use tracing::{info, info_span};
 use tracing_futures::Instrument as _;
 
@@ -19,11 +19,17 @@ use super::{
 #[test]
 fn handshake_timeout() {
     let _guard = subscribe();
-    let (client_driver, client, _) = Endpoint::builder()
-        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+    let mut runtime = Builder::new()
+        .threaded_scheduler()
+        .enable_all()
+        .build()
         .unwrap();
+    let (client_driver, client, _) = runtime.enter(|| {
+        Endpoint::builder()
+            .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .unwrap()
+    });
 
-    let runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(client_driver.unwrap_or_else(|e| panic!("client endpoint driver failed: {}", e)));
 
     let mut client_config = crate::ClientConfig::default();
@@ -59,12 +65,18 @@ fn handshake_timeout() {
 #[test]
 fn drop_endpoint() {
     let _guard = subscribe();
-    let (driver, endpoint, _) = Endpoint::builder()
-        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+    let mut runtime = Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
         .unwrap();
+    let (driver, endpoint, _) = runtime.enter(|| {
+        Endpoint::builder()
+            .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .unwrap()
+    });
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-    runtime.spawn(
+    let handle = runtime.spawn(
         endpoint
             .connect(
                 &SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234),
@@ -84,16 +96,23 @@ fn drop_endpoint() {
     );
 
     drop((driver, endpoint));
-    runtime.run().unwrap();
+    runtime.block_on(handle).unwrap();
 }
 
 #[test]
 fn drop_endpoint_driver() {
     let _guard = subscribe();
     let endpoint = Endpoint::builder();
-    let (_, endpoint, _) = endpoint
-        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+    let runtime = Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
         .unwrap();
+    let (_, endpoint, _) = runtime.enter(|| {
+        endpoint
+            .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .unwrap()
+    });
 
     assert!(endpoint
         .connect(
@@ -107,13 +126,19 @@ fn drop_endpoint_driver() {
 fn close_endpoint() {
     let _guard = subscribe();
     let endpoint = Endpoint::builder();
-    let (_driver, endpoint, incoming) = endpoint
-        .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+    let mut runtime = Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
         .unwrap();
+    let (_driver, endpoint, incoming) = runtime.enter(|| {
+        endpoint
+            .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .unwrap()
+    });
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(incoming.for_each(|_| future::ready(())));
-    runtime.spawn(
+    let handle = runtime.spawn(
         endpoint
             .connect(
                 &SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234),
@@ -129,14 +154,19 @@ fn close_endpoint() {
             }),
     );
     endpoint.close(0u32.into(), &[]);
-    runtime.run().unwrap();
+    runtime.block_on(handle).unwrap();
 }
 
 #[test]
 fn local_addr() {
     let socket = UdpSocket::bind("[::1]:0").unwrap();
     let addr = socket.local_addr().unwrap();
-    let (_, ep, _) = Endpoint::builder().with_socket(socket).unwrap();
+    let runtime = Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
+        .unwrap();
+    let (_, ep, _) = runtime.enter(|| Endpoint::builder().with_socket(socket).unwrap());
     assert_eq!(
         addr,
         ep.local_addr()
@@ -147,8 +177,12 @@ fn local_addr() {
 #[test]
 fn read_after_close() {
     let _guard = subscribe();
-    let (driver, endpoint, mut incoming) = endpoint();
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut runtime = Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
+        .unwrap();
+    let (driver, endpoint, mut incoming) = runtime.enter(|| endpoint());
     runtime.spawn(driver.unwrap_or_else(|e| panic!("{}", e)));
     const MSG: &[u8] = b"goodbye!";
     runtime.spawn(async move {
@@ -158,19 +192,19 @@ fn read_after_close() {
             .expect("endpoint")
             .await
             .expect("connection");
-        tokio::runtime::current_thread::spawn(new_conn.driver.unwrap_or_else(|_| ()));
+        tokio::spawn(new_conn.driver.unwrap_or_else(|_| ()));
         let mut s = new_conn.connection.open_uni().await.unwrap();
         s.write_all(MSG).await.unwrap();
         s.finish().await.unwrap();
     });
-    runtime.spawn(async move {
+    runtime.block_on(async move {
         let mut new_conn = endpoint
             .connect(&endpoint.local_addr().unwrap(), "localhost")
             .unwrap()
             .await
             .expect("connect");
-        tokio::runtime::current_thread::spawn(new_conn.driver.unwrap_or_else(|_| ()));
-        tokio::timer::delay(Instant::now() + Duration::from_millis(100)).await;
+        tokio::spawn(new_conn.driver.unwrap_or_else(|_| ()));
+        tokio::time::delay_until(Instant::now() + Duration::from_millis(100)).await;
         let stream = new_conn
             .uni_streams
             .next()
@@ -183,8 +217,6 @@ fn read_after_close() {
             .expect("read_to_end");
         assert_eq!(msg, MSG);
     });
-
-    runtime.run().unwrap();
 }
 
 /// Construct an endpoint suitable for connecting to itself
@@ -212,9 +244,13 @@ fn endpoint() -> (EndpointDriver, Endpoint, Incoming) {
 #[test]
 fn zero_rtt() {
     let _guard = subscribe();
-    let (driver, endpoint, incoming) = endpoint();
+    let mut runtime = Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
+        .unwrap();
+    let (driver, endpoint, incoming) = runtime.enter(|| endpoint());
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(driver.unwrap_or_else(|e| panic!("{}", e)));
     const MSG: &[u8] = b"goodbye!";
     runtime.spawn(incoming.take(2).for_each(|incoming| {
@@ -225,8 +261,8 @@ fn zero_rtt() {
                 connection,
                 ..
             } = incoming.into_0rtt().unwrap_or_else(|_| unreachable!()).0;
-            tokio::runtime::current_thread::spawn(driver.unwrap_or_else(|_| ()));
-            tokio::runtime::current_thread::spawn(async move {
+            tokio::spawn(driver.unwrap_or_else(|_| ()));
+            tokio::spawn(async move {
                 while let Some(Ok(x)) = uni_streams.next().await {
                     let msg = x.read_to_end(usize::max_value()).await.unwrap();
                     assert_eq!(msg, MSG);
@@ -251,9 +287,9 @@ fn zero_rtt() {
             .await
             .expect("connect");
 
-        tokio::runtime::current_thread::spawn(async move {
+        tokio::spawn(async move {
             // Buy time for the driver to process the server's NewSessionTicket
-            tokio::timer::delay(Instant::now() + Duration::from_millis(100)).await;
+            tokio::time::delay_until(Instant::now() + Duration::from_millis(100)).await;
             let stream = uni_streams
                 .next()
                 .await
@@ -288,7 +324,7 @@ fn zero_rtt() {
         s.write_all(MSG).await.expect("0-RTT write");
         s.finish().await.expect("0-RTT finish");
     });
-    runtime.spawn(driver.unwrap_or_else(|_| ()));
+    let handle = runtime.spawn(driver.unwrap_or_else(|_| ()));
     runtime.block_on(async move {
         let stream = uni_streams
             .next()
@@ -306,7 +342,7 @@ fn zero_rtt() {
     // The endpoint driver won't finish if we could still create new connections
     drop(endpoint);
 
-    runtime.run().unwrap();
+    runtime.block_on(handle).unwrap();
 }
 
 #[test]
@@ -336,8 +372,12 @@ fn echo_dualstack() {
 
 fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
     let _guard = subscribe();
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-    {
+    let mut runtime = Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
+        .unwrap();
+    let handler = {
         // We don't use the `endpoint` helper here because we want two different endpoints with
         // different addresses.
         let mut server_config = ServerConfigBuilder::default();
@@ -351,14 +391,15 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
         server.listen(server_config.build());
         let server_sock = UdpSocket::bind(server_addr).unwrap();
         let server_addr = server_sock.local_addr().unwrap();
-        let (server_driver, _, mut server_incoming) = server.with_socket(server_sock).unwrap();
+        let (server_driver, _, mut server_incoming) =
+            runtime.enter(|| server.with_socket(server_sock).unwrap());
 
         let mut client_config = ClientConfigBuilder::default();
         client_config.add_certificate_authority(cert).unwrap();
         client_config.enable_keylog();
         let mut client = Endpoint::builder();
         client.default_client_config(client_config.build());
-        let (client_driver, client, _) = client.bind(&client_addr).unwrap();
+        let (client_driver, client, _) = runtime.enter(|| client.bind(&client_addr).unwrap());
 
         runtime.spawn(
             server_driver
@@ -370,7 +411,7 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
                 .unwrap_or_else(|e| panic!("client driver failed: {}", e))
                 .instrument(info_span!("client endpoint")),
         );
-        runtime.spawn(async move {
+        let handler = runtime.spawn(async move {
             let incoming = server_incoming.next().await.unwrap();
             let new_conn = incoming.instrument(info_span!("server")).await.unwrap();
             tokio::spawn(
@@ -407,8 +448,9 @@ fn run_echo(client_addr: SocketAddr, server_addr: SocketAddr) {
             assert_eq!(&data[..], b"foo");
             new_conn.connection.close(0u32.into(), b"done");
         });
-    }
-    runtime.run().unwrap();
+        handler
+    };
+    runtime.block_on(handler).unwrap();
 }
 
 async fn echo((mut send, recv): (SendStream, RecvStream)) {

--- a/quinn/src/udp.rs
+++ b/quinn/src/udp.rs
@@ -1,9 +1,13 @@
-use std::{io, net::SocketAddr};
+use std::{
+    io,
+    net::SocketAddr,
+    task::{Context, Poll},
+};
 
-use futures::{ready, task::Context, Poll};
+use futures::ready;
 use mio;
 
-use tokio_net::{driver::Handle, util::PollEvented};
+use tokio::io::PollEvented;
 
 use proto::{EcnCodepoint, Transmit};
 
@@ -19,10 +23,10 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
-    pub fn from_std(socket: std::net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {
+    pub fn from_std(socket: std::net::UdpSocket) -> io::Result<UdpSocket> {
         let io = mio::net::UdpSocket::from_socket(socket)?;
         io.init_ext()?;
-        let io = PollEvented::new_with_handle(io, handle)?;
+        let io = PollEvented::new(io)?;
         Ok(UdpSocket { io })
     }
 

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -37,7 +37,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     let shared2 = shared.clone();
     let read_incoming_data = incoming_conns
         .filter_map(|connect| connect.map(|x| x.ok()))
-        .take(expected_messages as u64)
+        .take(expected_messages as usize)
         .for_each(move |new_conn| {
             let conn = new_conn.connection;
             current_thread::spawn(new_conn.driver.unwrap_or_else(|_| ()));

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -37,7 +37,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     let shared2 = shared.clone();
     let read_incoming_data = incoming_conns
         .filter_map(|connect| connect.map(|x| x.ok()))
-        .take(expected_messages as usize)
+        .take(expected_messages)
         .for_each(move |new_conn| {
             let conn = new_conn.connection;
             current_thread::spawn(new_conn.driver.unwrap_or_else(|_| ()));

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -21,14 +21,14 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     )
     .unwrap();
 
-    let mut runtime = unwrap!(Builder::new().basic_scheduler().build());
+    let mut runtime = unwrap!(Builder::new().basic_scheduler().enable_all().build());
     let shared = Arc::new(Mutex::new(Shared { errors: vec![] }));
 
     let (cfg, listener_cert) = configure_listener();
     let mut ep_builder = quinn::Endpoint::builder();
     ep_builder.listen(cfg);
     let (driver, endpoint, incoming_conns) =
-        unwrap!(ep_builder.bind(&"127.0.0.1:0".parse().unwrap()));
+        unwrap!(runtime.enter(|| ep_builder.bind(&"127.0.0.1:0".parse().unwrap())));
     runtime.spawn(driver.unwrap_or_else(|e| panic!("Listener IO error: {}", e)));
     let listener_addr = unwrap!(endpoint.local_addr());
 

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -68,12 +68,12 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
         let shared = shared.clone();
         let task = unwrap!(endpoint.connect_with(client_cfg.clone(), &listener_addr, "localhost"))
             .and_then(move |new_conn| {
-                tokio::spawn(write_to_peer(new_conn.connection, data).unwrap_or_else(
-                    move |e| {
+                tokio::spawn(
+                    write_to_peer(new_conn.connection, data).unwrap_or_else(move |e| {
                         // Error will also be propagated to the driver
                         eprintln!("write failed: {}", e);
-                    },
-                ));
+                    }),
+                );
                 new_conn.driver
             })
             .unwrap_or_else(move |e| {

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -4,7 +4,7 @@ use crc::crc32;
 use futures::{future, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use quinn::{ConnectionError, ReadError, WriteError};
 use rand::{self, RngCore};
-use tokio::runtime::current_thread::{self, Runtime};
+use tokio::runtime::Builder;
 use unwrap::unwrap;
 
 struct Shared {
@@ -21,7 +21,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     )
     .unwrap();
 
-    let mut runtime = unwrap!(Runtime::new());
+    let mut runtime = unwrap!(Builder::new().basic_scheduler().build());
     let shared = Arc::new(Mutex::new(Shared { errors: vec![] }));
 
     let (cfg, listener_cert) = configure_listener();
@@ -40,7 +40,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
         .take(expected_messages)
         .for_each(move |new_conn| {
             let conn = new_conn.connection;
-            current_thread::spawn(new_conn.driver.unwrap_or_else(|_| ()));
+            tokio::spawn(new_conn.driver.unwrap_or_else(|_| ()));
 
             let shared = shared2.clone();
             let task = new_conn
@@ -55,11 +55,11 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
                 .unwrap_or_else(move |e| {
                     shared.lock().unwrap().errors.push(e);
                 });
-            current_thread::spawn(task);
+            tokio::spawn(task);
 
             future::ready(())
         });
-    runtime.spawn(read_incoming_data);
+    let handle = runtime.spawn(read_incoming_data);
 
     let client_cfg = configure_connector(&listener_cert);
 
@@ -68,7 +68,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
         let shared = shared.clone();
         let task = unwrap!(endpoint.connect_with(client_cfg.clone(), &listener_addr, "localhost"))
             .and_then(move |new_conn| {
-                current_thread::spawn(write_to_peer(new_conn.connection, data).unwrap_or_else(
+                tokio::spawn(write_to_peer(new_conn.connection, data).unwrap_or_else(
                     move |e| {
                         // Error will also be propagated to the driver
                         eprintln!("write failed: {}", e);
@@ -94,7 +94,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     // finished.
     drop(endpoint);
 
-    unwrap!(runtime.run());
+    unwrap!(runtime.block_on(handle));
     let shared = shared.lock().unwrap();
     if !shared.errors.is_empty() {
         panic!("some connections failed: {:?}", shared.errors);


### PR DESCRIPTION
<details><summary>Old post</summary>I had to put `tracing` to `0.1.9` until https://github.com/tokio-rs/mio/pull/1170 is resolved.

Also https://github.com/carllerche/string/pull/17 and https://github.com/carllerche/string/pull/18 need to pass, but there are probably workarounds for those.
This is also an option: https://github.com/carllerche/string/pull/20.

Examples and tests aren't done yet, ~~I'm still trying to get the `server` <-> `client` example to work~~.

Any help is appreciated!</details>

This updates the following:
-  `tokio`: `0.2.0-alpha.6` -> `0.2.2`
-  `futures`: `0.3.0-alpha.18` -> `0.3.1`
-  `bytes`: `0.4.7` -> `0.5.2`
-  `string`: `0.2` -> `master`
-  `http`: `a3a8fcb213bc456e0b7a42cf0e2bd57afa49851b` -> `43dffa1eb79f6801e5e07f3338fa56191dc454bb`

Tests, examples and benchmarks are minimally changed to keep the PR small.