### PR TITLE
Update datagram transport parameter to one-way semantics

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -218,7 +218,7 @@ impl TransportConfig {
     }
 
     /// Maximum number of incoming application datagram bytes to buffer, or None to disable
-    /// datagrams
+    /// incoming datagrams
     ///
     /// The peer is forbidden to send single datagrams larger than this size. If the aggregate size
     /// of all datagrams that have been received from the peer but not consumed by the application

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -794,7 +794,6 @@ where
             - 4                 // worst-case packet number size
             - self.space(SpaceId::Data).crypto.as_ref().map_or_else(|| &self.zero_rtt_crypto.as_ref().unwrap().packet, |x| &x.packet.local).tag_len()
             - Datagram::SIZE_BOUND;
-        self.config.datagram_receive_buffer_size?;
         let limit = self.params.max_datagram_frame_size?.into_inner();
         Some(limit.min(max_size as u64) as usize)
     }


### PR DESCRIPTION
As of current master in the datagram draft, you no longer need to accept datagrams to send them. See https://github.com/quicwg/datagram/pull/11.