### PR TITLE
Interop client enhancement

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.22"
 bytes = "0.5.2"
 futures = "0.3.1"
 http = "0.2"
+lazy_static = "1"
 quinn = { path = "../quinn" }
 quinn-h3 = { path = "../quinn-h3" }
 quinn-proto = { path = "../quinn-proto" }

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -15,6 +15,8 @@ use tracing::{error, info, warn};
 #[structopt(name = "interop")]
 struct Opt {
     host: Option<String>,
+    #[structopt(short, long)]
+    name: Option<String>,
     #[structopt(default_value = "4433")]
     port: u16,
     #[structopt(default_value = "4434")]
@@ -147,6 +149,13 @@ async fn main() {
                 _ => Alpn::HqH3,
             },
         }]
+    } else if opt.name.is_some() {
+        let name = opt.name.as_ref().unwrap();
+        PEERS[..]
+            .iter()
+            .filter(|p| &p.name == name)
+            .cloned()
+            .collect()
     } else {
         Vec::from(&PEERS[..])
     };

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -151,13 +151,17 @@ async fn main() {
         Vec::from(&PEERS[..])
     };
 
-    for peer in peers.into_iter() {
-        let name = peer.name.clone();
-        if let Err(e) = run(peer, opt.keylog).await {
-            eprintln!("ERROR: {}: {}", name, e);
-            code = 1;
+    let keylog = opt.keylog;
+    future::join_all(peers.into_iter().map(|peer| {
+        async move {
+            let name = peer.name.clone();
+            if let Err(e) = run(peer, keylog).await {
+                eprintln!("ERROR: {}: {}", name, e);
+                code = 1;
+            }
         }
-    }
+    }))
+    .await;
     ::std::process::exit(code);
 }
 

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -168,6 +168,12 @@ impl Connection {
             .quic
             .close(ErrorCode::NO_ERROR.into(), b"Connection closed");
     }
+
+    // Update traffic keys spontaneously for testing purposes.
+    #[doc(hidden)]
+    pub fn force_key_update(&self) {
+        self.0.quic.force_key_update();
+    }
 }
 
 pub struct Connecting {

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -103,6 +103,20 @@ impl Client {
             connecting: self.endpoint.connect(addr, server_name)?,
         })
     }
+
+    pub fn connect_with(
+        &self,
+        client_config: quinn::ClientConfig,
+        addr: &SocketAddr,
+        server_name: &str,
+    ) -> Result<Connecting, quinn::ConnectError> {
+        Ok(Connecting {
+            settings: self.settings.clone(),
+            connecting: self
+                .endpoint
+                .connect_with(client_config, addr, server_name)?,
+        })
+    }
 }
 
 pub struct Connection(ConnectionRef);

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -62,7 +62,7 @@ pub use crate::builders::{
 mod connection;
 pub use connection::{
     Connecting, Connection, ConnectionDriver, Datagrams, IncomingBiStreams, IncomingUniStreams,
-    NewConnection, OpenBi, OpenUni,
+    NewConnection, OpenBi, OpenUni, ZeroRttAccepted,
 };
 
 mod endpoint;


### PR DESCRIPTION
- [x] Automate interop test to run against all known endpoints at once, when run whitout arguments #524
- [x] Run interop test with HTTP/0.9 / H3 flags to select which tests to execute

If you guys see other subjects to adress, I'd be pleased to implement them.

Do we have to stick with the manual runtime syntax ?
Could it be interesting to run each endpoint interop in parallel ?