### PR TITLE
H3: don't run request before client closure tests

### DIFF
--- a/quinn-h3/src/tests/mod.rs
+++ b/quinn-h3/src/tests/mod.rs
@@ -41,16 +41,6 @@ async fn incoming_request_stream_ends_on_client_closure() {
     let server_handle = tokio::spawn(async move { serve_one(incoming).await });
 
     let conn = helper.make_connection().await;
-    let (resp, _) = conn
-        .send_request(
-            Request::get("https://localhost/")
-                .body(())
-                .expect("request"),
-        )
-        .await
-        .expect("request");
-    let _ = resp.await;
-
     conn.close();
     // After connection closure, IncomingRequest::next() polling should
     // resolve to None, so server_handle will resolve as well.
@@ -68,15 +58,6 @@ async fn incoming_request_stream_closed_on_client_drop() {
     let server_handle = tokio::spawn(async move { serve_one(incoming).await });
 
     let conn = helper.make_connection().await;
-    let (resp, _) = conn
-        .send_request(
-            Request::get("https://localhost/")
-                .body(())
-                .expect("request"),
-        )
-        .await
-        .expect("request");
-    let _ = resp.await;
     drop(conn);
 
     timeout(Duration::from_millis(500), server_handle)


### PR DESCRIPTION
Another tentative to fix the flakyness of `incoming_request_stream_ends_on_client_*()`. The test was actually wrong, because making a request here will advance server beyond `incoming.next().await`. Which _is_ the line we want to test.

Hope it will remove the flakiness.

There was this problem happening:
Calling server's `body_writer.close().await` will timeout if the client's connection is closed beforehand. 

Client closure uses `quinn::Connection::reset()` under the hood: I guess the server receives something even if it is not `.await`able ?

So any call should resolve on the server at the moment it receives the `CONNECTION_CLOSE` (including `BodyWriter::close()`)?