### PR TITLE
Connection ID fixes

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2106,8 +2106,8 @@ where
             return;
         }
 
-        let initially_active = 1 + self.params.preferred_address.is_some() as u64;
-        let n = (self.params.active_connection_id_limit - initially_active).min(LOC_CID_COUNT - 1);
+        // Subtract 1 to account for the CID we supplied while handshaking
+        let n = self.params.active_connection_id_limit.min(LOC_CID_COUNT) - 1;
         self.endpoint_events
             .push_back(EndpointEventInner::NeedIdentifiers(n));
         self.cids_issued += n;

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -56,7 +56,10 @@ where
     rem_cid: ConnectionId,
     /// The CID the peer initially chose, for use during the handshake
     rem_handshake_cid: ConnectionId,
-    /// Sequence number of `rem_cid`. Always < self.next_rem_cid_seq, usually by exactly 1.
+    /// Sequence number of `rem_cid`
+    ///
+    /// Exactly one prior to `self.rem_cids.offset` except during processing of certain
+    /// NEW_CONNECTION_ID frames.
     rem_cid_seq: u64,
     path: PathData,
     prev_path: Option<PathData>,


### PR DESCRIPTION
Fixes #689, which turned out to be a regression introduced in #683.

This bug caused unintended `RETIRE_CONNECTION_ID` frames to be sent for active remote CID when a duplicate `NEW_CONNECTION_ID` frame was received containing it. The peer responded to that packet with a `NEW_CONNECTION_ID` to replace the retired CID, triggering a false `CONNECTION_ID_LIMIT_ERROR`. Additionally, future packets received by the peer elicited a stateless reset, as they still bore the retired CID. These stateless resets raced with the `NEW_CONNECTION_ID`, sometimes causing an unexpected connection reset before the `CONNECTION_ID_LIMIT_ERROR` was triggered.

Thanks to @DemiMarie-parity for the brute-force testing that identified this issue! As an issue that only arose when certain packets are spuriously retransmitted, this is another example of the value to be had in #675.