### PR TITLE
fuzzing

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "quinn-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+arbitrary = { version = "0.4.5", features = ["derive"] }
+libfuzzer-sys = "0.3"
+
+[dependencies.proto]
+features = ["arbitrary"]
+path = "../quinn-proto"
+package = "quinn-proto"
+version = "0.6.1"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "streams"
+path = "fuzz_targets/streams.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "streamid"
+path = "fuzz_targets/streamid.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/streamid.rs
+++ b/fuzz/fuzz_targets/streamid.rs
@@ -1,0 +1,19 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+extern crate proto;
+use proto::{Dir, Side, StreamId};
+
+#[derive(Arbitrary, Debug)]
+struct StreamIdParams {
+    side: Side,
+    dir: Dir,
+    index: u64,
+}
+
+fuzz_target!(|data: StreamIdParams| {
+    let s = StreamId::new(data.side, data.dir, data.index);
+    assert_eq!(s.initiator(), data.side);
+    assert_eq!(s.dir(), data.dir);
+});

--- a/fuzz/fuzz_targets/streams.rs
+++ b/fuzz/fuzz_targets/streams.rs
@@ -1,0 +1,65 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+extern crate proto;
+use proto::fuzzing::{ResetStream, Streams, TransportParameters};
+use proto::{Dir, Side, StreamId, VarInt};
+
+#[derive(Arbitrary, Debug)]
+struct StreamParams {
+    side: Side,
+    max_remote_uni: u16,
+    max_remote_bi: u16,
+    send_window: u16,
+    receive_window: u16,
+    stream_receive_window: u16,
+    dir: Dir,
+    transport_params: TransportParameters
+}
+
+#[derive(Arbitrary, Debug)]
+enum Operation {
+    Open,
+    Accept(Dir),
+    Finish(StreamId),
+    ReceivedStopSending(StreamId, VarInt),
+    ReceivedReset(ResetStream),
+    Reset(StreamId),
+}
+
+fuzz_target!(|input: (StreamParams, Vec<Operation>)| {
+    let (params, operations) = input;
+    let mut stream = Streams::new(
+        params.side,
+        params.max_remote_uni.into(),
+        params.max_remote_bi.into(),
+        params.send_window.into(),
+        params.receive_window.into(),
+        params.stream_receive_window.into(),
+    );
+
+    for operation in operations {
+        match operation {
+            Operation::Open => {
+                stream.open(&params.transport_params, params.dir);
+            }
+            Operation::Accept(dir) => {
+                stream.accept(dir);
+            }
+            Operation::Finish(id) => {
+                stream.finish(id);
+            }
+            Operation::ReceivedStopSending(sid, err_code) => {
+                stream.received_stop_sending(sid, err_code);
+            }
+            Operation::ReceivedReset(rs) => {
+                stream.received_reset(rs);
+            }
+            Operation::Reset(id) => {
+                stream.reset(id);
+            }
+        }
+    }
+});

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -25,6 +25,7 @@ tls-rustls = ["rustls", "webpki", "ring"]
 native-certs = ["rustls-native-certs"]
 
 [dependencies]
+arbitrary = { version = "0.4.5", features = ["derive"], optional = true }
 bytes = "0.5.2"
 ct-logs = { version = "0.7", optional = true }
 err-derive = "0.2.3"

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -42,7 +42,7 @@ mod spaces;
 use spaces::{PacketSpace, Retransmits, SentPacket};
 
 mod streams;
-use streams::Streams;
+pub use streams::Streams;
 pub use streams::{FinishError, ReadError, StreamEvent, UnknownStream, WriteError};
 
 mod timer;

--- a/quinn-proto/src/connection/streams.rs
+++ b/quinn-proto/src/connection/streams.rs
@@ -19,7 +19,7 @@ use crate::{
     Dir, Side, StreamId, TransportError, VarInt, MAX_STREAM_COUNT,
 };
 
-pub(crate) struct Streams {
+pub struct Streams {
     side: Side,
     // Set of streams that are currently open, or could be immediately opened by the peer
     send: HashMap<StreamId, Send>,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -13,6 +13,9 @@ use crate::{
     RESET_TOKEN_SIZE,
 };
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Type(u64);
 
@@ -732,6 +735,7 @@ impl<'a> Iterator for AckIter<'a> {
     }
 }
 
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Debug, Copy, Clone)]
 pub struct ResetStream {
     pub id: StreamId,

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -90,10 +90,36 @@ mod rustls_impls {
 #[cfg(feature = "rustls")]
 pub use crate::rustls_impls::*;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+
+#[doc(hidden)]
+#[cfg(fuzzing)]
+pub mod fuzzing {
+    pub use crate::connection::Streams;
+    pub use crate::frame::ResetStream;
+    pub use crate::transport_parameters::TransportParameters;
+    use arbitrary::{Arbitrary, Result, Unstructured};
+
+    impl Arbitrary for TransportParameters {
+        fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
+            let (a, b, c, d): (u64, u64, u64, u64) = u.arbitrary()?;
+
+            Ok(TransportParameters {
+                initial_max_streams_bidi: a,
+                initial_max_streams_uni: b,
+                ack_delay_exponent: c,
+                max_udp_payload_size: d,
+                ..TransportParameters::default()
+            })
+        }
+    }
+}
 /// The QUIC protocol version implemented
 const VERSION: u32 = 0xff00_001d;
 
 /// Whether an endpoint was the initiator of a connection
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Side {
     /// The initiator of a connection
@@ -127,6 +153,7 @@ impl ops::Not for Side {
 }
 
 /// Whether a stream communicates data in both directions or only from the initiator
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Dir {
     /// Data flows in both directions
@@ -152,6 +179,7 @@ impl fmt::Display for Dir {
 }
 
 /// Identifier for a stream within a particular connection
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct StreamId(#[doc(hidden)] pub u64);
 

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -5,11 +5,15 @@ use err_derive::Error;
 
 use crate::coding::{self, Codec, UnexpectedEnd};
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+
 /// An integer less than 2^62
 ///
 /// Values of this type are suitable for encoding as QUIC variable-length integer.
 // It would be neat if we could express to Rust that the top two bits are available for use as enum
 // discriminants
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct VarInt(pub(crate) u64);
 


### PR DESCRIPTION
# summary

adds a starting point for fuzzing with `cargo-fuzz` following from #15 

this is runnable as `cargo fuzz run streams` with libfuzzer assuming the subcommand [is installed](https://github.com/rust-fuzz/cargo-fuzz#installation)