### PR TITLE
H3: accept goaway from client

### DIFF
--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -484,6 +484,14 @@ impl Connection {
             .close(ErrorCode::NO_ERROR.into(), b"Connection closed");
     }
 
+    /// Close the connection gracefully
+    ///
+    /// All ongoing requests will be completed, all new requests or server push will
+    /// be rejected.
+    pub fn go_away(&mut self) {
+        self.0.h3.lock().unwrap().inner.go_away();
+    }
+
     // Update traffic keys spontaneously for testing purposes.
     #[doc(hidden)]
     pub fn force_key_update(&self) {

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -89,7 +89,7 @@ impl ConnectionRef {
                 incoming_bi: bi_streams,
                 incoming_uni: uni_streams,
                 pending_uni: VecDeque::with_capacity(3),
-                inner: Connection::with_settings(settings),
+                inner: Connection::new(side, settings),
                 requests: VecDeque::with_capacity(16),
                 requests_task: None,
                 recv_control: None,

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -380,7 +380,7 @@ impl ConnectionInner {
                             trace!("Got Settings: {:#?}", s);
                             self.inner.set_remote_settings(Settings::from_frame(s)?)?;
                         }
-                        (true, Side::Client, HttpFrame::Goaway(id)) => {
+                        (true, _, HttpFrame::Goaway(id)) => {
                             trace!("Got Goaway({:?})", id);
                             self.inner.leave(StreamId(id));
                         }

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -202,9 +202,6 @@ impl ConnectionInner {
         stream_id: StreamId,
         header: &HeadersFrame,
     ) -> Poll<Result<Header, Error>> {
-        if self.closed {
-            return Poll::Ready(Err(Error::Aborted));
-        }
         let res = self
             .inner
             .decode_header(stream_id, header)

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -141,13 +141,10 @@ impl ConnectionInner {
 
         self.reset_waker(cx);
 
-        Ok(
-            if self.inner.is_closing() && self.inner.requests_in_flight() == 0 {
-                DriveState::Closed
-            } else {
-                DriveState::Running
-            },
-        )
+        Ok(match self.inner.shutdown_complete() {
+            true => DriveState::Closed,
+            false => DriveState::Running,
+        })
     }
 
     pub fn next_request(

--- a/quinn-h3/src/data.rs
+++ b/quinn-h3/src/data.rs
@@ -153,7 +153,7 @@ where
                     ready!(Pin::new(me.send).poll_finish(cx))?;
                     if *me.finish {
                         let mut conn = me.conn.h3.lock().unwrap();
-                        conn.inner.request_finished(*me.stream_id);
+                        conn.inner.remote_stream_finished(*me.stream_id);
                     }
                     return Poll::Ready(Ok(()));
                 }

--- a/quinn-h3/src/data.rs
+++ b/quinn-h3/src/data.rs
@@ -154,6 +154,7 @@ where
                     if *me.finish {
                         let mut conn = me.conn.h3.lock().unwrap();
                         conn.inner.remote_stream_finished(*me.stream_id);
+                        conn.wake();
                     }
                     return Poll::Ready(Ok(()));
                 }

--- a/quinn-h3/src/proto/connection.rs
+++ b/quinn-h3/src/proto/connection.rs
@@ -248,8 +248,8 @@ impl Connection {
         );
     }
 
-    pub fn requests_in_flight(&self) -> usize {
-        self.requests_in_flight.len()
+    pub fn shutdown_complete(&self) -> bool {
+        self.go_away.is_some() && self.requests_in_flight.is_empty()
     }
 
     pub fn is_closing(&self) -> bool {

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -508,10 +508,10 @@ pub struct IncomingRequest(ConnectionRef);
 impl IncomingRequest {
     /// Gracefully close the connection.
     ///
-    /// All currently running requests will be honored, as well as those sent before the
-    /// client received the GoAway frame.
-    pub fn go_away(&mut self) {
-        self.0.h3.lock().unwrap().inner.go_away();
+    /// All currently running requests will be honored, as well as `allow_requests` requests
+    /// sent before the client received the GoAway frame.
+    pub fn go_away(&mut self, allow_requests: u64) {
+        self.0.h3.lock().unwrap().inner.go_away(allow_requests);
     }
 }
 

--- a/quinn-h3/src/tests/helpers.rs
+++ b/quinn-h3/src/tests/helpers.rs
@@ -23,6 +23,7 @@ use crate::{
     SendData, ZeroRttAccepted,
 };
 use quinn_proto::StreamId;
+use tracing_subscriber::EnvFilter;
 
 pub fn get(path: &str) -> Request<Body> {
     Request::get(format!("https://localhost{}", path))
@@ -48,7 +49,9 @@ pub struct Helper {
 
 impl Helper {
     pub fn new() -> Self {
-        let _ = tracing_subscriber::fmt().try_init();
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .try_init();
 
         let port = PORT_COUNT.fetch_add(1, Ordering::SeqCst);
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -176,7 +176,8 @@ impl fmt::Display for StreamId {
 }
 
 impl StreamId {
-    pub(crate) fn new(initiator: Side, dir: Dir, index: u64) -> Self {
+    /// Create a new StreamId
+    pub fn new(initiator: Side, dir: Dir, index: u64) -> Self {
         StreamId(index << 2 | (dir as u64) << 1 | initiator as u64)
     }
     /// Which side of a connection initiated the stream


### PR DESCRIPTION
Make it possible to gracefully shutdown the connection from the client, as described in draft-29. 
This is not very useful as long as server push is not implemented.