### PR TITLE
Renamed single char variables

### DIFF
--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -310,32 +310,32 @@ fn run(options: Opt) -> Result<()> {
     drop(state); // Ensure the drivers will shut down once idle
     runtime.run().unwrap();
 
-    let r = results.lock().unwrap();
-    if r.handshake {
+    let results = results.lock().unwrap();
+    if results.handshake {
         print!("VH");
     }
-    if r.stream_data {
+    if results.stream_data {
         print!("D");
     }
-    if r.close {
+    if results.close {
         print!("C");
     }
-    if r.resumption {
+    if results.resumption {
         print!("R");
     }
-    if r.zero_rtt {
+    if results.zero_rtt {
         print!("Z");
     }
-    if r.retry {
+    if results.retry {
         print!("S");
     }
-    if r.rebinding {
+    if results.rebinding {
         print!("B");
     }
-    if r.key_update {
+    if results.key_update {
         print!("U");
     }
-    if r.h3 {
+    if results.h3 {
         print!("3");
     }
 

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -1014,12 +1014,12 @@ where
             .insert(crypto.offset, crypto.data.clone());
         let mut buf = [0; 8192];
         loop {
-            let size = space.crypto_stream.read(&mut buf);
-            if size == 0 {
+            let read = space.crypto_stream.read(&mut buf);
+            if read == 0 {
                 return Ok(());
             }
-            trace!("read {} TLS bytes", size);
-            self.tls.read_handshake(&buf[..size])?;
+            trace!("read {} TLS bytes", read);
+            self.tls.read_handshake(&buf[..read])?;
         }
     }
 
@@ -2891,7 +2891,7 @@ where
         );
         let budget = conn_budget.min(stream_budget).min(data.len() as u64) as usize;
         self.queue_stream_data(stream, (&data[0..budget]).into())?;
-        trace!(%stream, "wrote {} bytes", n);
+        trace!(%stream, "wrote {} bytes", budget);
         Ok(budget)
     }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -652,13 +652,13 @@ where
 
     #[cfg(test)]
     pub(crate) fn known_connections(&self) -> usize {
-        let x = self.connections.len();
-        debug_assert_eq!(x, self.connection_ids_initial.len());
+        let connection_count = self.connections.len();
+        debug_assert_eq!(connection_count, self.connection_ids_initial.len());
         // Not all connections have known reset tokens
-        debug_assert!(x >= self.connection_reset_tokens.0.len());
+        debug_assert!(connection_count >= self.connection_reset_tokens.0.len());
         // Not all connections have unique remotes, and 0-length CIDs might not be in use.
-        debug_assert!(x >= self.connection_remotes.len());
-        x
+        debug_assert!(connection_count >= self.connection_remotes.len());
+        connection_count
     }
 
     #[cfg(test)]

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -520,11 +520,11 @@ impl Iter {
             Type::CONNECTION_CLOSE => Frame::Close(Close::Connection(ConnectionClose {
                 error_code: self.bytes.get()?,
                 frame_type: {
-                    let x = self.bytes.get_var()?;
-                    if x == 0 {
+                    let var_int = self.bytes.get_var()?;
+                    if var_int == 0 {
                         None
                     } else {
-                        Some(Type(x))
+                        Some(Type(var_int))
                     }
                 },
                 reason: self.take_len()?,

--- a/quinn-proto/src/range_set.rs
+++ b/quinn-proto/src/range_set.rs
@@ -213,9 +213,9 @@ impl<'a> Iterator for EltIter<'a> {
             self.next = start;
             self.end = end;
         }
-        let x = self.next;
+        let int = self.next;
         self.next += 1;
-        Some(x)
+        Some(int)
     }
 }
 

--- a/quinn-proto/src/spaces.rs
+++ b/quinn-proto/src/spaces.rs
@@ -95,9 +95,9 @@ where
     pub(crate) fn get_tx_number(&mut self) -> u64 {
         // TODO: Handle packet number overflow gracefully
         assert!(self.next_packet_number < 2u64.pow(62));
-        let x = self.next_packet_number;
+        let packet_number = self.next_packet_number;
         self.next_packet_number += 1;
-        x
+        packet_number
     }
 
     pub(crate) fn can_send(&self) -> bool {

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -296,8 +296,9 @@ impl TestEndpoint {
     }
 
     fn is_idle(&self) -> bool {
-        let t = self.next_wakeup();
-        t == self.timers[Timer(TimerKind::Idle)] || t == self.timers[Timer(TimerKind::KeepAlive)]
+        let instant = self.next_wakeup();
+        instant == self.timers[Timer(TimerKind::Idle)]
+            || instant == self.timers[Timer(TimerKind::KeepAlive)]
     }
 
     pub fn delay_outbound(&mut self) {

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -100,12 +100,12 @@ macro_rules! errors {
 
         impl fmt::Display for Code {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let x = match self.0 {
+                let message = match self.0 {
                     $($val => $desc,)*
                     _ if self.0 >= 0x100 && self.0 < 0x200 => "the cryptographic handshake failed", // FIXME: Describe specific alert
                     _ => "unknown error",
                 };
-                f.write_str(x)
+                f.write_str(message)
             }
         }
     }

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -47,14 +47,14 @@ impl VarInt {
 
     /// Compute the number of bytes needed to encode this value
     pub fn size(self) -> usize {
-        let x = self.0;
-        if x < 2u64.pow(6) {
+        let int = self.0;
+        if int < 2u64.pow(6) {
             1
-        } else if x < 2u64.pow(14) {
+        } else if int < 2u64.pow(14) {
             2
-        } else if x < 2u64.pow(30) {
+        } else if int < 2u64.pow(30) {
             4
-        } else if x < 2u64.pow(62) {
+        } else if int < 2u64.pow(62) {
             8
         } else {
             unreachable!("malformed VarInt");
@@ -128,7 +128,7 @@ impl Codec for VarInt {
         buf[0] = r.get_u8();
         let tag = buf[0] >> 6;
         buf[0] &= 0b0011_1111;
-        let x = match tag {
+        let int = match tag {
             0b00 => u64::from(buf[0]),
             0b01 => {
                 if r.remaining() < 1 {
@@ -153,19 +153,19 @@ impl Codec for VarInt {
             }
             _ => unreachable!(),
         };
-        Ok(VarInt(x))
+        Ok(VarInt(int))
     }
 
     fn encode<B: BufMut>(&self, w: &mut B) {
-        let x = self.0;
-        if x < 2u64.pow(6) {
-            w.put_u8(x as u8);
-        } else if x < 2u64.pow(14) {
-            w.put_u16_be(0b01 << 14 | x as u16);
-        } else if x < 2u64.pow(30) {
-            w.put_u32_be(0b10 << 30 | x as u32);
-        } else if x < 2u64.pow(62) {
-            w.put_u64_be(0b11 << 62 | x);
+        let int = self.0;
+        if int < 2u64.pow(6) {
+            w.put_u8(int as u8);
+        } else if int < 2u64.pow(14) {
+            w.put_u16_be(0b01 << 14 | int as u16);
+        } else if int < 2u64.pow(30) {
+            w.put_u32_be(0b10 << 30 | int as u32);
+        } else if int < 2u64.pow(62) {
+            w.put_u64_be(0b11 << 62 | int);
         } else {
             unreachable!("malformed VarInt")
         }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -86,9 +86,9 @@ impl Future for Connecting {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let connected = match self.0 {
             Some(ref mut driver) => {
-                let r = driver.poll_unpin(cx)?;
+                let result = driver.poll_unpin(cx)?;
                 let driver = self.0.as_mut().unwrap().0.lock().unwrap(); // borrowck workaround
-                match r {
+                match result {
                     Poll::Ready(()) => {
                         return Poll::Ready(Err(driver.error.as_ref().unwrap().clone()));
                     }


### PR DESCRIPTION
Single char variables should not be used except for counters, indexers, and variables like that. Therefore I renamed those to a more meaning full name. Naming variables, even if those are simple, will make code more readable in my opinion, because one does not have to check where the variable comes from to understand the meaning. QUINN has a lot of places were `x`, `n`, `r` was used, sometimes, it is obvious, and sometimes it isn't. I decided to update all of them for the sake of consistency I used this regex `let [a-z] =`, so this does not include other variables than `let ` statements.

If you think, a certain name should be reverted, is not clear enough, is nonsense, please let me know, and I will do the update.


# Changes
- Renamed single-character variable names to have a more descriptive name.
- No changes in logic