### PR TITLE
Return UnknownStream from Connection::reset for closed/reset streams

### DIFF
--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -233,7 +233,7 @@ impl ConnectionInner {
                     }
                     Side::Server => {
                         if self.inner.is_closing() {
-                            send.reset(ErrorCode::REQUEST_REJECTED.into());
+                            let _ = send.reset(ErrorCode::REQUEST_REJECTED.into());
                             let _ = recv.stop(ErrorCode::REQUEST_REJECTED.into());
                         } else {
                             self.inner.request_initiated(send.id());

--- a/quinn-h3/src/data.rs
+++ b/quinn-h3/src/data.rs
@@ -82,7 +82,7 @@ where
     ///
     /// The peer will receive a request error with `REQUEST_CANCELLED` code.
     pub fn cancel(&mut self) {
-        self.send.reset(ErrorCode::REQUEST_CANCELLED.into());
+        let _ = self.send.reset(ErrorCode::REQUEST_CANCELLED.into());
         self.state = SendDataState::Finished;
     }
 }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -573,7 +573,7 @@ impl RecvRequest {
             recv.reset(ErrorCode::REQUEST_REJECTED);
         }
         if let Some(mut send) = self.send.take() {
-            send.reset(ErrorCode::REQUEST_REJECTED.into());
+            let _ = send.reset(ErrorCode::REQUEST_REJECTED.into());
         }
     }
 
@@ -604,7 +604,7 @@ impl RecvRequest {
                 r.reset(ErrorCode::REQUEST_REJECTED);
             }
             if let Some(s) = &mut self.send {
-                s.reset(ErrorCode::REQUEST_REJECTED.into());
+                let _ = s.reset(ErrorCode::REQUEST_REJECTED.into());
             }
             return Err(Error::peer(format!(
                 "Tried an non indempotent method in 0-RTT: {}",
@@ -718,7 +718,8 @@ impl Sender {
     /// Cancelling a request means that some request data have been processed by the application, which
     /// decided to abandon the response.
     pub fn cancel(&mut self) {
-        self.send
+        let _ = self
+            .send
             .as_mut()
             .unwrap()
             .reset(ErrorCode::REQUEST_CANCELLED.into());

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -231,7 +231,7 @@ fn reset_stream() {
 
     info!("resetting stream");
     const ERROR: VarInt = VarInt(42);
-    pair.client_conn_mut(client_ch).reset(s, ERROR);
+    pair.client_conn_mut(client_ch).reset(s, ERROR).unwrap();
     pair.drive();
 
     assert_matches!(
@@ -869,7 +869,9 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
         Err(WriteError::Blocked)
     );
     pair.drive();
-    pair.client_conn_mut(client_conn).reset(s, VarInt(42));
+    pair.client_conn_mut(client_conn)
+        .reset(s, VarInt(42))
+        .unwrap();
     pair.drive();
     assert_eq!(
         pair.server_conn_mut(server_conn).read(s, &mut buf),

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -136,10 +136,9 @@ where
 
     /// Close the send stream immediately.
     ///
-    /// No new data can be written after calling this method. Locally buffered data is dropped,
-    /// and previously transmitted data will no longer be retransmitted if lost. If `poll_finish`
-    /// was called previously and all data has already been transmitted at least once, the peer
-    /// may still receive all written data.
+    /// No new data can be written after calling this method. Locally buffered data is dropped, and
+    /// previously transmitted data will no longer be retransmitted if lost. If an attempt has
+    /// already been made to finish the stream, the peer may still receive all written data.
     pub fn reset(&mut self, error_code: VarInt) {
         let mut conn = self.conn.lock().unwrap();
         if self.is_0rtt && conn.check_0rtt().is_err() {

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -139,13 +139,14 @@ where
     /// No new data can be written after calling this method. Locally buffered data is dropped, and
     /// previously transmitted data will no longer be retransmitted if lost. If an attempt has
     /// already been made to finish the stream, the peer may still receive all written data.
-    pub fn reset(&mut self, error_code: VarInt) {
+    pub fn reset(&mut self, error_code: VarInt) -> Result<(), UnknownStream> {
         let mut conn = self.conn.lock().unwrap();
         if self.is_0rtt && conn.check_0rtt().is_err() {
-            return;
+            return Ok(());
         }
-        conn.inner.reset(self.stream, error_code);
+        conn.inner.reset(self.stream, error_code)?;
         conn.wake();
+        Ok(())
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
Improves consistency with other stream interfaces. H3 logic was
updated to ignore errors to preserve existing behavior, but future
work might want to insert some unwraps there if static correctness
guarantees are available.