### PR TITLE
Refactor H3 settings for validation and defaults management

### DIFF
--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -307,11 +307,7 @@ impl State {
             Alpn::Hq => None,
             _ => {
                 let mut h3_client = quinn_h3::client::Builder::default();
-                h3_client.settings(Settings {
-                    qpack_max_table_capacity: 0,
-                    qpack_blocked_streams: 0,
-                    ..Settings::default()
-                });
+                h3_client.settings(Settings::default());
                 Some(h3_client.endpoint(endpoint.clone()))
             }
         };

--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -20,10 +20,11 @@ use crate::{
     proto::{
         frame::{DataFrame, HttpFrame},
         headers::Header,
+        settings::Settings,
         ErrorCode,
     },
     streams::Reset,
-    Error, Settings,
+    Error,
 };
 
 #[cfg_attr(test, derive(Clone))]
@@ -49,7 +50,7 @@ impl Builder {
         client_config.protocols(&[crate::ALPN]);
         Self {
             client_config,
-            settings: Settings::default(),
+            settings: Settings::new(),
         }
     }
 

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -15,6 +15,7 @@ extern crate assert_matches;
 mod tests;
 
 pub use body::Body;
+pub use proto::settings::Settings;
 
 pub mod body;
 pub mod client;
@@ -29,9 +30,7 @@ mod streams;
 
 use err_derive::Error;
 
-use proto::{frame::SettingsFrame, ErrorCode};
-
-pub type Settings = SettingsFrame;
+use proto::ErrorCode;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/quinn-h3/src/proto/mod.rs
+++ b/quinn-h3/src/proto/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 pub mod connection;
 pub mod frame;
 pub mod headers;
+pub mod settings;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StreamType(pub u64);

--- a/quinn-h3/src/proto/settings.rs
+++ b/quinn-h3/src/proto/settings.rs
@@ -58,9 +58,9 @@ impl Settings {
     /// Create settings with quinn-h3's recomended values
     pub fn new() -> Self {
         Self {
-            max_header_list_size: DEFAULT_MAX_HEADER_LIST_SIZE,
-            qpack_max_table_capacity: DEFAULT_QPACK_MAX_TABLE_CAPACITY,
-            qpack_max_blocked_streams: DEFAULT_QPACK_MAX_BLOCKED_STREAMS,
+            max_header_list_size: 0,
+            qpack_max_table_capacity: 4096,
+            qpack_max_blocked_streams: 128,
         }
     }
 
@@ -322,19 +322,7 @@ mod tests {
         let frame = settings.to_frame();
         assert_eq!(frame.len, 3);
         assert_eq!(frame.entries[0], (SettingId::MAX_HEADER_LIST_SIZE, 43));
-        assert_eq!(
-            frame.entries[1],
-            (
-                SettingId::QPACK_MAX_TABLE_CAPACITY,
-                DEFAULT_QPACK_MAX_TABLE_CAPACITY
-            )
-        );
-        assert_eq!(
-            frame.entries[2],
-            (
-                SettingId::QPACK_MAX_BLOCKED_STREAMS,
-                DEFAULT_QPACK_MAX_BLOCKED_STREAMS
-            )
-        );
+        assert_matches!(frame.entries[1], (SettingId::QPACK_MAX_TABLE_CAPACITY, _));
+        assert_matches!(frame.entries[2], (SettingId::QPACK_MAX_BLOCKED_STREAMS, _));
     }
 }

--- a/quinn-h3/src/proto/settings.rs
+++ b/quinn-h3/src/proto/settings.rs
@@ -1,0 +1,340 @@
+use bytes::{Buf, BufMut};
+use quinn_proto::{
+    coding::{BufExt, BufMutExt, Codec, UnexpectedEnd},
+    VarInt,
+};
+
+use super::frame::{FrameHeader, Type as FrameType};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+pub struct SettingId(pub u64);
+
+macro_rules! setting_identifiers {
+    {$($name:ident = $val:expr,)*} => {
+        impl SettingId {
+            $(pub const $name: SettingId = SettingId($val);)*
+        }
+    }
+}
+
+impl SettingId {
+    const NONE: SettingId = SettingId(0);
+}
+
+setting_identifiers! {
+    QPACK_MAX_TABLE_CAPACITY = 0x1,
+    QPACK_MAX_BLOCKED_STREAMS = 0x7,
+    MAX_HEADER_LIST_SIZE = 0x6,
+}
+
+impl Codec for SettingId {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, UnexpectedEnd> {
+        Ok(SettingId(buf.get_var()?))
+    }
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        buf.write_var(self.0);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Settings {
+    max_header_list_size: u64,
+    qpack_max_table_capacity: u64,
+    qpack_max_blocked_streams: u64,
+}
+
+impl Default for Settings {
+    /// Create settings with H3 default values
+    fn default() -> Self {
+        Self {
+            max_header_list_size: DEFAULT_MAX_HEADER_LIST_SIZE,
+            qpack_max_table_capacity: DEFAULT_QPACK_MAX_TABLE_CAPACITY,
+            qpack_max_blocked_streams: DEFAULT_QPACK_MAX_BLOCKED_STREAMS,
+        }
+    }
+}
+
+impl Settings {
+    /// Create settings with quinn-h3's recomended values
+    pub fn new() -> Self {
+        Self {
+            max_header_list_size: DEFAULT_MAX_HEADER_LIST_SIZE,
+            qpack_max_table_capacity: DEFAULT_QPACK_MAX_TABLE_CAPACITY,
+            qpack_max_blocked_streams: DEFAULT_QPACK_MAX_BLOCKED_STREAMS,
+        }
+    }
+
+    pub fn max_header_list_size(&self) -> u64 {
+        if self.max_header_list_size == 0 {
+            return std::u64::MAX;
+        }
+        self.max_header_list_size
+    }
+
+    pub fn qpack_max_table_capacity(&self) -> u64 {
+        self.qpack_max_table_capacity
+    }
+
+    pub fn qpack_max_blocked_streams(&self) -> u64 {
+        self.qpack_max_blocked_streams
+    }
+
+    pub fn set_max_header_list_size(&mut self, value: u64) -> Result<&mut Self, InvalidValue> {
+        if value > VarInt::MAX.into_inner() as u64 {
+            return Err(InvalidValue(SettingId::QPACK_MAX_TABLE_CAPACITY, value));
+        }
+        self.max_header_list_size = value;
+        Ok(self)
+    }
+
+    pub fn set_qpack_max_blocked_streams(&mut self, value: u64) -> Result<&mut Self, InvalidValue> {
+        if value > MAX_BLOCKED_STREAMS_MAX {
+            return Err(InvalidValue(SettingId::QPACK_MAX_BLOCKED_STREAMS, value));
+        }
+        self.qpack_max_blocked_streams = value;
+        Ok(self)
+    }
+
+    pub fn set_qpack_max_table_capacity(&mut self, value: u64) -> Result<&mut Self, InvalidValue> {
+        if value > MAX_TABLE_CAPACITY_MAX {
+            return Err(InvalidValue(SettingId::QPACK_MAX_TABLE_CAPACITY, value));
+        }
+        self.qpack_max_table_capacity = value;
+        Ok(self)
+    }
+
+    pub(crate) fn from_frame(settings: SettingsFrame) -> Result<Settings, Error> {
+        let mut this = Self::default();
+        for (id, val) in settings.entries[..settings.len].iter() {
+            match *id {
+                SettingId::MAX_HEADER_LIST_SIZE => this.set_max_header_list_size(*val)?,
+                SettingId::QPACK_MAX_TABLE_CAPACITY => this.set_qpack_max_table_capacity(*val)?,
+                SettingId::QPACK_MAX_BLOCKED_STREAMS => this.set_qpack_max_blocked_streams(*val)?,
+                x => return Err(Error::InvalidSettingId(x.0)),
+            };
+        }
+        Ok(this)
+    }
+
+    pub(super) fn to_frame(&self) -> SettingsFrame {
+        let mut frame = SettingsFrame::default();
+        if self.max_header_list_size != DEFAULT_MAX_HEADER_LIST_SIZE {
+            frame
+                .insert(SettingId::MAX_HEADER_LIST_SIZE, self.max_header_list_size)
+                .expect("max header list");
+        }
+        if self.qpack_max_table_capacity != DEFAULT_QPACK_MAX_TABLE_CAPACITY {
+            frame
+                .insert(
+                    SettingId::QPACK_MAX_TABLE_CAPACITY,
+                    self.qpack_max_table_capacity,
+                )
+                .expect("qpack max table");
+        }
+        if self.qpack_max_blocked_streams != DEFAULT_QPACK_MAX_BLOCKED_STREAMS {
+            frame
+                .insert(
+                    SettingId::QPACK_MAX_BLOCKED_STREAMS,
+                    self.qpack_max_blocked_streams,
+                )
+                .expect("qpack max blocked");
+        }
+        frame
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct SettingsFrame {
+    entries: [(SettingId, u64); 3],
+    len: usize,
+}
+
+impl Default for SettingsFrame {
+    fn default() -> Self {
+        Self {
+            entries: [(SettingId::NONE, 0); 3],
+            len: 0,
+        }
+    }
+}
+
+impl SettingsFrame {
+    fn insert(&mut self, id: SettingId, value: u64) -> Result<(), Error> {
+        if self.len >= self.entries.len() {
+            return Err(Error::Exceeded);
+        }
+
+        match id {
+            SettingId::MAX_HEADER_LIST_SIZE
+            | SettingId::QPACK_MAX_TABLE_CAPACITY
+            | SettingId::QPACK_MAX_BLOCKED_STREAMS => (),
+            _ => return Ok(()),
+        }
+
+        if self.entries[..self.len].iter().any(|(i, _)| *i == id) {
+            return Err(Error::Repeated(id));
+        }
+
+        self.entries[self.len] = (id, value);
+        self.len += 1;
+        Ok(())
+    }
+
+    pub(super) fn encode<T: BufMut>(&self, buf: &mut T) {
+        self.encode_header(buf);
+        for (id, val) in self.entries[..self.len].iter() {
+            id.encode(buf);
+            buf.write_var(*val);
+        }
+    }
+
+    pub(super) fn decode<T: Buf>(buf: &mut T) -> Result<SettingsFrame, Error> {
+        let mut settings = SettingsFrame::default();
+        while buf.has_remaining() {
+            if buf.remaining() < 2 {
+                // remains less than 2 * minimum-size varint
+                return Err(Error::Malformed);
+            }
+            let identifier = SettingId::decode(buf).map_err(|_| Error::Malformed)?;
+            let value = buf.get_var().map_err(|_| Error::Malformed)?;
+
+            settings.insert(identifier, value)?;
+        }
+        Ok(settings)
+    }
+}
+
+impl FrameHeader for SettingsFrame {
+    const TYPE: FrameType = FrameType::SETTINGS;
+    fn len(&self) -> usize {
+        self.entries[..self.len].iter().fold(0, |len, (id, val)| {
+            len + VarInt::from_u64(id.0).unwrap().size() + VarInt::from_u64(*val).unwrap().size()
+        })
+    }
+}
+
+const MAX_TABLE_CAPACITY_MAX: u64 = 1_073_741_823; // 2^30 -1
+const MAX_BLOCKED_STREAMS_MAX: u64 = 65_535; // 2^16 - 1
+
+const DEFAULT_MAX_HEADER_LIST_SIZE: u64 = 0; // Infinity
+const DEFAULT_QPACK_MAX_TABLE_CAPACITY: u64 = 0;
+const DEFAULT_QPACK_MAX_BLOCKED_STREAMS: u64 = 0;
+
+#[derive(Debug)]
+pub(crate) enum Error {
+    Exceeded,
+    Malformed,
+    Repeated(SettingId),
+    InvalidSettingId(u64),
+    InvalidSettingValue(SettingId, u64),
+}
+
+#[derive(Debug)]
+pub struct InvalidValue(SettingId, u64);
+
+impl From<InvalidValue> for Error {
+    fn from(e: InvalidValue) -> Error {
+        Error::InvalidSettingValue(e.0, e.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn settings_from_frame() {
+        let mut frame = SettingsFrame::default();
+        frame
+            .insert(SettingId::QPACK_MAX_TABLE_CAPACITY, 40)
+            .unwrap();
+        frame
+            .insert(SettingId::QPACK_MAX_BLOCKED_STREAMS, 41)
+            .unwrap();
+        frame.insert(SettingId::MAX_HEADER_LIST_SIZE, 42).unwrap();
+        let settings = Settings::from_frame(frame).unwrap();
+        assert_eq!(settings.qpack_max_table_capacity(), 40);
+        assert_eq!(settings.qpack_max_blocked_streams(), 41);
+        assert_eq!(settings.max_header_list_size(), 42);
+    }
+
+    #[test]
+    fn frame_insert_twice() {
+        let mut frame = SettingsFrame::default();
+        frame
+            .insert(SettingId::QPACK_MAX_TABLE_CAPACITY, 0)
+            .unwrap();
+        assert_matches!(
+            frame.insert(SettingId::QPACK_MAX_TABLE_CAPACITY, 0),
+            Err(Error::Repeated(SettingId::QPACK_MAX_TABLE_CAPACITY))
+        );
+    }
+
+    #[test]
+    fn settings_frame_unknown_ignored() {
+        let mut frame = SettingsFrame::default();
+        frame.insert(SettingId(0x1aa), 0).unwrap();
+        frame.insert(SettingId(0x13a), 1).unwrap();
+        frame.insert(SettingId(0x12a), 2).unwrap();
+        frame.insert(SettingId(0x19a), 3).unwrap();
+        frame
+            .insert(SettingId::QPACK_MAX_TABLE_CAPACITY, 42)
+            .unwrap();
+        assert_eq!(
+            Settings::from_frame(frame)
+                .unwrap()
+                .qpack_max_table_capacity(),
+            42
+        );
+    }
+
+    #[test]
+    fn settings_frame_no_more_than_3() {
+        let mut frame = SettingsFrame::default();
+        frame.insert(SettingId::MAX_HEADER_LIST_SIZE, 0).unwrap();
+        frame
+            .insert(SettingId::QPACK_MAX_TABLE_CAPACITY, 1)
+            .unwrap();
+        frame
+            .insert(SettingId::QPACK_MAX_BLOCKED_STREAMS, 2)
+            .unwrap();
+        assert_matches!(frame.insert(SettingId::NONE, 42), Err(Error::Exceeded));
+    }
+
+    #[test]
+    fn settings_default_values_not_encoded() {
+        let mut settings = Settings::default();
+        settings.set_qpack_max_table_capacity(42).unwrap();
+        let frame = settings.to_frame();
+        assert_eq!(frame.len, 1);
+        assert_eq!(frame.entries[0], (SettingId::QPACK_MAX_TABLE_CAPACITY, 42));
+    }
+
+    #[test]
+    fn settings_all_defaults() {
+        assert_eq!(Settings::default().to_frame().len, 0);
+    }
+
+    #[test]
+    fn settings_all_values() {
+        let mut settings = Settings::new();
+        // all other values from new() are non-h3-default
+        settings.set_max_header_list_size(43).unwrap();
+        let frame = settings.to_frame();
+        assert_eq!(frame.len, 3);
+        assert_eq!(frame.entries[0], (SettingId::MAX_HEADER_LIST_SIZE, 43));
+        assert_eq!(
+            frame.entries[1],
+            (
+                SettingId::QPACK_MAX_TABLE_CAPACITY,
+                DEFAULT_QPACK_MAX_TABLE_CAPACITY
+            )
+        );
+        assert_eq!(
+            frame.entries[2],
+            (
+                SettingId::QPACK_MAX_BLOCKED_STREAMS,
+                DEFAULT_QPACK_MAX_BLOCKED_STREAMS
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR brings to settings:
* A way to validate the settings as the user set them
* This will make it possible to make some `Settings` usage infallible in lower layers, as a `Settings` struct is always valid now.
* Addressing  #521, only protocol's non-default values are sent.
* Differentiate protocol's defaults and crate's recommended values (used as default).