### PR TITLE
Listen on IPv6 by default in h3 server example

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -2,6 +2,7 @@
 name = "interop"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Jean-Christophe BEGUE <begue.jc@gmail.com>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 default-run = "main"
 publish = false

--- a/quinn-h3/examples/h3_server.rs
+++ b/quinn-h3/examples/h3_server.rs
@@ -23,7 +23,7 @@ struct Opt {
     #[structopt(parse(from_os_str), short = "c", long = "cert", requires = "key")]
     cert: Option<PathBuf>,
     /// Address to listen on
-    #[structopt(long = "listen", default_value = "0.0.0.0:4433")]
+    #[structopt(long = "listen", default_value = "[::]:4433")]
     listen: SocketAddr,
 }
 


### PR DESCRIPTION
Fixes #743. In most environments, this will produce a dual-stack socket, supporting both IPv4 and IPv6.