### PR TITLE
Compare reset tokens in constant time

### DIFF
--- a/quinn-proto/src/constant_time.rs
+++ b/quinn-proto/src/constant_time.rs
@@ -1,0 +1,22 @@
+// This function is non-inline to prevent the optimizer from looking inside it.
+#[inline(never)]
+fn constant_time_ne(a: &[u8], b: &[u8]) -> u8 {
+    assert!(a.len() == b.len());
+
+    // These useless slices make the optimizer elide the bounds checks.
+    // See the comment in clone_from_slice() added on Rust commit 6a7bc47.
+    let len = a.len();
+    let a = &a[..len];
+    let b = &b[..len];
+
+    let mut tmp = 0;
+    for i in 0..len {
+        tmp |= a[i] ^ b[i];
+    }
+    tmp // The compare with 0 must happen outside this function.
+}
+
+/// Compares byte strings in constant time.
+pub fn eq(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len() && constant_time_ne(a, b) == 0
+}

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, VecDeque},
+    convert::TryFrom,
     fmt, iter,
     net::SocketAddr,
     ops::{Index, IndexMut},
@@ -903,7 +904,8 @@ impl ResetTokenTable {
     }
 
     fn get(&self, remote: SocketAddr, token: &[u8]) -> Option<&ConnectionHandle> {
-        self.0.get(&remote).and_then(|x| x.get(token))
+        let token = ResetToken::from(<[u8; RESET_TOKEN_SIZE]>::try_from(token).ok()?);
+        self.0.get(&remote)?.get(&token)
     }
 }
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -23,6 +23,7 @@ use std::{fmt, net::SocketAddr, ops, time::Duration};
 mod assembler;
 #[doc(hidden)]
 pub mod coding;
+mod constant_time;
 mod packet;
 mod range_set;
 mod spaces;

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -553,15 +553,17 @@ impl EcnCodepoint {
 /// Stateless reset token
 ///
 /// Used for an endpoint to securely communicate that it has lost state for a connection.
-// FIXME: `Eq` must be constant-time!
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[allow(clippy::derive_hash_xor_eq)] // Custom PartialEq impl matches derived semantics
+#[derive(Debug, Copy, Clone, Hash)]
 pub struct ResetToken([u8; RESET_TOKEN_SIZE]);
 
-impl std::borrow::Borrow<[u8]> for ResetToken {
-    fn borrow(&self) -> &[u8] {
-        &self.0
+impl cmp::PartialEq for ResetToken {
+    fn eq(&self, other: &ResetToken) -> bool {
+        crate::constant_time::eq(&self.0, &other.0)
     }
 }
+
+impl cmp::Eq for ResetToken {}
 
 impl From<[u8; RESET_TOKEN_SIZE]> for ResetToken {
     fn from(x: [u8; RESET_TOKEN_SIZE]) -> Self {


### PR DESCRIPTION
Fixes #585. Opted to inline the constant time eq comparison based on the (CC0) constant_time_eq crate in the spirit of keeping the depgraph down.