### PR TITLE
More generous default receive buffer size

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -626,5 +626,5 @@ impl From<TryFromIntError> for ConfigError {
     }
 }
 
-// Implied by a 1280 byte IP packet
-const MAX_UDP_PAYLOAD_SIZE: u64 = 1232;
+/// Largest theoretically possible UDP/IPv4 payload
+const MAX_UDP_PAYLOAD_SIZE: u64 = 64 * 1024 - 8 - 20;


### PR DESCRIPTION
We'll want to shrink this back down when we implement recvmmsg or uring support, but for now this should improve interop.