### PR TITLE
Interop throughput

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -11,6 +11,8 @@ anyhow = "1.0.22"
 bytes = "0.5.2"
 futures = "0.3.1"
 http = "0.2"
+hyper = "0.13"
+hyper-rustls = "0.20"
 lazy_static = "1"
 quinn = { path = "../quinn" }
 quinn-h3 = { path = "../quinn-h3" }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -20,6 +20,7 @@ quinn-proto = { path = "../quinn-proto" }
 rustls = { version = "0.17", features = ["dangerous_configuration"] }
 structopt = "0.3.0"
 tokio = { version = "0.2.2", features = ["macros", "rt-core", "io-util"] }
+tokio-rustls = "0.13"
 tracing = "0.1.10"
 tracing-subscriber = { version = "0.2.3", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -333,7 +333,7 @@ impl State {
             .open_bi()
             .await
             .map_err(|e| anyhow!("failed to open stream: {}", e))?;
-        get(stream)
+        get(stream, "/")
             .await
             .map_err(|e| anyhow!("simple request failed: {}", e))?;
         result.stream_data = true;
@@ -360,7 +360,7 @@ impl State {
                     .open_bi()
                     .await
                     .map_err(|e| anyhow!("failed to open 0-RTT stream: {}", e))?;
-                get(stream)
+                get(stream, "/")
                     .await
                     .map_err(|e| anyhow!("0-RTT request failed: {}", e))?;
                 result.zero_rtt = true;
@@ -396,13 +396,13 @@ impl State {
             .open_bi()
             .await
             .map_err(|e| anyhow!("failed to open stream: {}", e))?;
-        get(stream).await?;
+        get(stream, "/").await?;
         conn.force_key_update();
         let stream = conn
             .open_bi()
             .await
             .map_err(|e| anyhow!("failed to open stream: {}", e))?;
-        get(stream).await?;
+        get(stream, "/").await?;
         conn.close(0u32.into(), b"done");
         Ok(())
     }
@@ -421,7 +421,7 @@ impl State {
             .open_bi()
             .await
             .map_err(|e| anyhow!("failed to open stream: {}", e))?;
-        get(stream).await?;
+        get(stream, "/").await?;
         new_conn.connection.close(0u32.into(), b"done");
         Ok(())
     }
@@ -442,7 +442,7 @@ impl State {
             .open_bi()
             .await
             .map_err(|e| anyhow!("failed to open stream: {}", e))?;
-        get(stream).await?;
+        get(stream, "/").await?;
         new_conn.connection.close(0u32.into(), b"done");
         Ok(())
     }
@@ -671,9 +671,9 @@ async fn h3_get(conn: &quinn_h3::client::Connection, uri: &http::Uri) -> Result<
     Ok(total_len)
 }
 
-async fn get(stream: (quinn::SendStream, quinn::RecvStream)) -> Result<Vec<u8>> {
+async fn get(stream: (quinn::SendStream, quinn::RecvStream), path: &str) -> Result<Vec<u8>> {
     let (mut send, recv) = stream;
-    send.write_all(b"GET /index.html\r\n")
+    send.write_all(&format!("GET {}\r\n", path).as_bytes())
         .await
         .map_err(|e| anyhow!("failed to send request: {}", e))?;
     send.finish()

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -320,6 +320,9 @@ impl State {
             tls_config.key_log = Arc::new(rustls::KeyLogFile::new());
         }
         let mut transport = quinn::TransportConfig::default();
+        transport.initial_window(1024 * 1024 * 5);
+        transport.send_window(1024 * 1024 * 2);
+        transport.receive_window(1024 * 1024 * 2);
         transport
             .max_idle_timeout(Some(Duration::from_secs(1)))
             .unwrap();

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -527,7 +527,7 @@ impl State {
                 "hq time {:+.2}% of h2's",
                 percentage
             );
-            if percentage > 30.0 {
+            if percentage > 10.0 {
                 return Err(anyhow!("Throughput {} is {:+.2}% slower", size, percentage));
             }
         }
@@ -600,7 +600,7 @@ impl State {
                 "h3 time {:+.2}% of h2's",
                 percentage
             );
-            if percentage > 30.0 {
+            if percentage > 10.0 {
                 return Err(anyhow!("Throughput {} is {:+.2}% slower", size, percentage));
             }
         }


### PR DESCRIPTION
Introducing a `HTTP/2` endpoint in interop tests to compare throughput with current implementation pair. Feat. `hyper`.