### PR TITLE
Store outgoing stream data with stream state

### DIFF
--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2695,15 +2695,7 @@ where
     ///
     /// If this fails, no [`Event::StreamFinished`] will be generated.
     pub fn finish(&mut self, id: StreamId) -> Result<(), FinishError> {
-        let ss = self
-            .streams
-            .send_mut(id)
-            .ok_or(FinishError::UnknownStream)?;
-        let was_pending = ss.is_pending();
-        ss.finish()?;
-        if !was_pending {
-            self.streams.pending.push(id);
-        }
+        self.streams.finish(id)?;
         // We no longer need to notify the application of capacity for additional writes.
         self.blocked_streams.remove(&id);
         Ok(())

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -27,6 +27,7 @@ pub mod coding;
 mod constant_time;
 mod packet;
 mod range_set;
+mod send_buffer;
 mod spaces;
 #[cfg(all(test, feature = "rustls"))]
 mod tests;

--- a/quinn-proto/src/range_set.rs
+++ b/quinn-proto/src/range_set.rs
@@ -172,10 +172,15 @@ impl RangeSet {
         }
     }
 
-    pub fn pop_min(&mut self) -> Option<Range<u64>> {
+    pub fn peek_min(&self) -> Option<Range<u64>> {
         let (&start, &end) = self.0.iter().next()?;
-        self.0.remove(&start);
         Some(start..end)
+    }
+
+    pub fn pop_min(&mut self) -> Option<Range<u64>> {
+        let result = self.peek_min()?;
+        self.0.remove(&result.start);
+        Some(result)
     }
 }
 

--- a/quinn-proto/src/send_buffer.rs
+++ b/quinn-proto/src/send_buffer.rs
@@ -112,6 +112,11 @@ impl SendBuffer {
     pub fn has_unsent_data(&self) -> bool {
         self.unsent != self.offset || !self.retransmits.is_empty()
     }
+
+    /// Compute the amount of data that hasn't been acknowledged
+    pub fn unacked(&self) -> u64 {
+        self.unacked.len() as u64 - self.acks.iter().map(|x| x.end - x.start).sum::<u64>()
+    }
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/send_buffer.rs
+++ b/quinn-proto/src/send_buffer.rs
@@ -1,0 +1,169 @@
+use std::ops::Range;
+
+use bytes::{Buf, BytesMut};
+
+use crate::range_set::RangeSet;
+
+/// Buffer of outgoing retransmittable stream data
+#[derive(Debug)]
+pub struct SendBuffer {
+    /// Data queued by the application but not yet acknowledged. May or may not have been sent.
+    unacked: BytesMut,
+    /// The first offset that hasn't been written by the application, i.e. the offset past the end of `unacked`
+    offset: u64,
+    /// The first offset that hasn't been sent
+    ///
+    /// Always lies in (offset - unacked.len())..offset
+    unsent: u64,
+    /// Acknowledged ranges which couldn't be discarded yet as they don't include the earliest
+    /// offset in `unacked`
+    // TODO: Recover storage from these by compacting (#700)
+    acks: RangeSet,
+    /// Previously transmitted ranges deemed lost
+    retransmits: RangeSet,
+    /// See the same-named method
+    in_flight: u64,
+}
+
+impl SendBuffer {
+    /// Construct an empty buffer at the initial offset
+    pub fn new() -> Self {
+        Self {
+            unacked: BytesMut::new(),
+            offset: 0,
+            unsent: 0,
+            acks: RangeSet::new(),
+            retransmits: RangeSet::new(),
+            in_flight: 0,
+        }
+    }
+
+    /// Append application data to the end of the stream
+    pub fn write(&mut self, data: &[u8]) {
+        self.unacked.extend_from_slice(data);
+        self.offset += data.len() as u64;
+        self.in_flight += data.len() as u64;
+    }
+
+    /// Discard a range of acknowledged stream data
+    ///
+    /// Each offset must be acknowledged at most once.
+    pub fn ack(&mut self, range: Range<u64>) {
+        self.in_flight -= range.end - range.start;
+        self.acks.insert(range);
+        while self.acks.min() == Some(self.offset - self.unacked.len() as u64) {
+            let prefix = self.acks.pop_min().unwrap();
+            self.unacked.advance((prefix.end - prefix.start) as usize);
+        }
+    }
+
+    /// Compute the next range to transmit on this stream and update state to account for that
+    /// transmission
+    pub fn poll_transmit(&mut self, max_len: usize) -> Range<u64> {
+        if let Some(range) = self.retransmits.pop_min() {
+            // Retransmit sent data
+            let end = range.end.min((max_len as u64).saturating_add(range.start));
+            if end != range.end {
+                self.retransmits.insert(end..range.end);
+            }
+            return range.start..end;
+        }
+        // Transmit new data
+        let end = self
+            .offset
+            .min((max_len as u64).saturating_add(self.unsent));
+        let result = self.unsent..end;
+        self.unsent = end;
+        result
+    }
+
+    pub fn get(&self, offsets: Range<u64>) -> &[u8] {
+        let base_offset = self.offset - self.unacked.len() as u64;
+        let start = (offsets.start - base_offset) as usize;
+        let end = (offsets.end - base_offset) as usize;
+        &self.unacked[start..end]
+    }
+
+    /// Queue a range of sent but unacknowledged data to be retransmitted
+    pub fn retransmit(&mut self, range: Range<u64>) {
+        debug_assert!(range.end <= self.unsent, "unsent data can't be lost");
+        self.retransmits.insert(range);
+    }
+
+    pub fn retransmit_all_for_0rtt(&mut self) {
+        debug_assert_eq!(self.offset, self.unacked.len() as u64);
+        self.unsent = 0;
+    }
+
+    /// First stream offset unwritten by the application, i.e. the offset that the next write will
+    /// begin at
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    /// Number of written bytes that have not been acknowledged
+    pub fn in_flight(&self) -> u64 {
+        self.in_flight
+    }
+
+    /// Whether there's data to send
+    ///
+    /// There may be sent unacknowledged data even when this is false.
+    pub fn has_unsent_data(&self) -> bool {
+        self.unsent != self.offset || !self.retransmits.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fragment() {
+        let mut buf = SendBuffer::new();
+        const MSG: &[u8] = b"Hello, world!";
+        buf.write(MSG);
+        assert_eq!(buf.poll_transmit(5), 0..5);
+        assert_eq!(buf.poll_transmit(MSG.len() - 5), 5..MSG.len() as u64);
+        assert_eq!(buf.poll_transmit(42), MSG.len() as u64..MSG.len() as u64);
+    }
+
+    #[test]
+    fn retransmit() {
+        let mut buf = SendBuffer::new();
+        const MSG: &[u8] = b"Hello, world!";
+        buf.write(MSG);
+        // Transmit two frames
+        assert_eq!(buf.poll_transmit(5), 0..5);
+        assert_eq!(buf.poll_transmit(2), 5..7);
+        // Lose the first, but not the second
+        buf.retransmit(0..5);
+        // Ensure we only retransmit the lost frame, then continue sending fresh data
+        assert_eq!(buf.poll_transmit(5), 0..5);
+        assert_eq!(buf.poll_transmit(MSG.len() - 7), 7..MSG.len() as u64);
+    }
+
+    #[test]
+    fn ack() {
+        let mut buf = SendBuffer::new();
+        const MSG: &[u8] = b"Hello, world!";
+        buf.write(MSG);
+        assert_eq!(buf.poll_transmit(5), 0..5);
+        buf.ack(0..5);
+        assert_eq!(buf.unacked, MSG[5..]);
+    }
+
+    #[test]
+    fn reordered_ack() {
+        let mut buf = SendBuffer::new();
+        const MSG: &[u8] = b"Hello, world!";
+        buf.write(MSG);
+        assert_eq!(buf.poll_transmit(5), 0..5);
+        assert_eq!(buf.poll_transmit(2), 5..7);
+        buf.ack(5..7);
+        assert_eq!(buf.unacked, MSG);
+        buf.ack(0..5);
+        assert_eq!(buf.unacked, MSG[7..]);
+        assert!(buf.acks.is_empty());
+    }
+}

--- a/quinn-proto/src/spaces.rs
+++ b/quinn-proto/src/spaces.rs
@@ -151,7 +151,10 @@ pub(crate) struct SentPacket {
     pub(crate) ack_eliciting: bool,
     pub(crate) acks: RangeSet,
     pub(crate) retransmits: Retransmits,
-    pub(crate) stream_frames: Vec<frame::Stream>,
+    /// Metadata for stream frames in a packet
+    ///
+    /// The actual application data is stored with the stream state.
+    pub(crate) stream_frames: Vec<frame::StreamMeta>,
 }
 
 /// Retransmittable data queue

--- a/quinn-proto/src/streams.rs
+++ b/quinn-proto/src/streams.rs
@@ -22,7 +22,10 @@ pub(crate) struct Streams {
     pub next_remote: [u64; 2],
     // Next to report to the application, once opened
     next_reported_remote: [u64; 2],
-    // Outbound streams
+    /// Number of outbound streams
+    ///
+    /// This differs from `self.send.len()` in that it does not include streams that the peer is
+    /// permitted to open but which have not yet been opened.
     send_streams: usize,
 }
 

--- a/quinn-proto/src/streams.rs
+++ b/quinn-proto/src/streams.rs
@@ -563,16 +563,6 @@ pub(crate) enum SendState {
     ResetRecvd { stop_reason: Option<VarInt> },
 }
 
-impl SendState {
-    pub fn was_reset(self) -> bool {
-        use self::SendState::*;
-        match self {
-            ResetSent { .. } | ResetRecvd { .. } => true,
-            _ => false,
-        }
-    }
-}
-
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum RecvState {
     Recv { size: Option<u64> },

--- a/quinn-proto/src/streams.rs
+++ b/quinn-proto/src/streams.rs
@@ -1,12 +1,19 @@
-use std::collections::{hash_map, HashMap};
+use std::{
+    collections::{hash_map, HashMap},
+    mem,
+};
 
 use bytes::Bytes;
 use err_derive::Error;
 use tracing::debug;
 
 use crate::{
-    assembler::Assembler, frame, range_set::RangeSet, send_buffer::SendBuffer,
-    transport_parameters::TransportParameters, Dir, Side, StreamId, TransportError, VarInt,
+    assembler::Assembler,
+    frame::{self, FrameStruct},
+    range_set::RangeSet,
+    send_buffer::SendBuffer,
+    transport_parameters::TransportParameters,
+    Dir, Side, StreamId, TransportError, VarInt,
 };
 
 pub(crate) struct Streams {
@@ -237,6 +244,34 @@ impl Streams {
 
     pub fn can_send(&self) -> bool {
         !self.pending.is_empty()
+    }
+
+    /// Get data to send on a stream frame, if any is available
+    pub fn poll_transmit(&mut self, max_frame_size: usize) -> Option<frame::StreamMeta> {
+        let max_data_len = max_frame_size.checked_sub(frame::Stream::SIZE_BOUND)?;
+        loop {
+            let id = self.pending.pop()?;
+            let stream = match self.send.get_mut(&id) {
+                Some(s) => s,
+                // Stream was reset with pending data and the reset was acknowledged
+                None => continue,
+            };
+            // Reset streams aren't removed from the pending list and still exist while the peer
+            // hasn't acknowledged the reset, but should not generate STREAM frames, so we need to
+            // check for them explicitly.
+            if stream.is_reset() {
+                continue;
+            }
+            let offsets = stream.pending.poll_transmit(max_data_len);
+            let fin = offsets.end == stream.pending.offset()
+                && mem::replace(&mut stream.fin_pending, false);
+            if stream.is_pending() {
+                self.pending.push(id);
+            }
+            // Would be nice to return a slice directly here as well so the caller doesn't have to
+            // call `pending_data` and redo the hash lookup, but borrowck objects.
+            return Some(frame::StreamMeta { id, offsets, fin });
+        }
     }
 
     /// Returns whether the stream was finished

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1307,7 +1307,9 @@ fn finish_acked() {
 
     const MSG: &[u8] = b"hello";
     pair.client_conn_mut(client_ch).write(s, MSG).unwrap();
+    info!("client sends data to server");
     pair.drive_client(); // send data to server
+    info!("server acknowledges data");
     pair.drive_server(); // process data and send data ack
 
     // Receive data
@@ -1330,10 +1332,12 @@ fn finish_acked() {
     // Finish before receiving data ack
     pair.client_conn_mut(client_ch).finish(s).unwrap();
     // Send FIN, receive data ack
+    info!("client receives ACK, sends FIN");
     pair.drive_client();
     // Check for premature finish from data ack
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     // Process FIN ack
+    info!("server ACKs FIN");
     pair.drive();
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),


### PR DESCRIPTION
Improves stream frame packing and establishes groundwork for intelligent selection of which stream to transmit for.

Fixes #561.

This is a major internal refactoring; prior drafts broke a bunch of tests and non-obvious further breakage is very possible. In the interest of making a robust release, let's take care not to merge this prior to 0.6.1.