### PR TITLE
H3 adjust read buffer size form decoding

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.1"
 quinn = { path = "../quinn" }
 rcgen = "0.7"
 rustls = "0.17"
-tokio = { version = "0.2.2", features = ["rt-core"] }
+tokio = { version = "0.2.13", features = ["rt-core"] }
 tracing = "0.1.10"
 tracing-subscriber = "0.2.0"
 

--- a/quinn-h3/src/frame.rs
+++ b/quinn-h3/src/frame.rs
@@ -30,12 +30,13 @@ pub struct FrameDecoder {
 
 impl FrameDecoder {
     pub fn stream<T: AsyncRead>(stream: T) -> FramedRead<T, Self> {
-        FramedRead::new(
+        FramedRead::with_capacity(
             stream,
             FrameDecoder {
                 expected: None,
                 partial: None,
             },
+            65535,
         )
     }
 }


### PR DESCRIPTION
Mainly addresses #355.

This PR sets the size of the framed read buffer to the size of one UDP packet payload. Thus reducing the chances of reallocations needed to parse an entire http frame.

It uses a new feature of `tokio-util` made available in `0.3.0`.

Some benchmarks have been added to assert the throughput enhancement.

Also brings connection closure fix and its test.


