### PR TITLE
Simplified, synchronous datagram send API

### DIFF
--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -34,10 +34,7 @@ mod timer;
 pub use timer::{Timer, TimerTable, TimerTableIter, TimerTableIterMut};
 
 mod connection;
-pub use crate::connection::{
-    ConnectionError, DatagramSender, DatagramTooLarge, Event, SendDatagramError, TimerSetting,
-    TimerUpdate,
-};
+pub use crate::connection::{ConnectionError, Event, SendDatagramError, TimerSetting, TimerUpdate};
 
 pub mod crypto;
 

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -129,7 +129,8 @@ pub struct TransportConfig {
     ///
     /// While datagrams are sent ASAP, it is possible for an application to generate data faster
     /// than the link, or even the underlying hardware, can transmit them. This limits the amount of
-    /// memory that may be consumed in that case.
+    /// memory that may be consumed in that case. When the send buffer is full and a new datagram is
+    /// sent, older datagrams are dropped until sufficient space is available.
     pub datagram_send_buffer_size: usize,
 }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1171,9 +1171,7 @@ fn datagram_send_recv() {
 
     const DATA: &[u8] = b"whee";
     pair.client_conn_mut(client_ch)
-        .send_datagram()
-        .unwrap()
-        .send(DATA.into())
+        .send_datagram(DATA.into())
         .unwrap();
     pair.drive();
     assert_matches!(
@@ -1188,7 +1186,7 @@ fn datagram_send_recv() {
 }
 
 #[test]
-fn datagram_window() {
+fn datagram_recv_buffer_overflow() {
     let _guard = subscribe();
     const WINDOW: usize = 100;
     let server = ServerConfig {
@@ -1210,19 +1208,13 @@ fn datagram_window() {
     const DATA2: &[u8] = &[0xBC; (WINDOW / 3) + 1];
     const DATA3: &[u8] = &[0xCD; (WINDOW / 3) + 1];
     pair.client_conn_mut(client_ch)
-        .send_datagram()
-        .unwrap()
-        .send(DATA1.into())
+        .send_datagram(DATA1.into())
         .unwrap();
     pair.client_conn_mut(client_ch)
-        .send_datagram()
-        .unwrap()
-        .send(DATA2.into())
+        .send_datagram(DATA2.into())
         .unwrap();
     pair.client_conn_mut(client_ch)
-        .send_datagram()
-        .unwrap()
-        .send(DATA3.into())
+        .send_datagram(DATA3.into())
         .unwrap();
     pair.drive();
     assert_matches!(
@@ -1240,9 +1232,7 @@ fn datagram_window() {
     assert_matches!(pair.server_conn_mut(server_ch).recv_datagram(), None);
 
     pair.client_conn_mut(client_ch)
-        .send_datagram()
-        .unwrap()
-        .send(DATA1.into())
+        .send_datagram(DATA1.into())
         .unwrap();
     pair.drive();
     assert_eq!(
@@ -1267,7 +1257,7 @@ fn datagram_unsupported() {
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     assert_matches!(pair.client_conn_mut(client_ch).max_datagram_size(), None);
 
-    match pair.client_conn_mut(client_ch).send_datagram() {
+    match pair.client_conn_mut(client_ch).send_datagram(Bytes::new()) {
         Err(SendDatagramError::UnsupportedByPeer) => {}
         Err(e) => panic!("unexpected error: {}", e),
         Ok(_) => panic!("unexpected success"),

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -74,7 +74,7 @@ fn throughput(c: &mut Criterion) {
         group.bench_function("small datagrams", |b| {
             b.iter(|| {
                 runtime.block_on(async {
-                    client.send_datagram(data.clone()).await.unwrap();
+                    client.send_datagram(data.clone()).unwrap();
                 });
             })
         });
@@ -91,7 +91,7 @@ fn throughput(c: &mut Criterion) {
         group.bench_function("medium datagrams", |b| {
             b.iter(|| {
                 runtime.block_on(async {
-                    client.send_datagram(data.clone()).await.unwrap();
+                    client.send_datagram(data.clone()).unwrap();
                 });
             })
         });

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -66,40 +66,6 @@ fn throughput(c: &mut Criterion) {
         thread.join().unwrap();
     }
 
-    {
-        let (addr, thread) = ctx.spawn_server();
-        let (client, mut runtime, handle) = ctx.make_client(addr);
-        let data = Bytes::from(&[0xAB; 1][..]);
-        group.throughput(Throughput::Elements(1));
-        group.bench_function("small datagrams", |b| {
-            b.iter(|| {
-                runtime.block_on(async {
-                    client.send_datagram(data.clone()).unwrap();
-                });
-            })
-        });
-        drop(client);
-        runtime.block_on(handle).unwrap();
-        thread.join().unwrap();
-    }
-
-    {
-        let (addr, thread) = ctx.spawn_server();
-        let (client, mut runtime, handle) = ctx.make_client(addr);
-        let data = Bytes::from(&[0xAB; 1182][..]);
-        group.throughput(Throughput::Bytes(data.len() as u64));
-        group.bench_function("medium datagrams", |b| {
-            b.iter(|| {
-                runtime.block_on(async {
-                    client.send_datagram(data.clone()).unwrap();
-                });
-            })
-        });
-        drop(client);
-        runtime.block_on(handle).unwrap();
-        thread.join().unwrap();
-    }
-
     group.finish();
 }
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -52,7 +52,7 @@ mod udp;
 
 pub use proto::{
     crypto, ApplicationClose, ClientConfig, ConnectError, ConnectionClose, ConnectionError,
-    ConnectionId, ServerConfig, Transmit, TransportConfig, VarInt,
+    ConnectionId, SendDatagramError, ServerConfig, Transmit, TransportConfig, VarInt,
 };
 
 pub use crate::builders::{


### PR DESCRIPTION
Applications sending datagrams are expected to prioritize freshness, at the cost of reliability if necessary. Blocking datagram sends when the buffer is full is inconsistent with that, particularly if congestion arises due to a low-priority bulk data stream. Instead, we should opt to discard old data in favor of newly sent data. The significant API and implementation simplification (including the capacity to trivially send datagrams from synchronous code!) is a nice bonus.

CC @LaylConway for thoughts, as the current known user of this API. Note that this only changes behavior on congested links.