### PR TITLE
Add PartialEq, Eq impls to errors throughout the library

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -3140,7 +3140,7 @@ where
 }
 
 /// Reasons why a connection might be lost.
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ConnectionError {
     /// The peer doesn't implement any supported version.
     #[error(display = "peer doesn't implement any supported version")]

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -857,7 +857,7 @@ enum ConnectionOpts<S: crypto::Session> {
 /// Errors in the parameters being used to create a new connection
 ///
 /// These arise before any I/O has been performed.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ConnectError {
     /// The endpoint can no longer create new connections
     ///

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -229,7 +229,7 @@ impl From<ApplicationClose> for Close {
 /// Reason for closing the connection
 ///
 /// This is distinct from the `ApplicationClose` type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectionClose {
     /// Class of error as encoded in the specification
     pub error_code: TransportErrorCode,
@@ -283,7 +283,7 @@ impl ConnectionClose {
 /// Reason for closing the connection
 ///
 /// This is distinct from the `ConnectionClose` type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApplicationClose {
     /// Application-specific reason code
     pub error_code: VarInt,

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -399,7 +399,7 @@ where
 }
 
 /// Errors in the configuration of an endpoint
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ConfigError {
     /// The supplied configuration contained an invalid value
     #[error(display = "illegal configuration value: {}", _0)]

--- a/quinn-proto/src/streams.rs
+++ b/quinn-proto/src/streams.rs
@@ -493,7 +493,7 @@ pub(crate) enum RecvState {
 }
 
 /// Reasons why attempting to finish a stream might fail
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum FinishError {
     /// The peer is no longer accepting data on this stream.
     #[error(display = "stopped by peer: error {}", error_code)]

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -532,7 +532,7 @@ impl<'a> Future for SendDatagram<'a> {
 }
 
 /// Errors that arise from sending a datagram
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum SendDatagramError {
     /// The connection was closed.
     #[error(display = "connection closed: {}", 0)]

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -399,7 +399,7 @@ impl Future for ReadToEnd {
 }
 
 /// Error from the ReadToEnd future
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ReadToEndError {
     /// An error occurred during reading
     #[error(display = "read error")]
@@ -453,7 +453,7 @@ impl Drop for RecvStream {
 }
 
 /// Errors that arise from reading from a stream.
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ReadError {
     /// The peer abandoned transmitting data on this stream.
     #[error(display = "stream reset by peer: error {}", error_code)]
@@ -489,7 +489,7 @@ impl From<ReadError> for io::Error {
 }
 
 /// Errors that arise from writing to a stream
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum WriteError {
     /// The peer is no longer accepting data on this stream.
     #[error(display = "sending stopped by peer: error {}", error_code)]
@@ -564,7 +564,7 @@ impl<'a> Future for ReadExact<'a> {
 }
 
 /// Errors that arise from reading from a stream.
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ReadExactError {
     /// The stream finished before all bytes were read
     #[error(display = "stream finished early")]


### PR DESCRIPTION
A few errors were spared because they were using std::io::Error
internally.

Fixes #549