### PR TITLE
Proactively discard data on stopped streams

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -20,6 +20,8 @@ pub(crate) struct Assembler {
     bytes_read: u64,
     /// Offsets received so far
     recvd: RangeSet,
+    /// Whether to discard data
+    stopped: bool,
 }
 
 impl Assembler {
@@ -144,7 +146,7 @@ impl Assembler {
 
     pub(crate) fn insert(&mut self, offset: u64, bytes: Bytes) {
         self.recvd.insert(offset..(offset + bytes.len() as u64));
-        if bytes.is_empty() {
+        if bytes.is_empty() || self.stopped {
             return;
         }
         self.data.push(Chunk { offset, bytes });
@@ -183,6 +185,16 @@ impl Assembler {
     pub(crate) fn clear(&mut self) {
         self.data.clear();
         self.defragmented = 0;
+    }
+
+    /// Discard buffered data and do not buffer future data, but continue tracking offsets.
+    pub(crate) fn stop(&mut self) {
+        self.stopped = true;
+        self.data.clear();
+    }
+
+    pub(crate) fn is_stopped(&self) -> bool {
+        self.stopped
     }
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -720,9 +720,8 @@ where
             id.dir() == Dir::Bi || id.initiator() != self.side,
             "only streams supporting incoming data may be stopped"
         );
-        self.streams.stop(id);
         // Only bother if there's data we haven't received yet
-        if !self.streams.is_peer_finished(id)? {
+        if self.streams.stop(id)? {
             let space = &mut self.spaces[SpaceId::Data as usize];
             space
                 .pending

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -711,12 +711,16 @@ where
         self.streams.write(stream, data)
     }
 
-    /// Signal to the peer that it should stop sending on the given recv stream
-    pub fn stop_sending(&mut self, id: StreamId, error_code: VarInt) -> Result<(), UnknownStream> {
+    /// Stop accepting data on the given receive stream
+    ///
+    /// Discards unread data and notifies the peer to stop transmitting. Once stopped, a stream
+    /// cannot be read from any further.
+    pub fn stop(&mut self, id: StreamId, error_code: VarInt) -> Result<(), UnknownStream> {
         assert!(
             id.dir() == Dir::Bi || id.initiator() != self.side,
             "only streams supporting incoming data may be stopped"
         );
+        self.streams.stop(id);
         // Only bother if there's data we haven't received yet
         if !self.streams.is_peer_finished(id)? {
             let space = &mut self.spaces[SpaceId::Data as usize];

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -259,9 +259,7 @@ fn stop_stream() {
 
     info!("stopping stream");
     const ERROR: VarInt = VarInt(42);
-    pair.server_conn_mut(server_ch)
-        .stop_sending(s, ERROR)
-        .unwrap();
+    pair.server_conn_mut(server_ch).stop(s, ERROR).unwrap();
     pair.drive();
 
     assert_matches!(
@@ -920,7 +918,7 @@ fn stop_opens_bidi() {
         .connections
         .get_mut(&server_conn)
         .unwrap()
-        .stop_sending(s, ERROR)
+        .stop(s, ERROR)
         .unwrap();
     pair.drive();
 
@@ -1102,9 +1100,7 @@ fn stop_before_finish() {
 
     info!("stopping stream");
     const ERROR: VarInt = VarInt(42);
-    pair.server_conn_mut(server_ch)
-        .stop_sending(s, ERROR)
-        .unwrap();
+    pair.server_conn_mut(server_ch).stop(s, ERROR).unwrap();
     pair.drive();
 
     assert_matches!(
@@ -1127,9 +1123,7 @@ fn stop_during_finish() {
     assert_matches!(pair.server_conn_mut(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
     info!("stopping and finishing stream");
     const ERROR: VarInt = VarInt(42);
-    pair.server_conn_mut(server_ch)
-        .stop_sending(s, ERROR)
-        .unwrap();
+    pair.server_conn_mut(server_ch).stop(s, ERROR).unwrap();
     pair.drive_server();
     pair.client_conn_mut(client_ch).finish(s).unwrap();
     pair.drive_client();


### PR DESCRIPTION
Previously, flow control credit would not be issued for data received
on stopped streams unless the application continued reading them
indefinitely. This produced a flow control leak in the high level API,
causing applications which dropped streams with unread data to
eventually grind to a halt.

Discarding data immediately should also improve performance when data
is being received on stopped streams, and allows us to discard stream
state earlier.