### PR TITLE
Fix missing wakeup on datagram send (backport to 0.5)

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/djc/quinn"

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -523,7 +523,10 @@ impl<'a> Future for SendDatagram<'a> {
         }
         match conn.inner.send_datagram() {
             Ok(sender) => match sender.send(mem::replace(&mut this.data, Bytes::new())) {
-                Ok(()) => Poll::Ready(Ok(())),
+                Ok(()) => {
+                    conn.wake();
+                    Poll::Ready(Ok(()))
+                }
                 Err(proto::DatagramTooLarge) => Poll::Ready(Err(SendDatagramError::TooLarge)),
             },
             Err(e) => conn.handle_datagram_err(cx, &mut this.state, e),


### PR DESCRIPTION
Backports #553 to the (newly created) 0.5 branch. Let's release this in a 0.5.1 as it's affecting @LaylConway's published crate.