### PR TITLE
expose export_keying_material from rustls

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.22"
 futures = "0.3.1"
 quinn = { path = "../quinn" }
 rcgen = "0.8"
-rustls = "0.18.0"
+rustls = { git = "https://github.com/ctz/rustls", rev = "fee894f7e030" }
 tokio = { version = "0.2.13", features = ["rt-core"] }
 tracing = "0.1.10"
 tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -14,15 +14,15 @@ futures = "0.3.1"
 http = "0.2"
 http-body = "0.3"
 hyper = "0.13"
-hyper-rustls = "0.21.0"
+hyper-rustls = { git = "https://github.com/kwantam/hyper-rustls", rev = "1cf069878193" }
 lazy_static = "1"
 quinn = { path = "../quinn" }
 quinn-h3 = { path = "../quinn-h3", features = ["interop-test-accessors"] }
 quinn-proto = { path = "../quinn-proto" }
-rustls = { version = "0.18.0", features = ["dangerous_configuration"] }
+rustls = { git = "https://github.com/ctz/rustls", rev = "fee894f7e030", features = ["dangerous_configuration"] }
 structopt = "0.3.0"
 tokio = { version = "0.2.2", features = ["macros", "rt-core", "io-util"] }
-tokio-rustls = "0.14.0"
+tokio-rustls = { git = "https://github.com/kwantam/tokio-rustls", rev = "684cc546e754" }
 tracing = "0.1.10"
 tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }

--- a/quinn-h3/Cargo.toml
+++ b/quinn-h3/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "1"
 pin-project = "^0.4.21"
 quinn-proto = { path = "../quinn-proto", version = "0.6.0" }
 quinn = { path = "../quinn", version = "0.6.0", features = ["tls-rustls"] }
-rustls = { version = "0.18", features = ["quic"] }
+rustls = { git = "https://github.com/ctz/rustls", rev = "fee894f7e030", features = ["quic"] }
 tokio = "0.2.6"
 tokio-util = { version = "0.3.0", features = ["codec"] }
 tracing = "0.1.10"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -30,8 +30,8 @@ ct-logs = { version = "0.7", optional = true }
 err-derive = "0.2.3"
 rand = "0.7"
 ring = { version = "0.16.7", optional = true }
-rustls = { version = "0.18", features = ["quic"], optional = true }
-rustls-native-certs = { version = "0.4", optional = true }
+rustls = { git = "https://github.com/ctz/rustls", rev = "fee894f7e030", features = ["quic"], optional = true }
+rustls-native-certs = { git = "https://github.com/kwantam/rustls-native-certs", rev = "52fc75ad4430", optional = true }
 slab = "0.4"
 tracing = "0.1.10"
 webpki = { version = "0.21", optional = true }

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -112,7 +112,7 @@ pub trait Session: Send + Sized {
         &self,
         output: &mut [u8],
         label: &[u8],
-        context: Option<&[u8]>
+        context: Option<&[u8]>,
     ) -> Result<(), Self::ExportKeyingMaterialError>;
 }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -112,7 +112,7 @@ pub trait Session: Send + Sized {
         &self,
         output: &mut [u8],
         label: &[u8],
-        context: Option<&[u8]>,
+        context: &[u8],
     ) -> Result<(), Self::ExportKeyingMaterialError>;
 }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -186,3 +186,22 @@ pub trait HmacKey: Send + Sized + Sync {
     /// Method for verifying a message
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), ()>;
 }
+
+/// A [Session] that can export keying material
+pub trait ExportKeyingMaterial: Session {
+    /// Error type returned when export_keying_mateiral fails
+    type Error;
+
+    /// Fill `output` with `output.len()` bytes of keying material derived
+    /// from the [Session]'s secrets, using `label` and `context` for domain
+    /// separation.
+    ///
+    /// This function will fail, returning `Self::Error`, if called before
+    /// the handshake with the peer is complete.
+    fn export_keying_material(
+        &self,
+        output: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>
+    ) -> Result<(), Self::Error>;
+}

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -106,8 +106,8 @@ pub trait Session: Send + Sized {
     /// from the [Session]'s secrets, using `label` and `context` for domain
     /// separation.
     ///
-    /// This function will fail, returning `Self::Error`, if called before
-    /// the handshake with the peer is complete.
+    /// This function will fail, returning [Self::ExportKeyingMaterialError],
+    /// if called before the handshake with the peer is complete.
     fn export_keying_material(
         &self,
         output: &mut [u8],

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -44,8 +44,6 @@ pub trait Session: Send + Sized {
     type PacketKey: PacketKey;
     /// Type used to hold configuration for server sessions
     type ServerConfig: ServerConfig<Self>;
-    /// Type of error returned by [export_keying_material](Self::export_keying_material).
-    type ExportKeyingMaterialError;
 
     /// Create the initial set of keys given the client's initial destination ConnectionId
     fn initial_keys(dst_cid: &ConnectionId, side: Side) -> Keys<Self>;
@@ -106,14 +104,14 @@ pub trait Session: Send + Sized {
     /// from the [Session]'s secrets, using `label` and `context` for domain
     /// separation.
     ///
-    /// This function will fail, returning [Self::ExportKeyingMaterialError],
-    /// if called before the handshake with the peer is complete.
+    /// This function will fail, returning [ExportKeyingMaterialError],
+    /// if the requested output length is too large.
     fn export_keying_material(
         &self,
         output: &mut [u8],
         label: &[u8],
         context: &[u8],
-    ) -> Result<(), Self::ExportKeyingMaterialError>;
+    ) -> Result<(), ExportKeyingMaterialError>;
 }
 
 /// A pair of keys for bidirectional communication
@@ -201,3 +199,9 @@ pub trait HmacKey: Send + Sized + Sync {
     /// Method for verifying a message
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), ()>;
 }
+
+/// Error returned by [Session::export_keying_material].
+///
+/// This error occurs if the requested output length is too large.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ExportKeyingMaterialError;

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -45,6 +45,23 @@ impl TlsSession {
     }
 }
 
+impl crypto::ExportKeyingMaterial for TlsSession {
+    type Error = TLSError;
+
+    fn export_keying_material(
+        &self,
+        output: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>
+    ) -> Result<(), Self::Error> {
+        let session: &dyn rustls::Session = match &self.inner {
+            SessionKind::Client(s) => s,
+            SessionKind::Server(s) => s,
+        };
+        session.export_keying_material(output, label, context)
+    }
+}
+
 impl crypto::Session for TlsSession {
     type HandshakeData = HandshakeData;
     type Identity = CertificateChain;

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -230,7 +230,8 @@ impl crypto::Session for TlsSession {
             SessionKind::Client(s) => s,
             SessionKind::Server(s) => s,
         };
-        session.export_keying_material(output, label, Some(context))
+        session
+            .export_keying_material(output, label, Some(context))
             .map_err(|_| ExportKeyingMaterialError)
     }
 }

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -225,7 +225,7 @@ impl crypto::Session for TlsSession {
         &self,
         output: &mut [u8],
         label: &[u8],
-        context: Option<&[u8]>
+        context: Option<&[u8]>,
     ) -> Result<(), Self::ExportKeyingMaterialError> {
         let session: &dyn rustls::Session = match &self.inner {
             SessionKind::Client(s) => s,

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -225,13 +225,13 @@ impl crypto::Session for TlsSession {
         &self,
         output: &mut [u8],
         label: &[u8],
-        context: Option<&[u8]>,
+        context: &[u8],
     ) -> Result<(), Self::ExportKeyingMaterialError> {
         let session: &dyn rustls::Session = match &self.inner {
             SessionKind::Client(s) => s,
             SessionKind::Server(s) => s,
         };
-        session.export_keying_material(output, label, context)
+        session.export_keying_material(output, label, Some(context))
     }
 }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -206,7 +206,7 @@ fn export_keying_material() {
         .export_keying_material(&mut server_buf, LABEL, CONTEXT)
         .unwrap();
 
-    assert_eq!(client_buf, server_buf);
+    assert_eq!(&client_buf[..], &server_buf[..]);
 }
 
 #[test]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -188,11 +188,10 @@ fn export_keying_material() {
     let (client_ch, server_ch) = pair.connect();
 
     const LABEL: &[u8] = b"test_label";
-    const CONTEXT: Option<&[u8]> = Some(b"test_context");
+    const CONTEXT: &[u8] = b"test_context";
 
     // client keying material
     let mut client_buf = [0u8; 64];
-    assert!(!pair.client_conn_mut(client_ch).is_handshaking());
     pair.client_conn_mut(client_ch)
         .crypto_session()
         .export_keying_material(&mut client_buf, LABEL, CONTEXT)
@@ -200,7 +199,6 @@ fn export_keying_material() {
 
     // server keying material
     let mut server_buf = [0u8; 64];
-    assert!(!pair.server_conn_mut(server_ch).is_handshaking());
     pair.server_conn_mut(server_ch)
         .crypto_session()
         .export_keying_material(&mut server_buf, LABEL, CONTEXT)

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -15,7 +15,6 @@ use tracing::info;
 
 use super::*;
 use crate::crypto::Session as _;
-use crate::crypto::ExportKeyingMaterial as _;
 mod util;
 use util::*;
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -33,7 +33,7 @@ futures = "0.3.1"
 libc = "0.2.69"
 mio = "0.6"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.6.1" }
-rustls = { version = "0.18.0", features = ["quic"], optional = true }
+rustls = { git = "https://github.com/ctz/rustls", rev = "fee894f7e030", features = ["quic"], optional = true }
 tracing = "0.1.10"
 tokio = { version = "0.2.6", features = ["rt-core", "io-driver", "time"] }
 webpki = { version = "0.21", optional = true }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -439,6 +439,33 @@ where
     }
 }
 
+impl<S> Connection<S>
+where
+    S: proto::crypto::ExportKeyingMaterial,
+{
+    /// Derive keying material from this connection's TLS session secrets.
+    ///
+    /// When both peers call this method with the same `label` and `context`
+    /// arguments and `output` buffers of equal length, they will get the
+    /// same sequence of bytes in `output`. These bytes are cryptographically
+    /// strong and pseudorandom, and are suitable for use as keying material.
+    ///
+    /// See [RFC5705](https://tools.ietf.org/html/rfc5705) for more information.
+    pub fn export_keying_material(
+        &self,
+        output: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>,
+    ) -> Result<(), <S as proto::crypto::ExportKeyingMaterial>::Error> {
+        self.0
+            .lock()
+            .unwrap()
+            .inner
+            .crypto_session()
+            .export_keying_material(output, label, context)
+    }
+}
+
 impl<S> Clone for Connection<S>
 where
     S: proto::crypto::Session,

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -437,12 +437,7 @@ where
     pub fn force_key_update(&self) {
         self.0.lock().unwrap().inner.initiate_key_update()
     }
-}
 
-impl<S> Connection<S>
-where
-    S: proto::crypto::ExportKeyingMaterial,
-{
     /// Derive keying material from this connection's TLS session secrets.
     ///
     /// When both peers call this method with the same `label` and `context`
@@ -456,7 +451,7 @@ where
         output: &mut [u8],
         label: &[u8],
         context: Option<&[u8]>,
-    ) -> Result<(), <S as proto::crypto::ExportKeyingMaterial>::Error> {
+    ) -> Result<(), <S as proto::crypto::Session>::ExportKeyingMaterialError> {
         self.0
             .lock()
             .unwrap()

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -451,7 +451,7 @@ where
         output: &mut [u8],
         label: &[u8],
         context: &[u8],
-    ) -> Result<(), <S as proto::crypto::Session>::ExportKeyingMaterialError> {
+    ) -> Result<(), proto::crypto::ExportKeyingMaterialError> {
         self.0
             .lock()
             .unwrap()

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -450,7 +450,7 @@ where
         &self,
         output: &mut [u8],
         label: &[u8],
-        context: Option<&[u8]>,
+        context: &[u8],
     ) -> Result<(), <S as proto::crypto::Session>::ExportKeyingMaterialError> {
         self.0
             .lock()

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -121,7 +121,7 @@ fn read_after_close_and_export_keying_material() {
             .connection
             .export_keying_material(&mut buf, b"asdf", Some(b"qwer"))
             .unwrap();
-        s_send.send(buf).unwrap();
+        s_send.send(buf).map_err(|_| ()).unwrap();
         s.write_all(MSG).await.unwrap();
         s.finish().await.unwrap();
     });
@@ -137,7 +137,7 @@ fn read_after_close_and_export_keying_material() {
             .connection
             .export_keying_material(&mut buf, b"asdf", Some(b"qwer"))
             .unwrap();
-        c_send.send(buf).unwrap();
+        c_send.send(buf).map_err(|_| ()).unwrap();
         let stream = new_conn
             .uni_streams
             .next()
@@ -154,7 +154,7 @@ fn read_after_close_and_export_keying_material() {
     // prior block_on call guarantees that try_recv's will succeed here
     let c_buf = c_recv.try_recv().unwrap().unwrap();
     let s_buf = s_recv.try_recv().unwrap().unwrap();
-    assert_eq!(c_buf, s_buf);
+    assert_eq!(&c_buf[..], &s_buf[..]);
 }
 
 #[tokio::test]

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use futures::{channel::oneshot, future, StreamExt};
+use futures::{future, StreamExt};
 use tokio::{
     runtime::{Builder, Runtime},
     time::{Duration, Instant},
@@ -98,16 +98,11 @@ fn local_addr() {
 }
 
 #[test]
-fn read_after_close_and_export_keying_material() {
+fn read_after_close() {
     let _guard = subscribe();
     let mut runtime = rt_basic();
     let (endpoint, mut incoming) = runtime.enter(endpoint);
     const MSG: &[u8] = b"goodbye!";
-
-    // compare key material
-    let (c_send, mut c_recv) = oneshot::channel();
-    let (s_send, mut s_recv) = oneshot::channel();
-
     runtime.spawn(async move {
         let new_conn = incoming
             .next()
@@ -116,12 +111,6 @@ fn read_after_close_and_export_keying_material() {
             .await
             .expect("connection");
         let mut s = new_conn.connection.open_uni().await.unwrap();
-        let mut buf = [0u8; 64];
-        new_conn
-            .connection
-            .export_keying_material(&mut buf, b"asdf", b"qwer")
-            .unwrap();
-        s_send.send(buf).map_err(|_| ()).unwrap();
         s.write_all(MSG).await.unwrap();
         s.finish().await.unwrap();
     });
@@ -132,12 +121,6 @@ fn read_after_close_and_export_keying_material() {
             .await
             .expect("connect");
         tokio::time::delay_until(Instant::now() + Duration::from_millis(100)).await;
-        let mut buf = [0u8; 64];
-        new_conn
-            .connection
-            .export_keying_material(&mut buf, b"asdf", b"qwer")
-            .unwrap();
-        c_send.send(buf).map_err(|_| ()).unwrap();
         let stream = new_conn
             .uni_streams
             .next()
@@ -150,11 +133,37 @@ fn read_after_close_and_export_keying_material() {
             .expect("read_to_end");
         assert_eq!(msg, MSG);
     });
+}
 
-    // prior block_on call guarantees that try_recv's will succeed here
-    let c_buf = c_recv.try_recv().unwrap().unwrap();
-    let s_buf = s_recv.try_recv().unwrap().unwrap();
-    assert_eq!(&c_buf[..], &s_buf[..]);
+#[test]
+fn export_keying_material() {
+    let _guard = subscribe();
+    let mut runtime = rt_basic();
+    let (endpoint, mut incoming) = runtime.enter(endpoint);
+    runtime.block_on(async move {
+        let outgoing_conn = endpoint
+            .connect(&endpoint.local_addr().unwrap(), "localhost")
+            .unwrap()
+            .await
+            .expect("connect");
+        let incoming_conn = incoming
+            .next()
+            .await
+            .expect("endpoint")
+            .await
+            .expect("connection");
+        let mut i_buf = [0u8; 64];
+        incoming_conn
+            .connection
+            .export_keying_material(&mut i_buf, b"asdf", b"qwer")
+            .unwrap();
+        let mut o_buf = [0u8; 64];
+        outgoing_conn
+            .connection
+            .export_keying_material(&mut o_buf, b"asdf", b"qwer")
+            .unwrap();
+        assert_eq!(&i_buf[..], &o_buf[..]);
+    });
 }
 
 #[tokio::test]

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -119,7 +119,7 @@ fn read_after_close_and_export_keying_material() {
         let mut buf = [0u8; 64];
         new_conn
             .connection
-            .export_keying_material(&mut buf, b"asdf", Some(b"qwer"))
+            .export_keying_material(&mut buf, b"asdf", b"qwer")
             .unwrap();
         s_send.send(buf).map_err(|_| ()).unwrap();
         s.write_all(MSG).await.unwrap();
@@ -135,7 +135,7 @@ fn read_after_close_and_export_keying_material() {
         let mut buf = [0u8; 64];
         new_conn
             .connection
-            .export_keying_material(&mut buf, b"asdf", Some(b"qwer"))
+            .export_keying_material(&mut buf, b"asdf", b"qwer")
             .unwrap();
         c_send.send(buf).map_err(|_| ()).unwrap();
         let stream = new_conn


### PR DESCRIPTION
This PR adds support for the export_keying_material method from rustls. Specifically:

- adds a trait, `proto::crypto::ExportKeyingMaterial`, that can be implemented on a `proto::crypto::Session`. I did this rather than implement it as part of `Session` because future crypto impls might not provide this functionality. Of course, can move it to `Session` if that would be better.

- implements `ExportKeyingMaterial` for `proto::crypto::rustls::TlsSession`, which calls the corresponding method on the rustls `Session` object.

- implements `export_keying_material` method on `quinn::Connection<S> where S: ExportKeyingMaterial`, which is just plumbing.

- tests `export_keying_material` in both `proto` and `quinn`.

To test this, you'll need to point to the current main branch of rustls in quinn and quinn-proto. You'll also need to point to a local copy of rustls-native-certs that pulls in the main branch of rustls.

Merging this is blocked on rustls and rustls-native-certs updating.

closes #834 