### PR TITLE
Update the dependency on http to a rebased commit

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -9,7 +9,7 @@ default-run = "main"
 quinn = { path = "../quinn" }
 quinn-h3 = { path = "../quinn-h3" }
 quinn-proto = { path = "../quinn-proto" }
-http = { git = "https://github.com/hyperium/http/", rev = "912534f1ef27d8a9050a4bd40d5ea0ee35136ea7" }
+http = { git = "https://github.com/hyperium/http/", rev = "a3a8fcb213bc456e0b7a42cf0e2bd57afa49851b" }
 bytes = "0.4.7"
 structopt = "0.3.0"
 tokio = "0.2.0-alpha.5"

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -27,7 +27,7 @@ bitlab = "0.8.1"
 bytes = "0.4.7"
 err-derive = "0.2"
 futures = { package = "futures-preview", version = "0.3.0-alpha.18" }
-http = { git = "https://github.com/hyperium/http", rev = "912534f1ef27d8a9050a4bd40d5ea0ee35136ea7" }
+http = { git = "https://github.com/hyperium/http", rev = "a3a8fcb213bc456e0b7a42cf0e2bd57afa49851b" }
 lazy_static = "1"
 quinn-proto = { path = "../quinn-proto", version = "0.4.0" }
 quinn = { path = "../quinn", version = "0.4.0" }


### PR DESCRIPTION
The 0.2.x branch got rebased to master, invalidating the commit we were
depending on previously. Depend on an older commit that has the HTTP 3
version but has not upgraded to bytes-0.5 for now.