### PR TITLE
Fix documentation in quinn-proto and quinn-h3

### DIFF
--- a/quinn-h3/src/data.rs
+++ b/quinn-h3/src/data.rs
@@ -25,11 +25,13 @@ use crate::{
     Error, HttpError,
 };
 
-/// Represent data transmission completion for a Request or a Response
+/// Represent data transmission completion for a Response
 ///
-/// This is yielded by [`SendRequest`] and [`SendResponse`]. It will encode and send
-/// the headers, then send the body if any data is polled from [`HttpBody::poll_data()`].
-/// It also encodes and sends the trailer a similar way, if any.
+/// This is yielded by [`Sender::send_response`]. It will encode and send the
+/// headers, then send the body if any data is polled from [`HttpBody::poll_data()`].  It also
+/// encodes and sends the trailer a similar way, if any.
+///
+/// [`Sender::send_response`]: crate::server::Sender::send_response()
 #[pin_project(project = SendDataProj)]
 pub struct SendData<B, P> {
     headers: Option<Header>,

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -667,7 +667,7 @@ impl Future for RecvRequest {
 ///
 /// [`RecvRequest`]: struct.RecvRequest.html
 /// [`http::Response`]: https://docs.rs/http/*/http/response/struct.Response.html
-/// [`send_response()`]: #method.Response
+/// [`send_response()`]: #method.send_response
 /// [`BodyReader`]: ../body/struct.BodyReader.html
 /// [`cancel()`]: #method.cancel
 pub struct Sender {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -715,12 +715,12 @@ where
     /// This does not ensure delivery of outstanding data. It is the application's responsibility to
     /// call this only when all important communications have been completed, e.g. by calling
     /// [`Connection::finish`] on outstanding streams and waiting for the corresponding
-    /// [`StreamFinished`] event.
+    /// [`StreamEvent::Finished`] event.
     ///
     /// If [`Connection::send_streams`] returns 0, all outstanding stream data has been
     /// delivered. There may still be data from the peer that has not been received.
     ///
-    /// [`StreamFinished`]: Event::StreamFinished
+    /// [`StreamEvent::Finished`]: crate::StreamEvent::Finished
     pub fn close(&mut self, now: Instant, error_code: VarInt, reason: Bytes) {
         let was_closed = self.state.is_closed();
         if !was_closed {
@@ -816,7 +816,9 @@ where
 
     /// Finish a send stream, signalling that no more data will be sent.
     ///
-    /// If this fails, no [`Event::StreamFinished`] will be generated.
+    /// If this fails, no [`StreamEvent::Finished`] will be generated.
+    ///
+    /// [`StreamEvent::Finished`]: crate::StreamEvent::Finished
     pub fn finish(&mut self, id: StreamId) -> Result<(), FinishError> {
         self.streams.finish(id)?;
         Ok(())

--- a/quinn-proto/src/connection/streams.rs
+++ b/quinn-proto/src/connection/streams.rs
@@ -908,10 +908,10 @@ impl Send {
 pub enum WriteError {
     /// The peer is not able to accept additional data, or the connection is congested.
     ///
-    /// If the peer issues additional flow control credit, a [`StreamWritable`] event will be
-    /// generated, indicating that retrying the write might succeed.
+    /// If the peer issues additional flow control credit, a [`StreamEvent::Writable`] event will
+    /// be generated, indicating that retrying the write might succeed.
     ///
-    /// [`StreamWritable`]: crate::Event::StreamWritable
+    /// [`StreamEvent::Writable`]: crate::StreamEvent::Writable
     #[error(display = "unable to accept further writes")]
     Blocked,
     /// The peer is no longer accepting data on this stream, and it has been implicitly reset. The
@@ -919,7 +919,7 @@ pub enum WriteError {
     ///
     /// Carries an application-defined error code.
     ///
-    /// [`StreamFinished`]: crate::Event::StreamFinished
+    /// [`StreamEvent::Finished`]: crate::StreamEvent::Finished
     #[error(display = "stopped by peer: code {}", 0)]
     Stopped(VarInt),
     /// Unknown stream
@@ -1135,9 +1135,11 @@ impl Default for RecvState {
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum FinishError {
     /// The peer is no longer accepting data on this stream. No
-    /// [`StreamFinished`](crate::Event::StreamFinished) event will be emitted for this stream.
+    /// [`StreamEvent::Finished`] event will be emitted for this stream.
     ///
     /// Carries an application-defined error code.
+    ///
+    /// [`StreamEvent::Finished`]: crate::StreamEvent::Finished
     #[error(display = "stopped by peer: code {}", 0)]
     Stopped(VarInt),
     /// The stream has not yet been created or was already finished or stopped.


### PR DESCRIPTION
Fix some documentation links in `quinn-proto` and `quinn-h3` that `cargo doc` was complaining about.

`quinn-proto` had some links that did not point to the correct locations, so these were updated to point to `enum` variants as well.

`quinn-h3` made references to structs that no longer seem to exist so this was updated too.