### PR TITLE
H3 fix user's facing Futures behaviors on driver errors

### DIFF
--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -46,7 +46,7 @@ proptest = "0.9.1"
 rand = "0.7.0"
 rcgen = "0.7"
 structopt = "0.3.0"
-tokio = { version = "0.2.6", features = ["io-util", "macros", "rt-threaded"] }
+tokio = { version = "0.2.6", features = ["io-util", "macros", "rt-threaded", "time"] }
 tracing-subscriber = "0.1.5"
 url = "2"
 

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -33,7 +33,7 @@ lazy_static = "1"
 quinn-proto = { path = "../quinn-proto", version = "0.5.0" }
 quinn = { path = "../quinn", version = "0.5.0" }
 rustls = { version = "0.16", features = ["quic"] }
-tokio = "0.2.2"
+tokio = "0.2.6"
 tokio-util = { version = "0.2.0", features = ["codec"] }
 tracing = "0.1.10"
 webpki = "0.21"
@@ -46,8 +46,8 @@ proptest = "0.9.1"
 rand = "0.7.0"
 rcgen = "0.7"
 structopt = "0.3.0"
-tracing-subscriber = "0.2.0"
-tokio = { version = "0.2.2", features = ["io-util", "macros", "rt-threaded"] }
+tokio = { version = "0.2.6", features = ["io-util", "macros", "rt-threaded"] }
+tracing-subscriber = "0.1.5"
 url = "2"
 
 [[example]]

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -26,6 +26,7 @@ use crate::{
     Error, Settings,
 };
 
+#[cfg_attr(test, derive(Clone))]
 pub struct Builder {
     settings: Settings,
     client_config: quinn::ClientConfigBuilder,

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -173,6 +173,14 @@ impl Connection {
     }
 }
 
+impl Drop for Connection {
+    fn drop(&mut self) {
+        self.0
+            .quic
+            .close(ErrorCode::NO_ERROR.into(), b"Connection closed");
+    }
+}
+
 pub struct Connecting {
     connecting: quinn::Connecting,
     settings: Settings,

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -62,6 +62,17 @@ impl Error {
     pub fn internal<T: Into<String>>(msg: T) -> Self {
         Error::Internal(msg.into())
     }
+
+    pub fn try_into_quic(&self) -> Option<&quinn_proto::ConnectionError> {
+        match self {
+            Error::Quic(e) => Some(e),
+            Error::Write(quinn::WriteError::ConnectionClosed(e)) => Some(e),
+            Error::Io(e) => e
+                .get_ref()
+                .and_then(|e| e.downcast_ref::<quinn_proto::ConnectionError>()),
+            _ => None,
+        }
+    }
 }
 
 impl From<proto::connection::Error> for Error {

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -11,6 +11,9 @@ extern crate proptest;
 #[macro_use]
 extern crate assert_matches;
 
+#[cfg(test)]
+mod tests;
+
 pub use body::Body;
 
 pub mod body;

--- a/quinn-h3/src/qpack/vas.rs
+++ b/quinn-h3/src/qpack/vas.rs
@@ -133,7 +133,7 @@ impl VirtualAddressSpace {
     }
 
     pub fn largest_ref(&self) -> usize {
-        (self.inserted - self.dropped)
+        self.inserted - self.dropped
     }
 
     pub fn total_inserted(&self) -> usize {

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -170,8 +170,9 @@ impl Stream for IncomingRequest {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         match self.0.h3.lock().unwrap().next_request(cx) {
-            Some((s, r)) => Poll::Ready(Some(RecvRequest::new(r, s, self.0.clone()))),
-            None => Poll::Pending
+            Ok(Some((s, r))) => Poll::Ready(Some(RecvRequest::new(r, s, self.0.clone()))),
+            Ok(None) => Poll::Pending,
+            Err(_) => Poll::Ready(None),
         }
     }
 }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -26,6 +26,7 @@ use crate::{
     try_take, Error, Settings,
 };
 
+#[cfg_attr(test, derive(Clone))]
 pub struct Builder {
     config: quinn::ServerConfigBuilder,
     listen: Option<SocketAddr>,

--- a/quinn-h3/src/tests/helpers.rs
+++ b/quinn-h3/src/tests/helpers.rs
@@ -1,0 +1,102 @@
+use std::{
+    fs, io,
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    sync::atomic::{AtomicU16, Ordering},
+};
+
+use anyhow::{bail, Context, Result};
+use quinn::{Certificate, CertificateChain, PrivateKey};
+
+use crate::{
+    client::{self, Client},
+    server::{self, IncomingConnection, Server},
+};
+
+static PORT_COUNT: AtomicU16 = AtomicU16::new(1024);
+
+pub struct Helper {
+    server: server::Builder,
+    client: client::Builder,
+    port: u16,
+}
+
+impl Helper {
+    pub fn new() -> Self {
+        let port = PORT_COUNT.fetch_add(1, Ordering::SeqCst);
+
+        let Certs { chain, key, cert } = CERTS.clone();
+        let mut server = server::Builder::default();
+        server.certificate(chain, key).expect("server certs");
+        server
+            .listen(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), port))
+            .unwrap();
+
+        let mut client = client::Builder::default();
+        client.add_certificate_authority(cert).unwrap();
+
+        Self {
+            server,
+            client,
+            port,
+        }
+    }
+
+    pub fn make_server(&self) -> (Server, IncomingConnection) {
+        self.server.clone().build().expect("server build")
+    }
+
+    pub fn make_client(&self) -> Client {
+        self.client.clone().build().expect("client build")
+    }
+
+    pub async fn make_connection(&self) -> client::Connection {
+        self.make_client()
+            .connect(
+                &SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), self.port),
+                "localhost",
+            )
+            .expect("connect")
+            .await
+            .expect("connecting")
+    }
+}
+
+#[derive(Clone)]
+struct Certs {
+    chain: CertificateChain,
+    cert: Certificate,
+    key: PrivateKey,
+}
+
+lazy_static! {
+    static ref CERTS: Certs = build_certs().expect("build certs");
+}
+
+fn build_certs() -> Result<Certs> {
+    let dirs = directories::ProjectDirs::from("org", "quinn", "quinn-examples").unwrap();
+    let path = dirs.data_local_dir();
+    let cert_path = path.join("cert.der");
+    let key_path = path.join("key.der");
+    let (cert, key) = match fs::read(&cert_path).and_then(|x| Ok((x, fs::read(&key_path)?))) {
+        Ok(x) => x,
+        Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
+            let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+            let key = cert.serialize_private_key_der();
+            let cert = cert.serialize_der().unwrap();
+            fs::create_dir_all(&path).context("failed to create certificate directory")?;
+            fs::write(&cert_path, &cert).context("failed to write certificate")?;
+            fs::write(&key_path, &key).context("failed to write private key")?;
+            (cert, key)
+        }
+        Err(e) => {
+            bail!("failed to read certificate: {}", e);
+        }
+    };
+    let key = quinn::PrivateKey::from_der(&key)?;
+    let cert = quinn::Certificate::from_der(&cert)?;
+    Ok(Certs {
+        chain: quinn::CertificateChain::from_certs(vec![cert.clone()]),
+        cert,
+        key,
+    })
+}

--- a/quinn-h3/src/tests/mod.rs
+++ b/quinn-h3/src/tests/mod.rs
@@ -1,0 +1,79 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+use http::{Request, Response, StatusCode};
+use tokio::time::timeout;
+
+use crate::server::IncomingConnection;
+
+mod helpers;
+use helpers::Helper;
+
+async fn serve_one(mut incoming: IncomingConnection) {
+    let mut incoming_req = incoming
+        .next()
+        .await
+        .expect("connecting")
+        .await
+        .expect("accept");
+    while let Some(recv_req) = incoming_req.next().await {
+        let (_, _, sender) = recv_req.await.expect("recv_req");
+        let body_writer = sender
+            .send_response(Response::builder().status(StatusCode::OK).body(()).unwrap())
+            .await
+            .expect("send_response");
+        body_writer.close().await.expect("response stream close");
+    }
+}
+
+#[tokio::test(threaded_scheduler)]
+async fn incoming_request_stream_ends_on_client_closure() {
+    let helper = Helper::new();
+    let (_, incoming) = helper.make_server();
+    let server_handle = tokio::spawn(async move { serve_one(incoming).await });
+
+    let conn = helper.make_connection().await;
+    let (resp, _) = conn
+        .send_request(
+            Request::get("https://localhost/")
+                .body(())
+                .expect("request"),
+        )
+        .await
+        .expect("request");
+    let _ = resp.await;
+
+    conn.close();
+    // After connection closure, IncomingRequest::next() polling should
+    // resolve to None, so server_handle will resolve as well.
+    timeout(Duration::from_millis(500), server_handle)
+        .await
+        .map_err(|_| panic!("IncomingRequest did not resolve"))
+        .expect("server panic")
+        .unwrap();
+}
+
+#[tokio::test(threaded_scheduler)]
+async fn incoming_request_stream_closed_on_client_drop() {
+    let helper = Helper::new();
+    let (_, incoming) = helper.make_server();
+    let server_handle = tokio::spawn(async move { serve_one(incoming).await });
+
+    let conn = helper.make_connection().await;
+    let (resp, _) = conn
+        .send_request(
+            Request::get("https://localhost/")
+                .body(())
+                .expect("request"),
+        )
+        .await
+        .expect("request");
+    let _ = resp.await;
+    drop(conn);
+
+    timeout(Duration::from_millis(500), server_handle)
+        .await
+        .map_err(|_| panic!("IncomingRequest did not resolve"))
+        .expect("server panic")
+        .unwrap();
+}

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -103,6 +103,7 @@ pub enum EndpointError {
 
 /// Helper for constructing a `ServerConfig` to be passed to `EndpointBuilder::listen` to enable
 /// incoming connections.
+#[derive(Clone)]
 pub struct ServerConfigBuilder {
     config: ServerConfig,
 }
@@ -169,6 +170,7 @@ impl Default for ServerConfigBuilder {
 /// If the `native-certs` and `ct-logs` features are enabled, `ClientConfigBuilder::default()` will
 /// construct a configuration that trusts the host OS certificate store and uses built-in
 /// certificate transparency logs respectively. These features are both enabled by default.
+#[derive(Clone)]
 pub struct ClientConfigBuilder {
     config: ClientConfig,
 }


### PR DESCRIPTION
This PR mainly fixes the `IncomingRequest` stream not resolving when a driver error occurs.

It also fixes driver behaviour when an on error: depending on the error type, it should send a `CONNECTION_CLOSE` frame or not. 

Logging the driver stop reason as an error is also not always pertinent. It depends on what  triggered it.

I'm currently writing a test to check the `IncomingRequest` resolving, but once again i'm blocked because I try to create a generic helper that helps to shorten the test itself.