### PR TITLE
Update rustls-native-certs

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.49"
 mio = "0.6"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.5.0" }
 rustls = { version = "0.16", features = ["quic"] }
-rustls-native-certs = { version = "0.1.0", optional = true }
+rustls-native-certs = { version = "0.2.1", optional = true }
 tracing = "0.1.10"
 tokio = { version = "0.2.6", features = ["rt-core", "io-driver", "time"] }
 webpki = "0.21"

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -235,8 +235,12 @@ impl Default for ClientConfigBuilder {
             Ok(x) => {
                 crypto.root_store = x;
             }
-            Err(e) => {
-                tracing::warn!("couldn't load default trust roots: {}", e);
+            Err((Some(x), e)) => {
+                crypto.root_store = x;
+                tracing::warn!("couldn't load some default trust roots: {}", e);
+            }
+            Err((None, e)) => {
+                tracing::warn!("couldn't load any default trust roots: {}", e);
             }
         }
         #[cfg(feature = "ct-logs")]


### PR DESCRIPTION
Improves robustness to certificate stores containing unsupported or invalid data.