### PR TITLE
Refactor receive stream buffering

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -17,7 +17,7 @@ pub(crate) struct Assembler {
     /// Whether to discard data
     stopped: bool,
     /// First offset we haven't received any data at or after
-    limit: u64,
+    end: u64,
 }
 
 impl Assembler {
@@ -153,7 +153,8 @@ impl Assembler {
     }
 
     pub(crate) fn insert(&mut self, mut offset: u64, mut bytes: Bytes) {
-        self.limit = self.limit.max(offset + bytes.len() as u64);
+        self.end = self.end.max(offset + bytes.len() as u64);
+
         if let State::Unordered { ref mut recvd } = self.state {
             // Discard duplicate data
             for duplicate in recvd.replace(offset..offset + bytes.len() as u64) {
@@ -190,13 +191,13 @@ impl Assembler {
     }
 
     /// Offset after the largest byte received
-    pub(crate) fn limit(&self) -> u64 {
-        self.limit
+    pub(crate) fn end(&self) -> u64 {
+        self.end
     }
 
-    /// Whether all data prior to `self.limit()` has been read
+    /// Whether all data prior to `self.end()` has been read
     pub(crate) fn is_fully_read(&self) -> bool {
-        self.bytes_read == self.limit
+        self.bytes_read == self.end
     }
 
     /// Discard all buffered data

--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -53,7 +53,7 @@ impl Assembler {
     pub(crate) fn read_unordered(&mut self) -> Option<(u64, Bytes)> {
         self.unordered = true;
         let (n, data) = self.pop()?;
-        self.bytes_read += n;
+        self.bytes_read += data.len() as u64;
         Some((n, data))
     }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1426,7 +1426,7 @@ where
             .insert(crypto.offset, crypto.data.clone());
         let mut buf = [0; 8192];
         loop {
-            let n = space.crypto_stream.read(&mut buf);
+            let n = space.crypto_stream.read(&mut buf).unwrap();
             if n == 0 {
                 return Ok(());
             }

--- a/quinn-proto/src/connection/streams.rs
+++ b/quinn-proto/src/connection/streams.rs
@@ -1045,7 +1045,7 @@ impl Recv {
                 self.state = RecvState::Closed;
                 Err(ReadError::Reset(error_code))
             }
-            RecvState::Closed => panic!("tried to read from a closed stream"),
+            RecvState::Closed => Err(ReadError::UnknownStream),
             RecvState::Recv { size } => {
                 if size == Some(self.assembler.end()) && self.assembler.is_fully_read() {
                     self.state = RecvState::Closed;

--- a/quinn-proto/src/connection/streams.rs
+++ b/quinn-proto/src/connection/streams.rs
@@ -1047,9 +1047,7 @@ impl Recv {
             }
             RecvState::Closed => panic!("tried to read from a closed stream"),
             RecvState::Recv { size } => {
-                if size == Some(self.assembler.limit())
-                    && self.assembler.is_complete_at(self.assembler.limit())
-                {
+                if size == Some(self.assembler.limit()) && self.assembler.is_fully_read() {
                     self.state = RecvState::Closed;
                     Ok(())
                 } else {

--- a/quinn-proto/src/range_set.rs
+++ b/quinn-proto/src/range_set.rs
@@ -90,6 +90,7 @@ impl RangeSet {
         true
     }
 
+    /// Find closest range to `x` that begins at or before it
     fn pred(&self, x: u64) -> Option<(u64, u64)> {
         self.0
             .range((Included(0), Included(x)))
@@ -98,6 +99,7 @@ impl RangeSet {
             .map(|(&x, &y)| (x, y))
     }
 
+    /// Find the closest range to `x` that begins after it
     fn succ(&self, x: u64) -> Option<(u64, u64)> {
         self.0
             .range((Excluded(x), Included(u64::max_value())))

--- a/quinn-proto/src/range_set.rs
+++ b/quinn-proto/src/range_set.rs
@@ -64,25 +64,16 @@ impl RangeSet {
                 // Wholly contained
                 return false;
             } else if end >= x.start {
-                // Overlaps with pred
+                // Extend overlapping predecessor
                 self.0.remove(&start);
-                while let Some((next_start, next_end)) = self.succ(x.start) {
-                    if next_start > x.end {
-                        break;
-                    }
-                    // ..and succ
-                    self.0.remove(&next_start);
-                    x.end = cmp::max(next_end, x.end);
-                }
-                self.0.insert(start, x.end);
-                return true;
+                x.start = start;
             }
         }
         while let Some((next_start, next_end)) = self.succ(x.start) {
             if next_start > x.end {
                 break;
             }
-            // Overlaps with succ
+            // Overlaps with successor
             self.0.remove(&next_start);
             x.end = cmp::max(next_end, x.end);
         }

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -320,6 +320,7 @@ where
                 Poll::Ready(Err(ReadError::Reset(error_code)))
             }
             Err(UnknownStream) => Poll::Ready(Err(ReadError::UnknownStream)),
+            Err(IllegalOrderedRead) => Poll::Ready(Err(ReadError::IllegalOrderedRead)),
         }
     }
 
@@ -366,6 +367,7 @@ where
                 Poll::Ready(Err(ReadError::Reset(error_code)))
             }
             Err(UnknownStream) => Poll::Ready(Err(ReadError::UnknownStream)),
+            Err(IllegalOrderedRead) => Poll::Ready(Err(ReadError::IllegalOrderedRead)),
         }
     }
 
@@ -541,6 +543,12 @@ pub enum ReadError {
     /// Unknown stream
     #[error(display = "unknown stream")]
     UnknownStream,
+    /// Attempted an ordered read following an unordered read
+    ///
+    /// Performing an unordered read allows discontinuities to arise in the receive buffer of a
+    /// stream which cannot be recovered, making further ordered reads impossible.
+    #[error(display = "ordered read after unordered read")]
+    IllegalOrderedRead,
     /// This was a 0-RTT stream and the server rejected it.
     ///
     /// Can only occur on clients for 0-RTT streams (opened using `Connecting::into_0rtt()`).
@@ -557,6 +565,7 @@ impl From<ReadError> for io::Error {
             }
             Reset { .. } | ZeroRttRejected => io::ErrorKind::ConnectionReset,
             UnknownStream => io::ErrorKind::NotConnected,
+            IllegalOrderedRead => io::ErrorKind::InvalidInput,
         };
         io::Error::new(kind, x)
     }

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -100,7 +100,10 @@ async fn read_from_peer(stream: quinn::RecvStream) -> Result<(), quinn::Connecti
             use quinn::ReadToEndError::*;
             use ReadError::*;
             match e {
-                TooLong | Read(UnknownStream) | Read(ZeroRttRejected) => unreachable!(),
+                TooLong
+                | Read(UnknownStream)
+                | Read(ZeroRttRejected)
+                | Read(IllegalOrderedRead) => unreachable!(),
                 Read(Reset(error_code)) => panic!("unexpected stream reset: {}", error_code),
                 Read(ConnectionClosed(e)) => Err(e),
             }


### PR DESCRIPTION
Fixes #735. Should marginally improve performance for ordered reads due to isolation of the (now somewhat more) complex `RangeSet` operations to the unordered case where they're necessary, leaving simple cursor-based logic for ordered behavior.