### PR TITLE
certificate: accept pem format

### DIFF
--- a/quinn-proto/src/crypto/types.rs
+++ b/quinn-proto/src/crypto/types.rs
@@ -18,8 +18,7 @@ impl Certificate {
 
     /// Parse a PEM-formatted certificate
     pub fn from_pem(pem: &[u8]) -> Result<Self, ParseError> {
-        let certs = pemfile::certs(&mut &pem[..])
-            .map_err(|()| ParseError("invalid pem cert"))?;
+        let certs = pemfile::certs(&mut &pem[..]).map_err(|()| ParseError("invalid pem cert"))?;
         if let Some(pem) = certs.into_iter().next() {
             return Ok(Self { inner: pem });
         }

--- a/quinn-proto/src/crypto/types.rs
+++ b/quinn-proto/src/crypto/types.rs
@@ -16,6 +16,17 @@ impl Certificate {
         })
     }
 
+    /// Parse a PEM-formatted certificate
+    pub fn from_pem(pem: &[u8]) -> Result<Self, ParseError> {
+        let certs = pemfile::certs(&mut &pem[..])
+            .map_err(|()| ParseError("invalid pem cert"))?;
+        if let Some(pem) = certs.into_iter().next() {
+            return Ok(Self { inner: pem });
+        }
+
+        Err(ParseError("no cert found"))
+    }
+
     /// View the certificate in DER format
     pub fn as_der(&self) -> &[u8] {
         &self.inner.0


### PR DESCRIPTION
I found `quinn::Certificate` missing a `from_pem` function when I use pem format certificates, just add it. 