### PR TITLE
Spawn driver tasks implicitly

### DIFF
--- a/quinn-debug
+++ b/quinn-debug
@@ -1,0 +1,390 @@
+Wireshark SSL debug log 
+
+Wireshark version: 3.1.0rc0-765-g3234152b (v3.1.0rc0-765-g3234152b)
+GnuTLS version:    3.4.17
+Libgcrypt version: 1.7.7
+
+
+dissect_ssl enter frame #736 (first time)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x7fcf29431510
+  record: offset = 0, reported_length_remaining = 50
+ssl_try_set_version found version 0x0303 -> state 0x10
+dissect_ssl3_record: content_type 23 Application Data
+decrypt_ssl3_record: app_data len 45, ssl state 0x10
+packet_from_server: is from server - FALSE
+decrypt_ssl3_record: using client decoder
+decrypt_ssl3_record: no decoder available
+
+dissect_ssl enter frame #738 (first time)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x7fcf294321f0
+  record: offset = 0, reported_length_remaining = 50
+ssl_try_set_version found version 0x0303 -> state 0x10
+dissect_ssl3_record: content_type 23 Application Data
+decrypt_ssl3_record: app_data len 45, ssl state 0x10
+packet_from_server: is from server - FALSE
+decrypt_ssl3_record: using client decoder
+decrypt_ssl3_record: no decoder available
+
+dissect_ssl enter frame #739 (first time)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x7fcf29432cc0
+  record: offset = 0, reported_length_remaining = 50
+ssl_try_set_version found version 0x0303 -> state 0x10
+dissect_ssl3_record: content_type 23 Application Data
+decrypt_ssl3_record: app_data len 45, ssl state 0x10
+packet_from_server: is from server - FALSE
+decrypt_ssl3_record: using client decoder
+decrypt_ssl3_record: no decoder available
+
+dissect_ssl enter frame #742 (first time)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x7fcf29433bb0
+  record: offset = 0, reported_length_remaining = 50
+ssl_try_set_version found version 0x0303 -> state 0x10
+dissect_ssl3_record: content_type 23 Application Data
+decrypt_ssl3_record: app_data len 45, ssl state 0x10
+packet_from_server: is from server - FALSE
+decrypt_ssl3_record: using client decoder
+decrypt_ssl3_record: no decoder available
+
+dissect_ssl enter frame #744 (first time)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x7fcf29432cc0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+decrypt_ssl3_record: app_data len 45, ssl state 0x10
+packet_from_server: is from server - FALSE
+decrypt_ssl3_record: using client decoder
+decrypt_ssl3_record: no decoder available
+
+dissect_ssl enter frame #745 (first time)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x7fcf294321f0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+decrypt_ssl3_record: app_data len 45, ssl state 0x10
+packet_from_server: is from server - FALSE
+decrypt_ssl3_record: using client decoder
+decrypt_ssl3_record: no decoder available
+
+dissect_ssl enter frame #746 (first time)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x7fcf29433bb0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+decrypt_ssl3_record: app_data len 45, ssl state 0x10
+packet_from_server: is from server - FALSE
+decrypt_ssl3_record: using client decoder
+decrypt_ssl3_record: no decoder available
+
+dissect_ssl enter frame #750 (first time)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x7fcf29431510
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+decrypt_ssl3_record: app_data len 45, ssl state 0x10
+packet_from_server: is from server - FALSE
+decrypt_ssl3_record: using client decoder
+decrypt_ssl3_record: no decoder available
+
+dissect_ssl enter frame #736 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #738 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #739 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #742 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #744 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #745 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #746 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #750 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #750 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #750 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #736 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #738 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #739 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #742 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #744 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #745 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #746 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #750 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #736 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #738 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #739 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #742 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #744 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #745 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #746 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #750 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #736 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #738 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #739 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #742 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #744 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #745 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #746 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #750 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #736 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #738 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #739 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #742 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #744 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #745 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #746 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #750 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #736 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #738 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #739 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #742 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #744 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29432610, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #745 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29431b40, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #746 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29433500, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data
+
+dissect_ssl enter frame #750 (already visited)
+packet_from_server: is from server - FALSE
+  conversation = 0x7fcf29430e60, ssl_session = 0x0
+  record: offset = 0, reported_length_remaining = 50
+dissect_ssl3_record: content_type 23 Application Data

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -28,19 +28,19 @@ use crate::{
     Error, Settings,
 };
 
-pub struct ConnectionDriver(pub(crate) ConnectionRef);
+pub(crate) struct ConnectionDriver(pub(crate) ConnectionRef);
 
 impl Future for ConnectionDriver {
-    type Output = Result<(), Error>;
+    type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let res = self.0.h3.lock().unwrap().drive(cx);
         match res {
             Ok(false) => Poll::Pending,
-            Ok(true) => Poll::Ready(Ok(())),
-            Err(DriverError(err, code, msg)) => {
+            Ok(true) => Poll::Ready(()),
+            Err(DriverError(_err, code, msg)) => {
                 self.0.quic.close(code.into(), msg.as_bytes());
-                Poll::Ready(Err(err))
+                Poll::Ready(())
             }
         }
     }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -199,7 +199,7 @@ where
                 None
             };
             ch.or_else(|| {
-                if first_decode.is_initial() {
+                if first_decode.is_initial() || first_decode.is_0rtt() {
                     self.connection_ids_initial.get(&dst_cid)
                 } else {
                     None

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -46,7 +46,7 @@ directories = "2.0.0"
 rand = "0.7"
 rcgen = "0.7"
 structopt = "0.3.0"
-tokio = { version = "0.2.2", features = ["rt-core", "rt-threaded", "time", "macros"] }
+tokio = { version = "0.2.6", features = ["rt-threaded", "time", "macros"] }
 tracing-subscriber = "0.1.5"
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 unwrap = "1.2.1"

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -1,8 +1,8 @@
 //! Commonly used code in most examples.
 
 use quinn::{
-    Certificate, CertificateChain, ClientConfig, ClientConfigBuilder, Endpoint, EndpointDriver,
-    Incoming, PrivateKey, ServerConfig, ServerConfigBuilder, TransportConfig,
+    Certificate, CertificateChain, ClientConfig, ClientConfigBuilder, Endpoint, Incoming,
+    PrivateKey, ServerConfig, ServerConfigBuilder, TransportConfig,
 };
 use std::{error::Error, net::SocketAddr, sync::Arc};
 
@@ -15,12 +15,12 @@ use std::{error::Error, net::SocketAddr, sync::Arc};
 pub fn make_client_endpoint(
     bind_addr: SocketAddr,
     server_certs: &[&[u8]],
-) -> Result<(Endpoint, EndpointDriver), Box<dyn Error>> {
+) -> Result<Endpoint, Box<dyn Error>> {
     let client_cfg = configure_client(server_certs)?;
     let mut endpoint_builder = Endpoint::builder();
     endpoint_builder.default_client_config(client_cfg);
-    let (driver, endpoint, _incoming) = endpoint_builder.bind(&bind_addr)?;
-    Ok((endpoint, driver))
+    let (endpoint, _incoming) = endpoint_builder.bind(&bind_addr)?;
+    Ok(endpoint)
 }
 
 /// Constructs a QUIC endpoint configured to listen for incoming connections on a certain address
@@ -28,18 +28,15 @@ pub fn make_client_endpoint(
 ///
 /// ## Returns
 ///
-/// - UDP socket driver
 /// - a sream of incoming QUIC connections
 /// - server certificate serialized into DER format
 #[allow(unused)]
-pub fn make_server_endpoint(
-    bind_addr: SocketAddr,
-) -> Result<(EndpointDriver, Incoming, Vec<u8>), Box<dyn Error>> {
+pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Incoming, Vec<u8>), Box<dyn Error>> {
     let (server_config, server_cert) = configure_server()?;
     let mut endpoint_builder = Endpoint::builder();
     endpoint_builder.listen(server_config);
-    let (driver, _endpoint, incoming) = endpoint_builder.bind(&bind_addr)?;
-    Ok((driver, incoming, server_cert))
+    let (_endpoint, incoming) = endpoint_builder.bind(&bind_addr)?;
+    Ok((incoming, server_cert))
 }
 
 /// Builds default quinn client config and trusts given certificates.

--- a/quinn/src/broadcast.rs
+++ b/quinn/src/broadcast.rs
@@ -19,6 +19,7 @@ use std::task::{Context, Waker};
 /// wakeup is genuine but the condition of interest has already passed, then the task's generation
 /// no longer matches the counter, and we infer that the task's `Waker` is no longer stored and a
 /// new one must be recorded.
+#[derive(Debug)]
 pub struct Broadcast {
     wakers: Vec<Waker>,
     generation: u64,

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -8,14 +8,13 @@
 //!
 //! The entry point of this crate is the [`Endpoint`](struct.Endpoint.html).
 //!
-//! ```
+//! ```no_run
 //! # use futures::TryFutureExt;
-//! let mut runtime = tokio::runtime::Builder::new().basic_scheduler().enable_all().build().unwrap();
 //! let mut builder = quinn::Endpoint::builder();
-//! // <configure builder>
-//! let (endpoint_driver, endpoint, _) = runtime.enter(|| builder.bind(&"[::]:0".parse().unwrap()).unwrap());
-//! runtime.spawn(endpoint_driver.unwrap_or_else(|e| panic!("I/O error: {}", e)));
-//! // <use endpoint>
+//! // ... configure builder ...
+//! // Ensure you're inside a tokio runtime context
+//! let (endpoint, _) = builder.bind(&"[::]:0".parse().unwrap()).unwrap();
+//! // ... use endpoint ...
 //! ```
 //! # About QUIC
 //!
@@ -64,12 +63,12 @@ pub use crate::builders::{
 
 mod connection;
 pub use connection::{
-    Connecting, Connection, ConnectionDriver, Datagrams, IncomingBiStreams, IncomingUniStreams,
-    NewConnection, OpenBi, OpenUni, ZeroRttAccepted,
+    Connecting, Connection, Datagrams, IncomingBiStreams, IncomingUniStreams, NewConnection,
+    OpenBi, OpenUni, ZeroRttAccepted,
 };
 
 mod endpoint;
-pub use endpoint::{Endpoint, EndpointDriver, Incoming};
+pub use endpoint::{Endpoint, Incoming};
 
 mod streams;
 pub use streams::{


### PR DESCRIPTION
We're already reliant on tokio's thread locals for UDP socket and timer registration, and [`Handle::enter`](https://docs.rs/tokio/0.2.6/tokio/runtime/struct.Handle.html#method.enter) provides adequate mechanism to route spawns to a particular runtime if absolutely needed, so passing driver tasks to the user explicitly wasn't buying us much considering how big a footgun it is.