### PR TITLE
Reject connections on ALPN failure

### DIFF
--- a/quinn-h3/src/tests/helpers.rs
+++ b/quinn-h3/src/tests/helpers.rs
@@ -59,6 +59,7 @@ impl Helper {
 
         let mut client_config = quinn::ClientConfigBuilder::default();
         client_config
+            .protocols(&[crate::ALPN])
             .add_certificate_authority(cert)
             .expect("client cert");
         client_config.enable_0rtt();


### PR DESCRIPTION
Fixes #441. Mild hack, but brings us closer to compliance, helps prevent people from relying on incorrect behavior, and will be easy to improve if rustls gets a richer API.