### PR TITLE
H3: Temporarily disable async tests in coverage

### DIFF
--- a/quinn-h3/src/tests/mod.rs
+++ b/quinn-h3/src/tests/mod.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(tarpaulin, skip)]
 use std::time::Duration;
 
 use futures::{AsyncReadExt, AsyncWriteExt, StreamExt};


### PR DESCRIPTION
As a quick response to #673, let everyone use the CI as async tests are broken and tiemout or fail when run under tarpaulin.

Fixing the test is currently addressed in the mean time.