### PR TITLE
Document a NewConnection footgun and the meaning of server_name

### DIFF
--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -108,12 +108,14 @@ fn run(options: Opt) -> Result<()> {
             .await
             .map_err(|e| anyhow!("failed to connect: {}", e))?;
         eprintln!("connected at {:?}", start.elapsed());
+        let quinn::NewConnection {
+            driver,
+            connection: conn,
+            ..
+        } = { new_conn };
         tokio::runtime::current_thread::spawn(
-            new_conn
-                .driver
-                .unwrap_or_else(|e| eprintln!("connection lost: {}", e)),
+            driver.unwrap_or_else(|e| eprintln!("connection lost: {}", e)),
         );
-        let conn = new_conn.connection;
         let (mut send, recv) = conn
             .open_bi()
             .await

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -156,6 +156,10 @@ pub struct NewConnection {
     /// Handle for interacting with the connection
     pub connection: Connection,
     /// Unidirectional streams initiated by the peer, in the order they were opened
+    ///
+    /// Note that data for separate streams may be delivered in any order. In other words, reading
+    /// from streams in the order they're opened is not optimal. See `IncomingUniStreams` for
+    /// details.
     pub uni_streams: IncomingUniStreams,
     /// Bidirectional streams initiated by the peer, in the order they were opened
     pub bi_streams: IncomingBiStreams,

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -132,6 +132,23 @@ impl Future for ZeroRttAccepted {
 /// Components of a newly established connection
 ///
 /// Ensure `driver` runs or the connection will not work.
+///
+/// All fields of this struct, in addition to any other handles constructed later, must be dropped
+/// for a connection to be implicitly closed. If the `NewConnection` is stored in a long-lived
+/// variable, moving individual fields won't cause remaining unused fields to be dropped, even with
+/// pattern-matching. The easiest way to ensure unused fields are dropped is to pattern-match on the
+/// variable wrapped in brackets, which forces the entire `NewConnection` to be moved out of the
+/// variable and into a temporary, ensuring all unused fields are dropped at the end of the
+/// statement:
+///
+/// ```rust
+/// # use quinn::NewConnection;
+/// # fn dummy(new_connection: NewConnection) {
+/// let NewConnection { driver, connection, .. } = { new_connection };
+/// # }
+/// ```
+///
+/// You can also explicitly invoke `Connection::close` at any time.
 #[derive(Debug)]
 pub struct NewConnection {
     /// The future responsible for handling I/O on the connection

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -43,6 +43,10 @@ impl Endpoint {
 
     /// Connect to a remote endpoint. Be sure to spawn the `ConnectionDriver` after connecting.
     ///
+    /// `server_name` must be covered by the certificate presented by the server. This prevents a
+    /// connection from being intercepted by an attacker with a valid certificate for some other
+    /// server.
+    ///
     /// May fail immediately due to configuration errors, or in the future if the connection could
     /// not be established.
     pub fn connect(
@@ -55,8 +59,7 @@ impl Endpoint {
 
     /// Connect to a remote endpoint using a custom configuration.
     ///
-    /// May fail immediately due to configuration errors, or in the future if the connection could
-    /// not be established.
+    /// See `connect` for details.
     pub fn connect_with(
         &self,
         config: ClientConfig,


### PR DESCRIPTION
Non-obvious details identified in the course of assisting a new user.