### PR TITLE
Derive Debug for TlsSession and SessionKind

### DIFF
--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -23,12 +23,14 @@ use crate::{
 };
 
 /// A rustls TLS session
+#[derive(Debug)]
 pub struct TlsSession {
     using_alpn: bool,
     got_handshake_data: bool,
     inner: SessionKind,
 }
 
+#[derive(Debug)]
 enum SessionKind {
     Client(rustls::ClientSession),
     Server(rustls::ServerSession),


### PR DESCRIPTION
This enables deriving `Debug` for other structures used in `quinn` that use `TlsSession` as a session type (for example `Incoming`, `Endpoint` etc),  which in turn enables 3rd parties structures to derive `Debug` easily when they use said structures in their code.

Addresses #841 