### PR TITLE
Make lazy_static a dev-dependency only

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -23,7 +23,6 @@ tls-rustls = ["rustls", "webpki", "ring"]
 [dependencies]
 bytes = "0.5.2"
 err-derive = "0.2"
-lazy_static = "1"
 rand = "0.7"
 ring = { version = "0.16.7", optional = true }
 rustls = { version = "0.16", features = ["quic"], optional = true }
@@ -36,3 +35,4 @@ assert_matches = "1.1"
 hex-literal = "0.2.0"
 rcgen = "0.7"
 tracing-subscriber = "0.2.0"
+lazy_static = "1"


### PR DESCRIPTION
This isn't used anywhere outside of tests.