### PR TITLE
Bump quinn-proto version to 0.5.2

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.5.0"
+version = "0.5.2"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/djc/quinn"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -31,7 +31,7 @@ err-derive = "0.2"
 futures = "0.3.1"
 libc = "0.2.49"
 mio = "0.6"
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.5.0" }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.5.2" }
 rustls = { version = "0.16", features = ["quic"] }
 rustls-native-certs = { version = "0.1.0", optional = true }
 tracing = "0.1.10"


### PR DESCRIPTION
Need this too due to aa80f285ad7d89110ce5a2d86508141eb861120a, whoops!