### PR TITLE
Replace bitlab dependency with homegrown bit twiddling

### DIFF
--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -25,7 +25,6 @@ codecov = { repository = "djc/quinn" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-bitlab = "0.8.1"
 bytes = "0.5.2"
 err-derive = "0.2.3"
 futures = "0.3.1"

--- a/quinn-h3/src/qpack/prefix_string/encode.rs
+++ b/quinn-h3/src/qpack/prefix_string/encode.rs
@@ -1738,7 +1738,7 @@ mod tests {
     #[test]
     fn byte_count_exact_when_bit_count_multiple_of_8() {
         let encoded = vec![
-            0x8cu8, 0x2d, 0x4b, 0x70, 0xdd, 0xf4, 0x5a, 0xbe, 0xfb, 0x40, 0x05, 0xdb,
+            0x8c, 0x2d, 0x4b, 0x70, 0xdd, 0xf4, 0x5a, 0xbe, 0xfb, 0x40, 0x05, 0xdb,
         ];
 
         let mut res = Vec::new();
@@ -1748,7 +1748,7 @@ mod tests {
 
         let reencoded = res.hpack_encode();
 
-        assert_eq!(reencoded.unwrap().last(), Some(&0xdbu8));
+        assert_eq!(reencoded.unwrap().last(), Some(&0xdb));
     }
 
     #[test]
@@ -1765,6 +1765,6 @@ mod tests {
 
         let reencoded = res.hpack_encode();
 
-        assert_eq!(reencoded.unwrap().last(), Some(&0xfcu8));
+        assert_eq!(reencoded.unwrap().last(), Some(&0xfc));
     }
 }


### PR DESCRIPTION
bitlab was a bit of an odd dependency, providing some convenience wrappers for writing bits across byte slices. It additionally pulled in the num crate. Replace it by writing our own version of the bit reading/writing routines, which should amount to much less code and is more optimized for our use case since a number of checks can be elided.

I'm not a very experienced bit twiddler and it took me way too long to get the encode side working. Happily we have pretty good regression tests for this stuff! Any feedback is welcome.