### PR TITLE
QUINN: Allow retrieving the peer's certificate chain from a connection

### DIFF
--- a/quinn/src/tls.rs
+++ b/quinn/src/tls.rs
@@ -15,6 +15,11 @@ impl Certificate {
             inner: rustls::Certificate(der.to_vec()),
         })
     }
+
+    /// View the certificate in DER format
+    pub fn as_der(&self) -> &[u8] {
+        &self.inner.0
+    }
 }
 
 /// A chain of signed TLS certificates ending the one to be used by a server


### PR DESCRIPTION
So this would be my take on #567. 

It turns out that there is already a wrapper for `rustls::Certificate`, so we're not leaking implementation details. The bigger design concern, iiuc, is that TLS is not the only possible crypto protocol for QUIC -- however, `quinn` already commits to TLS. It is also the case that the SNI hostname (which is quite TLS-specific) is accessible at various places even in `quinn-proto`.

An alternative, but much more intrusive approach I considered first was to define an associated datatype for `quinn_proto::crypto::Session`, which abstracts over the type of authentication data applicable to the concrete session. Something like this:

```rust
pub trait Session: Sized {
    // ...
    type AuthenticationData;

    fn authentication_data(&self) -> Self::AuthenticationData;
}

// For `TlsSession`, we'd define
pub struct TlsAuthenticationData {
    sni_hostname: Option<String>,
    peer_certificates: Vec<rustls::Certificate>,
}

// Finally, we don't want to leak `rustls` at the `quinn` layer, so we need to
// define an isomorphic type there, which we can return from the
// `quinn::Connection`:
pub struct AuthenticationData {
    server_name: Option<String>,
    peer_certificates: Option<Vec<quinn::tls::Certificate>>,
}

// Enforce accessors, so we can later decide to make `quinn::Connection` 
// polymorphic in the crypto protocol without breaking client code.
impl AuthenticationData {
    pub fn server_name(&self) -> Option<&str> { /* ... */ }
    pub fn peer_certificates(&self) -> Option<&[quinn::tls::Certificate> { /* ... */ }
}

impl From<TlsAuthenticationData> for AuthenticationData { /* ... */ }

impl quinn::Connection {
    pub fn authentication_data(&self) -> AuthenticationData {
        self.0.lock().unwrap().inner.crypto_session().authentication_data().into()
    }
}
```

**EDIT**: Obviously, since the generic `Connection` is parametric, we can always reify the actual session type. Thus, this approach seemed much ado for very little gain. Using the `AuthenticationData` struct only at the `quinn` level might still be an option, if you'd be willing to deprecate the `Connection::server_name()` method.

Let me know what you think.