### PR TITLE
Include ReadError in ReadToEndError::Read display

### DIFF
--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -460,11 +460,17 @@ where
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ReadToEndError {
     /// An error occurred during reading
-    #[error(display = "read error")]
-    Read(#[source] ReadError),
+    #[error(display = "read error: {}", 0)]
+    Read(ReadError),
     /// The stream is larger than the user-supplied limit
     #[error(display = "stream too long")]
     TooLong,
+}
+
+impl From<ReadError> for ReadToEndError {
+    fn from(x: ReadError) -> Self {
+        ReadToEndError::Read(x)
+    }
 }
 
 impl<S> AsyncRead for RecvStream<S>


### PR DESCRIPTION
By treating the read error as a component of, rather than an incidental ancestor to, the enclosing error we reduce the odds of unhelpful diagnostics.