### PR TITLE
Remove inappropriate reexport

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -52,7 +52,7 @@ mod udp;
 
 pub use proto::{
     crypto, ApplicationClose, ClientConfig, ConnectError, ConnectionClose, ConnectionError,
-    ConnectionId, DatagramEvent, ServerConfig, Transmit, TransportConfig, VarInt,
+    ConnectionId, ServerConfig, Transmit, TransportConfig, VarInt,
 };
 
 pub use crate::builders::{


### PR DESCRIPTION
Noticed this low-level-only enum exported from the high level crate when skimming the docs.