### PR TITLE
Replace criterion with bencher

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -14,7 +14,7 @@ rcgen = "0.8"
 rustls = "0.17"
 tokio = { version = "0.2.13", features = ["rt-core"] }
 tracing = "0.1.10"
-tracing-subscriber = "0.2.0"
+tracing-subscriber = { version = "0.2.3", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 
 [[bin]]
 name = "bulk"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -19,7 +19,7 @@ rustls = { version = "0.17", features = ["dangerous_configuration"] }
 structopt = "0.3.0"
 tokio = { version = "0.2.2", features = ["macros", "rt-core", "io-util"] }
 tracing = "0.1.10"
-tracing-subscriber = "0.2.0"
+tracing-subscriber = { version = "0.2.3", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 webpki = "0.21"
 

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -40,7 +40,7 @@ webpki = "0.21"
 [dev-dependencies]
 anyhow = "1.0.22"
 assert_matches = "1.1"
-criterion = "0.3"
+bencher = "0.1.5"
 directories = "2.0.1"
 proptest = "0.9.1"
 rand = "0.7.0"

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -47,7 +47,7 @@ rand = "0.7.0"
 rcgen = "0.8"
 structopt = "0.3.0"
 tokio = { version = "0.2.6", features = ["io-util", "macros", "rt-threaded", "time"] }
-tracing-subscriber = "0.2.1"
+tracing-subscriber = { version = "0.2.3", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 url = "2"
 

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -40,5 +40,5 @@ webpki = { version = "0.21", optional = true }
 assert_matches = "1.1"
 hex-literal = "0.2.0"
 rcgen = "0.8"
-tracing-subscriber = "0.2.0"
+tracing-subscriber = { version = "0.2.3", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 lazy_static = "1"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -41,13 +41,13 @@ webpki = { version = "0.21", optional = true }
 [dev-dependencies]
 anyhow = "1.0.22"
 crc = "1.8.1"
-criterion = "0.3"
+bencher = "0.1.5"
 directories = "2.0.0"
 rand = "0.7"
 rcgen = "0.8"
 structopt = "0.3.0"
 tokio = { version = "0.2.6", features = ["rt-threaded", "time", "macros"] }
-tracing-subscriber = "0.2.0"
+tracing-subscriber = "0.2.3"
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 unwrap = "1.2.1"
 url = "2"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -47,7 +47,7 @@ rand = "0.7"
 rcgen = "0.8"
 structopt = "0.3.0"
 tokio = { version = "0.2.6", features = ["rt-threaded", "time", "macros"] }
-tracing-subscriber = "0.2.3"
+tracing-subscriber = { version = "0.2.3", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 unwrap = "1.2.1"
 url = "2"


### PR DESCRIPTION
I never found criterion's statistics to be correct, and it has a *lot* of dependencies. Results in 32 fewer dev-dependencies.