### PR TITLE
[#783] Encrypt retry token

### DIFF
--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::BytesMut;
-use ring::{aead, aead::quic::HeaderProtectionKey, hmac};
+use ring::{aead, aead::quic::HeaderProtectionKey, hkdf, hmac};
 pub use rustls::TLSError;
 use rustls::{
     self,
@@ -50,6 +50,7 @@ impl crypto::Session for TlsSession {
     type Identity = CertificateChain;
     type ClientConfig = Arc<rustls::ClientConfig>;
     type HmacKey = hmac::Key;
+    type HandshakeTokenKey = hkdf::Prk;
     type PacketKey = PacketKey;
     type HeaderKey = HeaderProtectionKey;
     type ServerConfig = Arc<rustls::ServerConfig>;

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -548,9 +548,13 @@ where
         let (retry_src_cid, orig_dst_cid) = if server_config.use_stateless_retry {
             if token.is_empty() {
                 // First Initial
+                let mut random_bytes = vec![0u8; RetryToken::RANDOM_BYTES_LEN];
+                self.rng.fill_bytes(&mut random_bytes);
+
                 let token = RetryToken {
                     orig_dst_cid: dst_cid,
                     issued: SystemTime::now(),
+                    random_bytes: &random_bytes,
                 }
                 .encode(&*server_config.token_key, &remote, &temp_loc_cid);
                 let mut buf = Vec::new();

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -557,11 +557,13 @@ where
                     random_bytes: &random_bytes,
                 }
                 .encode(&*server_config.token_key, &remote, &temp_loc_cid);
-                let mut buf = Vec::new();
+
                 let header = Header::Retry {
                     src_cid: temp_loc_cid,
                     dst_cid: src_cid,
                 };
+
+                let mut buf = Vec::new();
                 let encode = header.encode(&mut buf);
                 buf.put_slice(&token);
                 buf.extend_from_slice(&S::retry_tag(&dst_cid, &buf));

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -8,7 +8,7 @@ use bytes::BufMut;
 
 use crate::{
     coding::{BufExt, BufMutExt},
-    crypto::HmacKey,
+    crypto::{AeadKey, HandshakeTokenKey, HmacKey},
     shared::ConnectionId,
     RESET_TOKEN_SIZE,
 };
@@ -19,20 +19,44 @@ use crate::{
 // - AEAD nonce is always set to 0
 // in other words, for each ticket, use different key derived from random using HKDF
 
-pub struct RetryToken {
+pub struct RetryToken<'a> {
     /// The destination connection ID set in the very first packet from the client
     pub orig_dst_cid: ConnectionId,
     /// The time at which this token was issued
     pub issued: SystemTime,
+    /// Random bytes for deriving AEAD key
+    pub random_bytes: &'a [u8],
 }
 
-impl RetryToken {
+impl<'a> RetryToken<'a> {
+    const MAX_ADDITIONAL_DATA_SIZE: usize = 39; // max(ipv4, ipv6) + port + retry_src_cid
+    pub const RANDOM_BYTES_LEN: usize = 32;
+
+    fn put_additional_data<'b>(
+        address: &SocketAddr,
+        retry_src_cid: &ConnectionId,
+        additional_data: &'b mut [u8],
+    ) -> &'b [u8] {
+        let mut cursor = &mut additional_data[..];
+        match address.ip() {
+            IpAddr::V4(x) => cursor.put_slice(&x.octets()),
+            IpAddr::V6(x) => cursor.put_slice(&x.octets()),
+        }
+        cursor.write(address.port());
+        retry_src_cid.encode_long(&mut cursor);
+
+        let size = Self::MAX_ADDITIONAL_DATA_SIZE - cursor.len();
+        &additional_data[..size]
+    }
+
     pub fn encode(
         &self,
-        key: &impl HmacKey,
+        key: &impl HandshakeTokenKey,
         address: &SocketAddr,
         retry_src_cid: &ConnectionId,
     ) -> Vec<u8> {
+        let aead_key = key.aead_from_hkdf(self.random_bytes);
+
         let mut buf = Vec::new();
 
         self.orig_dst_cid.encode_long(&mut buf);
@@ -43,46 +67,45 @@ impl RetryToken {
                 .unwrap_or(0),
         );
 
-        let signature_pos = buf.len();
-        match address.ip() {
-            IpAddr::V4(x) => buf.put_slice(&x.octets()),
-            IpAddr::V6(x) => buf.put_slice(&x.octets()),
-        }
-        buf.write(address.port());
-        retry_src_cid.encode_long(&mut buf);
+        let mut additional_data = [0u8; Self::MAX_ADDITIONAL_DATA_SIZE];
+        let additional_data =
+            Self::put_additional_data(address, retry_src_cid, &mut additional_data);
+        aead_key.seal(&mut buf, additional_data).unwrap();
 
-        let signature = key.sign(&buf);
-        // No reason to actually encode the IP in the token, since we always have the remote addr for an incoming packet.
-        buf.truncate(signature_pos);
-        buf.extend_from_slice(signature.as_ref());
-        buf
+        let mut token = Vec::new();
+        token.put_slice(self.random_bytes);
+        token.put_slice(&buf);
+        token
     }
 
     pub fn from_bytes(
-        key: &impl HmacKey,
+        key: &impl HandshakeTokenKey,
         address: &SocketAddr,
         retry_src_cid: &ConnectionId,
-        data: &[u8],
+        raw_token_bytes: &'a [u8],
     ) -> Result<Self, ()> {
+        if raw_token_bytes.len() < Self::RANDOM_BYTES_LEN {
+            // Invalid length
+            return Err(());
+        }
+
+        let random_bytes = &raw_token_bytes[..Self::RANDOM_BYTES_LEN];
+        let aead_key = key.aead_from_hkdf(random_bytes);
+        let mut sealed_token = raw_token_bytes[Self::RANDOM_BYTES_LEN..].to_vec();
+
+        let mut additional_data = [0u8; Self::MAX_ADDITIONAL_DATA_SIZE];
+        let additional_data =
+            Self::put_additional_data(address, retry_src_cid, &mut additional_data);
+        let data = aead_key.open(&mut sealed_token, additional_data)?;
         let mut reader = io::Cursor::new(data);
 
         let orig_dst_cid = ConnectionId::decode_long(&mut reader).ok_or(())?;
         let issued = UNIX_EPOCH + Duration::new(reader.get::<u64>().map_err(|_| ())?, 0);
 
-        let signature_start = reader.position() as usize;
-        let mut buf = Vec::new();
-        buf.put_slice(&data[0..signature_start]);
-        match address.ip() {
-            IpAddr::V4(x) => buf.put_slice(&x.octets()),
-            IpAddr::V6(x) => buf.put_slice(&x.octets()),
-        }
-        buf.write(address.port());
-        retry_src_cid.encode_long(&mut buf);
-
-        key.verify(&buf, &data[signature_start..]).map_err(|_| ())?;
         Ok(Self {
             orig_dst_cid,
             issued,
+            random_bytes,
         })
     }
 }
@@ -141,17 +164,27 @@ mod test {
     fn token_sanity() {
         use super::*;
         use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
-        use crate::MAX_CID_SIZE;
+        use crate::{crypto, MAX_CID_SIZE};
+
         use rand::RngCore;
-        use ring::hmac;
         use std::{
             net::Ipv6Addr,
             time::{Duration, UNIX_EPOCH},
         };
 
-        let mut key = [0; 64];
-        rand::thread_rng().fill_bytes(&mut key);
-        let key = <hmac::Key as HmacKey>::new(&key).unwrap();
+        let rng = &mut rand::thread_rng();
+
+        let mut master_key = [0; 64];
+        rng.fill_bytes(&mut master_key);
+
+        let mut random_bytes = [0; 32];
+        rng.fill_bytes(&mut random_bytes);
+
+        let mut master_key = vec![0u8; 64];
+        rng.fill_bytes(&mut master_key);
+
+        let prk: ring::hkdf::Prk = crypto::HandshakeTokenKey::from_secret(&master_key);
+
         let addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 4433);
         let (retry_src_cid, _) = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
         let token = RetryToken {
@@ -159,11 +192,52 @@ mod test {
                 .generate_cid()
                 .0,
             issued: UNIX_EPOCH + Duration::new(42, 0), // Fractional seconds would be lost
+            random_bytes: &random_bytes,
         };
-        let encoded = token.encode(&key, &addr, &retry_src_cid);
-        let decoded = RetryToken::from_bytes(&key, &addr, &retry_src_cid, &encoded)
+        let encoded = token.encode(&prk, &addr, &retry_src_cid);
+
+        let decoded = RetryToken::from_bytes(&prk, &addr, &retry_src_cid, &encoded)
             .expect("token didn't validate");
         assert_eq!(token.orig_dst_cid, decoded.orig_dst_cid);
         assert_eq!(token.issued, decoded.issued);
+    }
+
+    #[cfg(feature = "ring")]
+    #[test]
+    fn invalid_token_returns_err() {
+        use super::*;
+        use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
+        use crate::{crypto, MAX_CID_SIZE};
+        use rand::RngCore;
+        use std::net::Ipv6Addr;
+
+        let rng = &mut rand::thread_rng();
+
+        let mut master_key = [0; 64];
+        rng.fill_bytes(&mut master_key);
+
+        let mut random_bytes = [0; 32];
+        rng.fill_bytes(&mut random_bytes);
+
+        let prk: ring::hkdf::Prk = crypto::HandshakeTokenKey::from_secret(&master_key);
+
+        let addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 4433);
+        let (retry_src_cid, _) = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
+
+        let mut invalid_token = Vec::new();
+        invalid_token.put_slice(&random_bytes);
+
+        let mut random_data = [0; 32];
+        rand::thread_rng().fill_bytes(&mut random_data);
+        invalid_token.put_slice(&random_data);
+
+        // Assert: garbage sealed data with valid random bytes returns err
+        assert!(RetryToken::from_bytes(&prk, &addr, &retry_src_cid, &invalid_token).is_err());
+
+        let invalid_token = [0; 31];
+        rand::thread_rng().fill_bytes(&mut random_bytes);
+
+        // Assert: completely invalid retry token returns error
+        assert!(RetryToken::from_bytes(&prk, &addr, &retry_src_cid, &invalid_token).is_err());
     }
 }


### PR DESCRIPTION
**DISCLAIMER**: I am a first time contributor (Rust and QUIC).

I would like some feedback on the direction of this :slightly_smiling_face: 

Resolves #783 , following changes have been introduced,

- `master_key` has been added to `ServerConfig` for aiding AEAD key derivation
- A new trait `AeadKey` has been introduced which provided following API,
  - `from_hkdf` : derive a AEAD key using `master_key` and some `random_bytes`
  - `seal`: seal a message with the given AEAD key
  - `open`: open a message with a given AEAD key

~TODO~
- `[test]` scenario when a garbage retry token is received and the opening operation fails
