### PR TITLE
Update rustls for interop fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ debug = true
 debug = true
 
 [patch.crates-io]
-rustls = { git = "https://github.com/ctz/rustls", rev = "59ee30545e0851bb26f2b00305cb5c672113dbde" }
+rustls = { git = "https://github.com/ctz/rustls", rev = "46c259bd8e28dcfca6c1934aabb58a0da0736cb7" }


### PR DESCRIPTION
Disables the forbidden legacy_session_id field in ClientHello and fixes our key updates.