### PR TITLE
Include iOS in the conditional compilation for mac platforms

### DIFF
--- a/quinn/src/platform/unix.rs
+++ b/quinn/src/platform/unix.rs
@@ -71,7 +71,7 @@ impl super::UdpExt for UdpSocket {
         Ok(())
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     fn send_ext(&self, transmits: &[Transmit]) -> io::Result<usize> {
         use crate::udp::BATCH_SIZE;
         let mut msgs: [libc::mmsghdr; BATCH_SIZE] = unsafe { mem::zeroed() };
@@ -105,7 +105,7 @@ impl super::UdpExt for UdpSocket {
         }
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn send_ext(&self, transmits: &[Transmit]) -> io::Result<usize> {
         let mut hdr: libc::msghdr = unsafe { mem::zeroed() };
         let mut iov: libc::iovec = unsafe { mem::zeroed() };


### PR DESCRIPTION
Hi there! We recently updated the quinn version used in [maidsafe/quic-p2p](https://github.com/maidsafe/quic-p2p) to 0.5.3. But after this update we noticed that our Android & iOS builds were failing. This is because `rustls-native-certs` doesn't support Android and iOS (See ctz/rustls-native-certs#3).

Since it's a feature-enabled dependency (enabled by default), I disabled the default features and tried compiling quinn for Android & iOS. The Android build [was successful](https://github.com/maidsafe/safe_client_libs/runs/443170367?check_suite_focus=true), but the iOS [build failed](https://github.com/maidsafe/safe_client_libs/runs/443170238?check_suite_focus=true#step:9:876).

The platform-native API for Mac and iOS are the same so adding this condition gave us a [passing build](https://github.com/maidsafe/safe_client_libs/pull/1168/checks?check_run_id=454639315) and the iOS libraries built were able to successfully establish a connection and exchange messages.