### PR TITLE
Update license to proper SPDX expression

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -3,7 +3,7 @@ name = "bench"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 edition = "2018"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -2,7 +2,7 @@
 name = "interop"
 version = "0.1.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Jean-Christophe BEGUE <begue.jc@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 default-run = "main"
 publish = false

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Benjamin Saunders <ben.e.saunders@gmail.com>", "Dirkjan Ochtman <dirkjan@ochtman.nl>",
     "Jean-Christophe BEGUE <begue.jc@gmail.com>"
 ]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/djc/quinn"
 description = "QUIC HTTP/3 protocol implementation"
 readme = "../README.md"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quinn-proto"
 version = "0.6.1"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Dirkjan Ochtman <dirkjan@ochtman.nl>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/djc/quinn"
 description = "State machine for the QUIC transport protocol"
 keywords = ["quic"]

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quinn"
 version = "0.6.1"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Dirkjan Ochtman <dirkjan@ochtman.nl>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/djc/quinn"
 description = "QUIC transport protocol implementation for Tokio"
 readme = "../README.md"


### PR DESCRIPTION
From the Cargo docs:

"Previously multiple licenses could be separated with a /,
but that usage is deprecated."

https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields