### PR TITLE
Decouple secrets from keys, split keys

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -2,6 +2,7 @@
 name = "interop"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Jean-Christophe BEGUE <begue.jc@gmail.com>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 default-run = "main"
 publish = false

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     cid_queue::CidQueue,
     coding::BufMutExt,
     config::{EndpointConfig, ServerConfig, TransportConfig},
-    crypto::{self, HeaderKey, KeyPair, PacketKey},
+    crypto::{self, HeaderKey, KeyPair, Keys, PacketKey},
     frame,
     frame::{Close, Datagram, FrameStruct},
     packet::{Header, LongType, Packet, PacketNumber, PartialDecode, SpaceId},
@@ -35,7 +35,6 @@ mod assembler;
 mod send_buffer;
 
 mod spaces;
-pub use spaces::CryptoSpace;
 use spaces::{PacketSpace, Retransmits, SentPacket};
 
 mod streams;
@@ -1496,7 +1495,7 @@ where
     }
 
     /// Switch to stronger cryptography during handshake
-    fn upgrade_crypto(&mut self, space: SpaceId, crypto: CryptoSpace<S>) {
+    fn upgrade_crypto(&mut self, space: SpaceId, crypto: Keys<S>) {
         debug_assert!(
             self.spaces[space as usize].crypto.is_none(),
             "already reached packet space {:?}",

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     cid_queue::CidQueue,
     coding::BufMutExt,
     config::{EndpointConfig, ServerConfig, TransportConfig},
-    crypto::{self, HeaderKey, Key, KeyPair},
+    crypto::{self, HeaderKey, KeyPair, PacketKey},
     frame,
     frame::{Close, Datagram, FrameStruct},
     packet::{Header, LongType, Packet, PacketNumber, PartialDecode, SpaceId},
@@ -102,12 +102,12 @@ where
     /// Highest usable packet number space
     highest_space: SpaceId,
     /// 1-RTT keys used prior to a key update
-    prev_crypto: Option<PrevCrypto<S::Key>>,
+    prev_crypto: Option<PrevCrypto<S::PacketKey>>,
     /// 1-RTT keys to be used for the next key update
     ///
     /// These are generated in advance to prevent timing attacks and/or DoS by third-party attackers
     /// spoofing key updates.
-    next_crypto: Option<KeyPair<S::Key>>,
+    next_crypto: Option<KeyPair<S::PacketKey>>,
     /// Latest PATH_CHALLENGE token issued to the peer along the current path
     path_challenge: Option<u64>,
     accepted_0rtt: bool,
@@ -2806,7 +2806,7 @@ pub fn initial_close<K, H, R>(
     reason: R,
 ) -> Box<[u8]>
 where
-    K: crypto::Key,
+    K: crypto::PacketKey,
     H: crypto::HeaderKey,
     R: Into<Close>,
 {
@@ -2965,7 +2965,7 @@ const MAX_ACK_BLOCKS: usize = 64;
 
 struct PrevCrypto<K>
 where
-    K: crypto::Key,
+    K: crypto::PacketKey,
 {
     /// The keys used for the previous key phase, temporarily retained to decrypt packets sent by
     /// the peer prior to its own key update.
@@ -3156,5 +3156,5 @@ impl DatagramState {
 
 struct ZeroRttCrypto<S: crypto::Session> {
     header: S::HeaderKey,
-    packet: S::Key,
+    packet: S::PacketKey,
 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1506,7 +1506,7 @@ where
         trace!("{:?} keys ready", space);
         if space == SpaceId::Data {
             // Precompute the first key update
-            self.next_crypto = Some(self.crypto.update_keys(&crypto));
+            self.next_crypto = Some(self.crypto.next_1rtt_keys());
         }
         self.spaces[space as usize].crypto = Some(CryptoSpace::new(crypto));
         debug_assert!(space as usize > self.highest_space as usize);
@@ -2686,7 +2686,7 @@ where
         // Generate keys for the key phase after the one we're switching to, store them in
         // `next_crypto`, make the contents of `next_crypto` current, and move the current keys into
         // `prev_crypto`.
-        let new = self.crypto.update_keys(self.next_crypto.as_ref().unwrap());
+        let new = self.crypto.next_1rtt_keys();
         let old = mem::replace(
             &mut self.spaces[SpaceId::Data as usize]
                 .crypto

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -179,7 +179,7 @@ where
             Side::Client
         };
         let initial_space = PacketSpace {
-            crypto: Some(CryptoSpace::new(S::Keys::new_initial(&init_cid, side))),
+            crypto: Some(CryptoSpace::new(S::initial_keys(&init_cid, side))),
             ..PacketSpace::new(now)
         };
         let state = State::Handshake(state::Handshake {
@@ -1764,9 +1764,7 @@ where
 
                         self.discard_space(SpaceId::Initial); // Make sure we clean up after any retransmitted Initials
                         self.spaces[0] = PacketSpace {
-                            crypto: Some(CryptoSpace::new(S::Keys::new_initial(
-                                &rem_cid, self.side,
-                            ))),
+                            crypto: Some(CryptoSpace::new(S::initial_keys(&rem_cid, self.side))),
                             next_packet_number: self.spaces[0].next_packet_number,
                             crypto_offset: client_hello.len() as u64,
                             ..PacketSpace::new(now)

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use super::assembler::Assembler;
-use crate::{crypto, frame, range_set::RangeSet, shared::IssuedCid, StreamId, VarInt};
+use crate::{
+    crypto, crypto::KeyPair, frame, range_set::RangeSet, shared::IssuedCid, StreamId, VarInt,
+};
 
 pub(crate) struct PacketSpace<S>
 where
@@ -306,8 +308,8 @@ pub struct CryptoSpace<S>
 where
     S: crypto::Session,
 {
-    pub packet: S::Keys,
-    pub header: S::HeaderKeys,
+    pub packet: KeyPair<S::Key>,
+    pub header: KeyPair<S::HeaderKey>,
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -308,7 +308,7 @@ pub struct CryptoSpace<S>
 where
     S: crypto::Session,
 {
-    pub packet: KeyPair<S::Key>,
+    pub packet: KeyPair<S::PacketKey>,
     pub header: KeyPair<S::HeaderKey>,
 }
 

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -7,14 +7,14 @@ use std::{
 
 use super::assembler::Assembler;
 use crate::{
-    crypto, crypto::KeyPair, frame, range_set::RangeSet, shared::IssuedCid, StreamId, VarInt,
+    crypto, crypto::Keys, frame, range_set::RangeSet, shared::IssuedCid, StreamId, VarInt,
 };
 
 pub(crate) struct PacketSpace<S>
 where
     S: crypto::Session,
 {
-    pub(crate) crypto: Option<CryptoSpace<S>>,
+    pub(crate) crypto: Option<Keys<S>>,
     pub(crate) dedup: Dedup,
     /// Highest received packet number
     pub(crate) rx_packet: u64,
@@ -302,14 +302,6 @@ impl Dedup {
             true
         }
     }
-}
-
-pub struct CryptoSpace<S>
-where
-    S: crypto::Session,
-{
-    pub packet: KeyPair<S::PacketKey>,
-    pub header: KeyPair<S::HeaderKey>,
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -8,11 +8,11 @@ use std::{
 use super::assembler::Assembler;
 use crate::{crypto, frame, range_set::RangeSet, shared::IssuedCid, StreamId, VarInt};
 
-pub(crate) struct PacketSpace<K>
+pub(crate) struct PacketSpace<S>
 where
-    K: crypto::Keys,
+    S: crypto::Session,
 {
-    pub(crate) crypto: Option<CryptoSpace<K>>,
+    pub(crate) crypto: Option<CryptoSpace<S>>,
     pub(crate) dedup: Dedup,
     /// Highest received packet number
     pub(crate) rx_packet: u64,
@@ -58,9 +58,9 @@ where
     pub(crate) ping_pending: bool,
 }
 
-impl<K> PacketSpace<K>
+impl<S> PacketSpace<S>
 where
-    K: crypto::Keys,
+    S: crypto::Session,
 {
     pub(crate) fn new(now: Instant) -> Self {
         Self {
@@ -302,24 +302,12 @@ impl Dedup {
     }
 }
 
-pub struct CryptoSpace<K>
+pub struct CryptoSpace<S>
 where
-    K: crypto::Keys,
+    S: crypto::Session,
 {
-    pub packet: K,
-    pub header: K::HeaderKeys,
-}
-
-impl<K> CryptoSpace<K>
-where
-    K: crypto::Keys,
-{
-    pub fn new(packet: K) -> Self {
-        Self {
-            header: packet.header_keys(),
-            packet,
-        }
-    }
+    pub packet: S::Keys,
+    pub header: S::HeaderKeys,
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -38,7 +38,7 @@ pub trait Session: Send + Sized {
     /// Type of keys used to protect packet headers
     type HeaderKey: HeaderKey;
     /// Type used to represent packet protection keys
-    type Key: Key;
+    type PacketKey: PacketKey;
     /// Type used to hold configuration for server sessions
     type ServerConfig: ServerConfig<Self>;
 
@@ -59,7 +59,7 @@ pub trait Session: Send + Sized {
     ///
     /// Returns `None` if the key material is not available. This might happen if you have
     /// not connected to this server before.
-    fn early_crypto(&self) -> Option<(Self::HeaderKey, Self::Key)>;
+    fn early_crypto(&self) -> Option<(Self::HeaderKey, Self::PacketKey)>;
 
     /// If the 0-RTT-encrypted data has been accepted by the peer
     fn early_data_accepted(&self) -> Option<bool>;
@@ -86,7 +86,7 @@ pub trait Session: Send + Sized {
     fn write_handshake(&mut self, buf: &mut Vec<u8>) -> Option<CryptoSpace<Self>>;
 
     /// Compute keys for the next key update
-    fn next_1rtt_keys(&mut self) -> KeyPair<Self::Key>;
+    fn next_1rtt_keys(&mut self) -> KeyPair<Self::PacketKey>;
 
     /// Generate the integrity tag for a retry packet
     fn retry_tag(orig_dst_cid: &ConnectionId, packet: &[u8]) -> [u8; 16];
@@ -136,7 +136,7 @@ where
 }
 
 /// Keys used to protect packet payloads
-pub trait Key: Send {
+pub trait PacketKey: Send {
     /// Encrypt the packet payload with the given packet number
     fn encrypt(&self, packet: u64, buf: &mut [u8], header_len: usize);
     /// Decrypt the packet payload with the given packet number

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -80,8 +80,8 @@ pub trait Session: Send + Sized {
     /// keys to encrypt data with.
     fn write_handshake(&mut self, buf: &mut Vec<u8>) -> Option<Self::Keys>;
 
-    /// Update the given set of keys
-    fn update_keys(&self, keys: &Self::Keys) -> Self::Keys;
+    /// Compute keys for the next key update
+    fn next_1rtt_keys(&mut self) -> Self::Keys;
 
     /// Generate the integrity tag for a retry packet
     fn retry_tag(orig_dst_cid: &ConnectionId, packet: &[u8]) -> [u8; 16];

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -40,6 +40,9 @@ pub trait Session: Send + Sized {
     /// Type used to hold configuration for server sessions
     type ServerConfig: ServerConfig<Self>;
 
+    /// Create the initial set of keys given the client's initial destination ConnectionId
+    fn initial_keys(dst_cid: &ConnectionId, side: Side) -> Self::Keys;
+
     /// Get the data agreed upon during the cryptographic handshake
     ///
     /// For TLS, this includes the peer's certificates, the negotiated protocol and the hostname
@@ -127,8 +130,6 @@ pub trait Keys: Send {
     /// Type used for header protection keys
     type HeaderKeys: HeaderKeys;
 
-    /// Create the initial set of keys given the initial ConnectionId
-    fn new_initial(id: &ConnectionId, side: Side) -> Self;
     /// Encrypt the packet payload with the given packet number
     fn encrypt(&self, packet: u64, buf: &mut [u8], header_len: usize);
     /// Decrypt the packet payload with the given packet number

--- a/quinn-proto/src/crypto/ring.rs
+++ b/quinn-proto/src/crypto/ring.rs
@@ -61,7 +61,7 @@ impl From<hkdf::Okm<'_, IvLen>> for Iv {
     }
 }
 
-impl crypto::Key for PacketKey {
+impl crypto::PacketKey for PacketKey {
     fn encrypt(&self, packet: u64, buf: &mut [u8], header_len: usize) {
         let mut nonce_buf = [0u8; aead::NONCE_LEN];
         let nonce = &mut nonce_buf[..self.key.algorithm().nonce_len()];
@@ -259,7 +259,7 @@ pub(crate) fn generate_keys(
 mod test {
     use super::*;
     use crate::{
-        crypto::{HeaderKey, Key},
+        crypto::{HeaderKey, PacketKey as _},
         MAX_CID_SIZE,
     };
     use hex_literal::hex;

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -46,7 +46,7 @@ impl crypto::Session for TlsSession {
     type ClientConfig = Arc<rustls::ClientConfig>;
     type HmacKey = hmac::Key;
     type HeaderKey = aead::quic::HeaderProtectionKey;
-    type Key = PacketKey;
+    type PacketKey = PacketKey;
     type ServerConfig = Arc<rustls::ServerConfig>;
 
     /// Create the initial set of keys given the initial ConnectionId
@@ -66,7 +66,7 @@ impl crypto::Session for TlsSession {
         }
     }
 
-    fn early_crypto(&self) -> Option<(Self::HeaderKey, Self::Key)> {
+    fn early_crypto(&self) -> Option<(Self::HeaderKey, Self::PacketKey)> {
         let secret = self.get_early_secret()?;
         // If an early secret is known, TLS guarantees it's associated with a resumption
         // ciphersuite,
@@ -126,7 +126,7 @@ impl crypto::Session for TlsSession {
         Some(result)
     }
 
-    fn next_1rtt_keys(&mut self) -> KeyPair<Self::Key> {
+    fn next_1rtt_keys(&mut self) -> KeyPair<Self::PacketKey> {
         let secrets = self.secrets.as_ref().expect("not in 1rtt");
         let next = self.update_secrets(&secrets.client, &secrets.server);
         let (local, remote) = select_secrets(&next, self.side());

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -14,7 +14,7 @@ use rustls::{
 };
 use webpki::DNSNameRef;
 
-use super::ring::Crypto;
+use super::ring::{initial_keys, Crypto};
 use crate::{
     crypto, transport_parameters::TransportParameters, CertificateChain, ConnectError,
     ConnectionId, Side, TransportError, TransportErrorCode,
@@ -47,6 +47,11 @@ impl crypto::Session for TlsSession {
     type HmacKey = hmac::Key;
     type Keys = Crypto;
     type ServerConfig = Arc<rustls::ServerConfig>;
+
+    /// Create the initial set of keys given the initial ConnectionId
+    fn initial_keys(id: &ConnectionId, side: Side) -> Crypto {
+        initial_keys(id, side)
+    }
 
     fn authentication_data(&self) -> AuthenticationData {
         AuthenticationData {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -252,7 +252,7 @@ where
                 return None;
             }
 
-            let crypto = S::Keys::new_initial(&dst_cid, Side::Server);
+            let crypto = S::initial_keys(&dst_cid, Side::Server);
             let header_crypto = crypto.header_keys();
             return match first_decode.finish(Some(&header_crypto)) {
                 Ok(packet) => self

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -19,7 +19,8 @@ use crate::{
     config::{ClientConfig, ConfigError, EndpointConfig, ServerConfig},
     connection::{initial_close, Connection, ConnectionError},
     crypto::{
-        self, ClientConfig as ClientCryptoConfig, Key, KeyPair, ServerConfig as ServerCryptoConfig,
+        self, ClientConfig as ClientCryptoConfig, KeyPair, PacketKey,
+        ServerConfig as ServerCryptoConfig,
     },
     packet::{Header, Packet, PacketDecodeError, PartialDecode},
     shared::{
@@ -456,7 +457,7 @@ where
         ecn: Option<EcnCodepoint>,
         mut packet: Packet,
         rest: Option<BytesMut>,
-        crypto: &KeyPair<S::Key>,
+        crypto: &KeyPair<S::PacketKey>,
         header_crypto: &KeyPair<S::HeaderKey>,
     ) -> Option<(ConnectionHandle, Connection<S>)> {
         let (src_cid, dst_cid, token, packet_number) = match packet.header {
@@ -551,7 +552,7 @@ where
                 let encode = header.encode(&mut buf);
                 buf.put_slice(&token);
                 buf.extend_from_slice(&S::retry_tag(&dst_cid, &buf));
-                encode.finish::<S::Key, S::HeaderKey>(&mut buf, &header_crypto.local, None);
+                encode.finish::<S::PacketKey, S::HeaderKey>(&mut buf, &header_crypto.local, None);
 
                 self.transmits.push_back(Transmit {
                     destination: remote,

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -432,7 +432,7 @@ pub(crate) struct PartialEncode {
 impl PartialEncode {
     pub(crate) fn finish<K, H>(self, buf: &mut [u8], header_crypto: &H, crypto: Option<(u64, &K)>)
     where
-        K: crypto::Key,
+        K: crypto::PacketKey,
         H: crypto::HeaderKey,
     {
         let PartialEncode { header_len, pn, .. } = self;
@@ -826,7 +826,7 @@ mod tests {
     #[test]
     fn header_encoding() {
         use crate::{
-            crypto::{rustls::TlsSession, Key, Session},
+            crypto::{rustls::TlsSession, PacketKey, Session},
             Side,
         };
 

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -822,16 +822,16 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "ring")]
+    #[cfg(feature = "rustls")]
     #[test]
     fn header_encoding() {
         use crate::{
-            crypto::{ring::Crypto, Keys},
+            crypto::{rustls::TlsSession, Keys, Session},
             Side,
         };
 
         let dcid = ConnectionId::new(&hex!("06b858ec6f80452b"));
-        let client_crypto = Crypto::new_initial(&dcid, Side::Client);
+        let client_crypto = TlsSession::initial_keys(&dcid, Side::Client);
         let client_header_crypto = client_crypto.header_keys();
         let mut buf = Vec::new();
         let header = Header::Initial {
@@ -857,7 +857,7 @@ mod tests {
             )[..]
         );
 
-        let server_crypto = Crypto::new_initial(&dcid, Side::Server);
+        let server_crypto = TlsSession::initial_keys(&dcid, Side::Server);
         let server_header_crypto = server_crypto.header_keys();
         let decode = PartialDecode::new(buf.as_slice().into(), 0).unwrap().0;
         let mut packet = decode.finish(Some(&server_header_crypto)).unwrap();

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -537,7 +537,7 @@ fn stream_id_backpressure() {
 }
 
 #[test]
-fn key_update() {
+fn key_update_simple() {
     let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
@@ -564,6 +564,7 @@ fn key_update() {
         Ok(Some((ref data, 0))) if data == MSG1
     );
 
+    info!("initiating key update");
     pair.client_conn_mut(client_ch).initiate_key_update();
 
     const MSG2: &[u8] = b"hello2";


### PR DESCRIPTION
Allows more graceful handling of the one-directional 0-RTT keys, and paves the way for secrets to no longer be exposed from rustls.

Motivated by #740. Merging this separately will avoid severe rebase hazards, given that the rustls release cycle is quite slow.