### PR TITLE
H3 ignore unknown frames and uni streams

### DIFF
--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -283,10 +283,7 @@ impl ConnectionInner {
             self.pending_uni.remove(i - removed);
             match res {
                 Err(Error::UnknownStream(ty)) => {
-                    return Err(DriverError::peer(
-                        ErrorCode::STREAM_CREATION_ERROR,
-                        format!("unknown stream type {}", ty),
-                    ))
+                    trace!("unknown stream type {}", ty);
                 }
                 Err(e) => {
                     let msg = format!("{:?}", e);

--- a/quinn-h3/src/frame.rs
+++ b/quinn-h3/src/frame.rs
@@ -90,6 +90,11 @@ impl Decoder for FrameDecoder {
                     Ok(None)
                 }
             }
+            Err(frame::Error::UnknownFrame(_)) => {
+                src.advance(pos);
+                self.expected = None;
+                Ok(None)
+            }
             Err(frame::Error::Incomplete(min)) => {
                 self.expected = Some(min);
                 Ok(None)

--- a/quinn-h3/src/tests/helpers.rs
+++ b/quinn-h3/src/tests/helpers.rs
@@ -47,6 +47,8 @@ pub struct Helper {
 
 impl Helper {
     pub fn new() -> Self {
+        let _ = tracing_subscriber::fmt().try_init();
+
         let port = PORT_COUNT.fetch_add(1, Ordering::SeqCst);
 
         let Certs { chain, key, cert } = CERTS.clone();


### PR DESCRIPTION
Addresses the two failing tests on [quic tracker](https://quic-tracker.info.ucl.ac.be/grid).