### PR TITLE
Pub transport params

### DIFF
--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -25,7 +25,7 @@ mod range_set;
 mod spaces;
 #[cfg(all(test, feature = "rustls"))]
 mod tests;
-mod transport_parameters;
+pub mod transport_parameters;
 mod varint;
 
 pub use varint::{VarInt, VarIntBoundsExceeded};

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -178,8 +178,6 @@ impl PreferredAddress {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Error)]
 pub enum Error {
-    #[error(display = "version negotiation was tampered with")]
-    VersionNegotiation,
     #[error(display = "parameter had illegal value")]
     IllegalValue,
     #[error(display = "parameters were malformed")]
@@ -189,7 +187,6 @@ pub enum Error {
 impl From<Error> for TransportError {
     fn from(e: Error) -> Self {
         match e {
-            Error::VersionNegotiation => TransportError::VERSION_NEGOTIATION_ERROR(""),
             Error::IllegalValue => TransportError::TRANSPORT_PARAMETER_ERROR("illegal value"),
             Error::Malformed => TransportError::TRANSPORT_PARAMETER_ERROR("malformed"),
         }


### PR DESCRIPTION
@Ralith I was trying to figure out how to add doc attributes to your macro contraption (by prepending `#[$doc:meta]` to the pattern lists) but so far didn't succeed. Any clues on this?

Interestingly, `TransportParameters` is already somewhat public (cannot be made `pub(crate)`) since it appears in a public interface, but it cannot be named from external crates as far as I can tell. This makes it available (but not at the top-level, since most implementers shouldn't need it).

Doing this on the maintenance branch first, we can then merge it into master. Going in that direction can be slightly more straightforward than going the other way around.