### PR TITLE
H3 poll reset

### DIFF
--- a/quinn-h3/src/data.rs
+++ b/quinn-h3/src/data.rs
@@ -22,7 +22,7 @@ use crate::{
         ErrorCode,
     },
     streams::Reset,
-    Error,
+    Error, HttpError,
 };
 
 /// Represent data transmission completion for a Request or a Response
@@ -84,6 +84,14 @@ where
     pub fn cancel(&mut self) {
         self.send.reset(ErrorCode::REQUEST_CANCELLED.into());
         self.state = SendDataState::Finished;
+    }
+
+    /// Monitor stop sending signal from the peer
+    ///
+    /// This will return `Ready` when a STOP_SENDING frame from the peer has
+    /// been received for this stream. Else, it will return `Pending` indefinitely.
+    pub fn poll_stopped(&mut self, cx: &mut Context) -> Poll<Result<HttpError, Error>> {
+        Poll::Ready(Ok(ready!(self.send.poll_stopped(cx)?).into()))
     }
 }
 

--- a/quinn-h3/src/tests/mod.rs
+++ b/quinn-h3/src/tests/mod.rs
@@ -1,5 +1,5 @@
 use bytes::{BufMut, Bytes};
-use futures::StreamExt;
+use futures::{future, StreamExt};
 use http::{Response, StatusCode};
 use tokio::time::{delay_for, Duration};
 
@@ -173,6 +173,40 @@ async fn server_cancel_response() {
         Err(Error::Http(HttpError::RequestCancelled, None))
     );
     timeout_join(server_handle).await;
+}
+
+#[tokio::test]
+async fn poll_stopped() {
+    let helper = Helper::new();
+
+    let mut incoming = helper.make_server();
+    let server_handle = tokio::spawn(async move {
+        let mut incoming_req = incoming
+            .next()
+            .await
+            .expect("connecting")
+            .await
+            .expect("accept");
+        let recv_req = incoming_req.next().await.expect("wait request");
+        let (_, mut sender) = recv_req.await.expect("recv_req");
+        let mut send_data = sender.send_response(
+            Response::builder()
+                .status(StatusCode::OK)
+                .body(Body::from("a".repeat(1024 * 1024 * 100).as_ref()))
+                .unwrap(),
+        );
+        future::poll_fn(|cx| send_data.poll_stopped(cx)).await
+    });
+
+    let conn = helper.make_connection().await;
+    let (req, mut resp) = conn.send_request(get("/"));
+    req.await.unwrap();
+    resp.cancel().await;
+
+    assert_matches!(
+        timeout_join(server_handle).await,
+        Ok(HttpError::RequestCancelled)
+    );
 }
 
 #[tokio::test]

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -731,6 +731,11 @@ where
         Ok(())
     }
 
+    /// Check if this stream was stopped, get the reason if it was
+    pub fn stopped(&mut self, id: StreamId) -> Result<Option<VarInt>, UnknownStream> {
+        self.streams.stop_reason(id)
+    }
+
     /// Finish a send stream, signalling that no more data will be sent.
     ///
     /// If this fails, no [`Event::StreamFinished`] will be generated.

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -998,6 +998,13 @@ fn stop_opens_bidi() {
         Err(WriteError::Stopped(ERROR))
     );
     assert_eq!(pair.server_conn_mut(client_conn).send_streams(), 0);
+    assert_matches!(
+        pair.server_conn_mut(server_conn).poll(),
+        Some(Event::Stream(StreamEvent::Stopped {
+            id: _,
+            error_code: ERROR
+        }))
+    );
     assert_matches!(pair.server_conn_mut(server_conn).poll(), None);
 }
 
@@ -1187,6 +1194,10 @@ fn stop_during_finish() {
     pair.drive_server();
     pair.client_conn_mut(client_ch).finish(s).unwrap();
     pair.drive_client();
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::Stream(StreamEvent::Stopped { id, error_code: ERROR })) if id == s
+    );
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
         Some(Event::Stream(StreamEvent::Finished { id, stop_reason: Some(ERROR) })) if id == s

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -65,7 +65,7 @@ pub use proto::{
 
 pub use crate::builders::EndpointError;
 pub use crate::connection::{SendDatagramError, ZeroRttAccepted};
-pub use crate::streams::{ReadError, ReadExactError, ReadToEndError, WriteError};
+pub use crate::streams::{ReadError, ReadExactError, ReadToEndError, StoppedError, WriteError};
 
 /// Types that are generic over the crypto protocol implementation
 pub mod generic {

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -149,6 +149,30 @@ where
         conn.wake();
     }
 
+    /// Completes if/when the peer stops the stream, yielding the error code
+    pub fn stopped(&mut self) -> Stopped<'_, S> {
+        Stopped { stream: self }
+    }
+
+    #[doc(hidden)]
+    pub fn poll_stopped(&mut self, cx: &mut Context) -> Poll<Result<VarInt, StoppedError>> {
+        let mut conn = self.conn.lock().unwrap();
+
+        if self.is_0rtt {
+            conn.check_0rtt()
+                .map_err(|()| StoppedError::ZeroRttRejected)?;
+        }
+
+        match conn.inner.stopped(self.stream) {
+            Err(_) => Poll::Ready(Err(StoppedError::UnknownStream)),
+            Ok(Some(error_code)) => Poll::Ready(Ok(error_code)),
+            Ok(None) => {
+                conn.stopped.insert(self.stream, cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+
     #[doc(hidden)]
     pub fn id(&self) -> StreamId {
         self.stream
@@ -227,6 +251,25 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         self.get_mut().stream.poll_finish(cx)
+    }
+}
+
+/// Future produced by `SendStream::stopped`
+pub struct Stopped<'a, S>
+where
+    S: proto::crypto::Session,
+{
+    stream: &'a mut SendStream<S>,
+}
+
+impl<S> Future for Stopped<'_, S>
+where
+    S: proto::crypto::Session,
+{
+    type Output = Result<VarInt, StoppedError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        self.get_mut().stream.poll_stopped(cx)
     }
 }
 
@@ -570,6 +613,22 @@ pub enum WriteError {
     /// Carries an application-defined error code.
     #[error(display = "sending stopped by peer: error {}", 0)]
     Stopped(VarInt),
+    /// The connection was closed.
+    #[error(display = "connection closed: {}", _0)]
+    ConnectionClosed(ConnectionError),
+    /// Unknown stream
+    #[error(display = "unknown stream")]
+    UnknownStream,
+    /// This was a 0-RTT stream and the server rejected it.
+    ///
+    /// Can only occur on clients for 0-RTT streams (opened using `Connecting::into_0rtt()`).
+    #[error(display = "0-RTT rejected")]
+    ZeroRttRejected,
+}
+
+/// Errors that arise while monitoring for a send stream stop from the peer
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum StoppedError {
     /// The connection was closed.
     #[error(display = "connection closed: {}", _0)]
     ConnectionClosed(ConnectionError),


### PR DESCRIPTION
Addresses #723.

It adds a `StreamEvent::Stopped` variant to carry a `STOP_SENDING` event to the user.