### PR TITLE
H3 fix bench

### DIFF
--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -108,7 +108,7 @@
 use std::{
     future::Future,
     mem,
-    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6, UdpSocket},
     pin::Pin,
     task::{Context, Poll},
 };
@@ -234,6 +234,20 @@ impl Builder {
     ) -> Result<IncomingConnection, quinn::EndpointError> {
         let (_, incoming) = endpoint.bind(&self.listen)?;
 
+        Ok(IncomingConnection {
+            incoming,
+            settings: self.settings,
+        })
+    }
+
+    /// Create a new server attaching it to a bound socket
+    pub fn with_socket(
+        self,
+        socket: UdpSocket,
+    ) -> Result<IncomingConnection, quinn::EndpointError> {
+        let mut endpoint_builder = quinn::Endpoint::builder();
+        endpoint_builder.listen(self.config.build());
+        let (_, incoming) = endpoint_builder.with_socket(socket)?;
         Ok(IncomingConnection {
             incoming,
             settings: self.settings,

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -241,7 +241,7 @@ impl Builder {
     }
 }
 
-/// Stream of incoming connection for one server endpoint.
+/// Stream of incoming connection for one server endpoint
 ///
 /// Yields a new HTTP/3 connection as soon as the handshake starts. The returned [`Connecting`]
 /// object can then be used either to await the handshake completion or be converted


### PR DESCRIPTION
The new bench tool call top-level bench functions multiple times (`throughput_1k` for example). Kill the server at the end of each call fixes the failures this introduced.