### PR TITLE
Allocate exactly the necessary receive buffer size

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -38,7 +38,7 @@ pub struct TransportConfig {
     pub(crate) time_threshold: f32,
     pub(crate) initial_rtt: Duration,
 
-    pub(crate) max_datagram_size: u64,
+    pub(crate) max_udp_payload_size: u64,
     pub(crate) initial_window: u64,
     pub(crate) minimum_window: u64,
     pub(crate) loss_reduction_factor: f32,
@@ -157,14 +157,14 @@ impl TransportConfig {
     /// The sender’s maximum UDP payload size. Does not include UDP or IP overhead.
     ///
     /// Used for calculating initial and minimum congestion windows.
-    pub fn max_datagram_size(&mut self, value: u64) -> &mut Self {
-        self.max_datagram_size = value;
+    pub fn max_udp_payload_size(&mut self, value: u64) -> &mut Self {
+        self.max_udp_payload_size = value;
         self
     }
 
     /// Default limit on the amount of outstanding data in bytes.
     ///
-    /// Recommended value: `min(10 * max_datagram_size, max(2 * max_datagram_size, 14720))`
+    /// Recommended value: `min(10 * max_udp_payload_size, max(2 * max_udp_payload_size, 14720))`
     pub fn initial_window(&mut self, value: u64) -> &mut Self {
         self.initial_window = value;
         self
@@ -172,7 +172,7 @@ impl TransportConfig {
 
     /// Default minimum congestion window.
     ///
-    /// Recommended value: `2 * max_datagram_size`.
+    /// Recommended value: `2 * max_udp_payload_size`.
     pub fn minimum_window(&mut self, value: u64) -> &mut Self {
         self.minimum_window = value;
         self
@@ -247,7 +247,8 @@ impl Default for TransportConfig {
                                                         // Window size needed to avoid pipeline
                                                         // stalls
         const STREAM_RWND: u64 = MAX_STREAM_BANDWIDTH / 1000 * EXPECTED_RTT;
-        const MAX_DATAGRAM_SIZE: u64 = 1200;
+        // Implied by a 1280 byte IP packet
+        const MAX_UDP_PAYLOAD_SIZE: u64 = 1232;
 
         TransportConfig {
             stream_window_bidi: 32,
@@ -262,12 +263,12 @@ impl Default for TransportConfig {
             time_threshold: 9.0 / 8.0,
             initial_rtt: Duration::from_millis(500), // per spec, intentionally distinct from EXPECTED_RTT
 
-            max_datagram_size: MAX_DATAGRAM_SIZE,
+            max_udp_payload_size: MAX_UDP_PAYLOAD_SIZE,
             initial_window: cmp::min(
-                10 * MAX_DATAGRAM_SIZE,
-                cmp::max(2 * MAX_DATAGRAM_SIZE, 14720),
+                10 * MAX_UDP_PAYLOAD_SIZE,
+                cmp::max(2 * MAX_UDP_PAYLOAD_SIZE, 14720),
             ),
-            minimum_window: 2 * MAX_DATAGRAM_SIZE,
+            minimum_window: 2 * MAX_UDP_PAYLOAD_SIZE,
             loss_reduction_factor: 0.5,
             persistent_congestion_threshold: 3,
             keep_alive_interval: None,

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -319,6 +319,19 @@ where
         self.max_udp_payload_size = value;
         self
     }
+
+    /// Get the current value of `max_udp_payload_size`
+    ///
+    /// While most parameters don't need to be readable, this must be exposed to allow higher-level
+    /// layers, e.g. the `quinn` crate, to determine how large a receive buffer to allocate to
+    /// support an externally-defined `EndpointConfig`.
+    ///
+    /// While `get_` accessors are typically unidiomatic in Rust, we favor concision for setters,
+    /// which will be used far more heavily.
+    #[doc(hidden)]
+    pub fn get_max_udp_payload_size(&self) -> u64 {
+        self.max_udp_payload_size
+    }
 }
 
 impl<S: crypto::Session> fmt::Debug for EndpointConfig<S> {

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -287,16 +287,7 @@ pub struct EndpointConfig<S>
 where
     S: crypto::Session,
 {
-    /// Length of connection IDs for the endpoint.
-    ///
-    /// This must be no greater than 20. If zero, incoming packets are mapped to connections only by
-    /// their source address. Otherwise, the connection ID field is used alone, allowing for source
-    /// address to change and for multiple connections from a single address. When local_cid_len >
-    /// 0, at most 3/4 * 2^(local_cid_len * 8) simultaneous connections can be supported.
     pub(crate) local_cid_len: usize,
-
-    /// Private key used to send authenticated connection resets to peers who were
-    /// communicating with a previous instance of this endpoint.
     pub(crate) reset_key: Arc<S::HmacKey>,
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1014,7 +1014,7 @@ where
                     self.path.congestion_window += u64::from(info.size);
                 } else {
                     // Congestion avoidance.
-                    self.path.congestion_window += self.config.max_udp_payload_size
+                    self.path.congestion_window += self.endpoint_config.max_udp_payload_size
                         * u64::from(info.size)
                         / self.path.congestion_window;
                 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1014,7 +1014,7 @@ where
                     self.path.congestion_window += u64::from(info.size);
                 } else {
                     // Congestion avoidance.
-                    self.path.congestion_window += self.config.max_datagram_size
+                    self.path.congestion_window += self.config.max_udp_payload_size
                         * u64::from(info.size)
                         / self.path.congestion_window;
                 }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -632,6 +632,11 @@ where
         self.reject_new_connections = true;
     }
 
+    /// Access the configuration used by this endpoint
+    pub fn config(&self) -> &EndpointConfig<S> {
+        &self.config
+    }
+
     #[cfg(test)]
     pub(crate) fn known_connections(&self) -> usize {
         let x = self.connections.len();

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -119,6 +119,7 @@ impl TransportParameters {
             initial_max_stream_data_bidi_local: config.stream_receive_window,
             initial_max_stream_data_bidi_remote: config.stream_receive_window,
             initial_max_stream_data_uni: config.stream_receive_window,
+            max_udp_payload_size: config.max_udp_payload_size,
             max_idle_timeout: config.max_idle_timeout.map_or(0, |x| {
                 x.as_millis()
                     .try_into()

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -119,7 +119,7 @@ impl TransportParameters {
             initial_max_stream_data_bidi_local: config.stream_receive_window,
             initial_max_stream_data_bidi_remote: config.stream_receive_window,
             initial_max_stream_data_uni: config.stream_receive_window,
-            max_udp_payload_size: config.max_udp_payload_size,
+            max_udp_payload_size: endpoint_config.max_udp_payload_size,
             max_idle_timeout: config.max_idle_timeout.map_or(0, |x| {
                 x.as_millis()
                     .try_into()

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -445,6 +445,7 @@ where
     S: proto::crypto::Session,
 {
     pub(crate) fn new(socket: UdpSocket, inner: proto::generic::Endpoint<S>, ipv6: bool) -> Self {
+        let recv_buf = vec![0; inner.config().get_max_udp_payload_size().min(64 * 1024) as usize];
         let (sender, events) = mpsc::unbounded();
         Self(Arc::new(Mutex::new(EndpointInner {
             socket,
@@ -461,7 +462,7 @@ where
             ref_count: 0,
             close: None,
             driver_lost: false,
-            recv_buf: vec![0; 64 * 1024].into(),
+            recv_buf: recv_buf.into(),
             idle: Broadcast::new(),
         })))
     }


### PR DESCRIPTION
Reduces memory use a bit, a benefit which will be compounded dramatically when we switch to receiving multiple packets per syscall, via `recvmmsg` or other means.