### PR TITLE
H3: check :authority and Host headers

### DIFF
--- a/quinn-h3/src/body.rs
+++ b/quinn-h3/src/body.rs
@@ -133,6 +133,10 @@ impl RecvBody {
     pub fn cancel(&mut self) {
         self.recv.reset(ErrorCode::REQUEST_CANCELLED);
     }
+
+    pub(super) fn into_inner(self) -> FrameStream {
+        self.recv
+    }
 }
 
 impl HttpBody for RecvBody {

--- a/quinn-h3/src/lib.rs
+++ b/quinn-h3/src/lib.rs
@@ -159,6 +159,9 @@ pub enum Error {
     /// The peer issued an HTTP/3 error code and an optional text description
     #[error(display = "Http error: {:?}", _0)]
     Http(HttpError, Option<String>),
+    /// Header validity error from a client call
+    #[error(display = "Header error: {:?}", _0)]
+    Header(&'static str),
     /// Polling the issued body data yielded an error
     #[error(display = "Polling body error: {}", _0)]
     Body(Box<dyn StdError + Send + Sync>),

--- a/quinn-h3/src/proto/connection.rs
+++ b/quinn-h3/src/proto/connection.rs
@@ -270,6 +270,10 @@ impl From<headers::Error> for Error {
             headers::Error::InvalidHeaderValue(s) => Error::InvalidHeaderValue(s),
             headers::Error::InvalidRequest(e) => Error::InvalidRequest(format!("{:?}", e)),
             headers::Error::MissingMethod => Error::InvalidRequest("missing method".into()),
+            headers::Error::MissingAuthority => Error::InvalidRequest("missing authority".into()),
+            headers::Error::ContradictedAuthority => {
+                Error::InvalidRequest(":authority and Host are different".into())
+            }
             headers::Error::MissingStatus => Error::InvalidResponse("missing status".into()),
         }
     }

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -115,6 +115,7 @@ use quinn::{
 };
 use quinn_proto::Side;
 use rustls::TLSError;
+use tracing::trace;
 
 use crate::{
     body::RecvBody,
@@ -642,6 +643,7 @@ impl Future for RecvRequest {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let (header, body) = ready!(self.recv.as_mut().unwrap().poll_unpin(cx))?;
         let request = self.build_request(header, body)?;
+        trace!("Got {:?}", request);
         let sender = Sender {
             send: self.send.take(),
             conn: Some(self.conn.clone()),


### PR DESCRIPTION
This is part of draft-28 update for #785. Adressing draft's [3558](https://github.com/quicwg/base-drafts/pull/3558/files).

Authoritative header values still have to be checked against certificates values. Do you have some recommendations before I start to look for a solution on my own ?  Here is the extract I'll address:


> Once a connection exists to a server endpoint, this connection MAY be reused for requests with multiple different URI authority components. In general, a server is considered authoritative for all URIs with the "https" scheme for which the hostname in the URI is present in the authenticated certificate provided by the server, either as the CN field of the certificate subject or as a dNSName in the subjectAltName field of the certificate; see [RFC6125]. For a host that is an IP address, the client MUST verify that the address appears as an iPAddress in the subjectAltName field of the certificate. If the hostname or address is not present in the certificate, the client MUST NOT consider the server authoritative for origins containing that hostname or address. See Section 5.4 of [SEMANTICS] for more detail on authoritative access.