### PR TITLE
Don’t try to run code coverage on PRs

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,24 @@
+name: Coverage
+
+on:
+  push:
+    branches: ['master', '0.5.x']
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/tarpaulin@v0.1
+      - uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: code-coverage-report
+          path: cobertura.xml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,24 +55,6 @@ jobs:
           command: clippy
           args: --workspace --all-targets -- -D warnings
 
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/tarpaulin@v0.1
-      - uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-      - uses: actions/upload-artifact@v1
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
-
   audit:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It won’t work, as those builds don’t have access to the CodeCov API
token.