### PR TITLE
Fix initial data limit for remotely initiated bidirectional streams

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/djc/quinn"

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2723,12 +2723,8 @@ where
         if self.state.is_closed() {
             return None;
         }
-        let id = self.streams.open(self.side, dir)?;
-        // TODO: Queue STREAM_ID_BLOCKED if None
-        self.streams.send_mut(id).unwrap().max_data = match dir {
-            Dir::Uni => self.params.initial_max_stream_data_uni,
-            Dir::Bi => self.params.initial_max_stream_data_bidi_remote,
-        } as u64;
+        // TODO: Queue STREAM_ID_BLOCKED if this fails
+        let id = self.streams.open(&self.params, self.side, dir)?;
         Some(id)
     }
 
@@ -2750,7 +2746,8 @@ where
                 space.pending.max_uni_stream_id = true;
             }
         }
-        self.streams.alloc_remote_stream(self.side, dir);
+        self.streams
+            .alloc_remote_stream(&self.params, self.side, dir);
     }
 
     /// Accept a remotely initiated stream of a certain directionality, if possible

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/djc/quinn"
@@ -32,7 +32,7 @@ err-derive = "0.2.3"
 futures = "0.3.1"
 libc = "0.2.67"
 mio = "0.6"
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.6.0" }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.6.1" }
 rustls = { version = "0.17", features = ["quic"], optional = true }
 tracing = "0.1.10"
 tokio = { version = "0.2.6", features = ["rt-core", "io-driver", "time"] }


### PR DESCRIPTION
Although we were correctly setting the data limit for the send half of initially-available remotely-initiated bidirectional streams, we neglected to apply the limit to streams made available by stream ID flow control updates. As a result, the application would be erroneously prevented from writing to the send half of bidirectional streams opened by the peer after the initial stream_window_bidi streams.

Fixes #694.