### PR TITLE
H3: Test re-enabling h3 async tests after busy-loop fix

### DIFF
--- a/quinn-h3/src/tests/mod.rs
+++ b/quinn-h3/src/tests/mod.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(tarpaulin, skip)]
 use std::time::Duration;
 
 use futures::{AsyncReadExt, AsyncWriteExt, StreamExt};


### PR DESCRIPTION
To see if #686 has fixed them.