### PR TITLE
Expose some inner workings of quinn-proto in quinn

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -409,6 +409,14 @@ where
             .peer_identity()
     }
 
+    /// A stable identifier for this connection
+    ///
+    /// Peer addresses and connection IDs can change, but this value will remain
+    /// fixed for the lifetime of the connection.
+    pub fn stable_id(&self) -> usize {
+        self.0.stable_id()
+    }
+
     // Update traffic keys spontaneously for testing purposes.
     #[doc(hidden)]
     pub fn force_key_update(&self) {
@@ -621,6 +629,10 @@ where
             error: None,
             ref_count: 0,
         })))
+    }
+
+    fn stable_id(&self) -> usize {
+        &*self.0 as *const _ as usize
     }
 }
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -60,7 +60,7 @@ mod udp;
 
 pub use proto::{
     crypto, ApplicationClose, Certificate, CertificateChain, ConnectError, ConnectionClose,
-    ConnectionError, ParseError, PrivateKey, Transmit, TransportConfig, VarInt,
+    ConnectionError, ParseError, PrivateKey, StreamId, Transmit, TransportConfig, VarInt,
 };
 
 pub use crate::builders::EndpointError;

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -173,7 +173,7 @@ where
         }
     }
 
-    #[doc(hidden)]
+    /// Get the identity of this stream
     pub fn id(&self) -> StreamId {
         self.stream
     }
@@ -459,6 +459,11 @@ where
     /// level. Because read data is subject to replay attacks.
     pub fn is_0rtt(&self) -> bool {
         self.is_0rtt
+    }
+
+    /// Get the identity of this stream
+    pub fn id(&self) -> StreamId {
+        self.stream
     }
 }
 


### PR DESCRIPTION
Specifically, this PR enables the use of `StreamId`s from `SendStream`/`RecvStream`, implements `Hash`, `PartialEq`, and `Eq` for `Connection`, and adds a way to get a static ID for a `Connection` since IP addresses may change during the lifetime of a QUIC connection.

I'm not sure `Connection::index()` is the greatest name for a function that does that last part, but it's consistent with how `StreamId`s work. It might be more discoverable if it were named something like `quic_address()`, but I'll leave it to the maintainers to make that decision.