### PR TITLE
Ensure version negotiation grease is valid

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -157,6 +157,7 @@ where
             Err(PacketDecodeError::UnsupportedVersion {
                 source,
                 destination,
+                version,
             }) => {
                 if !self.is_server() {
                     debug!("dropping packet with unsupported version");
@@ -171,7 +172,12 @@ where
                     dst_cid: source,
                 }
                 .encode(&mut buf);
-                buf.write::<u32>(0x0a1a_2a3a); // reserved version
+                // Grease with a reserved version
+                if version != 0x0a1a_2a3a {
+                    buf.write::<u32>(0x0a1a_2a3a);
+                } else {
+                    buf.write::<u32>(0x0a1a_2a4a);
+                }
                 buf.write(VERSION); // supported version
                 self.transmits.push_back(Transmit {
                     destination: remote,

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -544,6 +544,7 @@ impl PlainHeader {
                 return Err(PacketDecodeError::UnsupportedVersion {
                     source: src_cid,
                     destination: dst_cid,
+                    version,
                 });
             }
 
@@ -722,10 +723,11 @@ pub(crate) enum LongType {
 
 #[derive(Debug, Error, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) enum PacketDecodeError {
-    #[error(display = "unsupported version")]
+    #[error(display = "unsupported version {:x}", version)]
     UnsupportedVersion {
         source: ConnectionId,
         destination: ConnectionId,
+        version: u32,
     },
     #[error(display = "invalid header: {}", _0)]
     InvalidHeader(&'static str),


### PR DESCRIPTION
It's unreasonable to emit a version negotiation packet that permits the version the peer requested.