### PR TITLE
Support customized Cid generation

### DIFF
--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -1,0 +1,50 @@
+use rand::RngCore;
+
+use crate::shared::ConnectionId;
+use crate::MAX_CID_SIZE;
+
+/// Generates connection IDs for incoming connections
+pub trait ConnectionIdGenerator: Send {
+    /// Generates a connection ID for a new connection
+    fn generate_cid(&mut self) -> ConnectionId;
+    /// Performs any validation it needs (e.g. HMAC, etc)
+    fn validate_cid(&mut self, cid: &ConnectionId) -> bool;
+    /// Returns the length of a connection id for cononections created by this generator
+    fn cid_len(&self) -> usize;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RandomConnectionIdGenerator {
+    cid_len: usize,
+}
+impl Default for RandomConnectionIdGenerator {
+    fn default() -> Self {
+        Self { cid_len: 8 }
+    }
+}
+impl RandomConnectionIdGenerator {
+    pub fn new(cid_len: usize) -> Self {
+        debug_assert!(cid_len <= MAX_CID_SIZE);
+        Self { cid_len }
+    }
+}
+impl ConnectionIdGenerator for RandomConnectionIdGenerator {
+    fn generate_cid(&mut self) -> ConnectionId {
+        let mut res = ConnectionId {
+            len: self.cid_len as u8,
+            bytes: [0; MAX_CID_SIZE],
+        };
+        rand::thread_rng().fill_bytes(&mut res.bytes[..self.cid_len]);
+        res
+    }
+
+    /// Cid is an array of random bytes. We only verify the length
+    fn validate_cid(&mut self, cid: &ConnectionId) -> bool {
+        cid.len as usize == self.cid_len
+    }
+
+    /// Provide the length of dst_cid in short header packet
+    fn cid_len(&self) -> usize {
+        self.cid_len
+    }
+}

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -26,9 +26,7 @@ pub trait ConnectionIdGenerator: Send {
     fn cid_len(&self) -> usize;
 }
 
-/// CID filled with random number/byte
-///
-/// This struct generates random CID with a customized length.
+/// Generates purely random connection IDs of a certain length
 #[derive(Debug, Clone, Copy)]
 pub struct RandomConnectionIdGenerator {
     cid_len: usize,

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -12,16 +12,6 @@ pub trait ConnectionIdGenerator: Send {
     /// issuer) to correlate them with other connection IDs for the same
     /// connection.
     fn generate_cid(&mut self) -> ConnectionId;
-    /// Performs any validation if it is needed (e.g. HMAC, etc)
-    ///
-    /// Apply validation check on those CIDs that may still exist in hash table
-    /// but considered invalid by application-layer logic.
-    /// e.g. we may want to limit the amount of time for which a CID is valid
-    /// in order to reduce the number of valid IDs that could be accumulated
-    /// by an attacker.
-    fn validate_cid(&mut self, _cid: &ConnectionId) -> bool {
-        true
-    }
     /// Returns the length of a CID for cononections created by this generator
     fn cid_len(&self) -> usize;
 }

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -14,7 +14,7 @@ pub trait ConnectionIdGenerator: Send {
     /// issuer) to correlate them with other connection IDs for the same
     /// connection.
     ///
-    /// Connection IDs will be proactively retired if lifetime is given (under development).
+    /// In the future, connection IDs will be retired after the returned `Duration`, if any.
     fn generate_cid(&mut self) -> (ConnectionId, Option<Duration>);
     /// Returns the length of a CID for cononections created by this generator
     fn cid_len(&self) -> usize;

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -5,14 +5,17 @@ use crate::MAX_CID_SIZE;
 
 /// Generates connection IDs for incoming connections
 pub trait ConnectionIdGenerator: Send {
-    /// Generates a connection ID for a new connection
+    /// Generates a new CID
     fn generate_cid(&mut self) -> ConnectionId;
-    /// Performs any validation it needs (e.g. HMAC, etc)
+    /// Performs any validation if it is needed (e.g. HMAC, etc)
     fn validate_cid(&mut self, cid: &ConnectionId) -> bool;
-    /// Returns the length of a connection id for cononections created by this generator
+    /// Returns the length of a CID for cononections created by this generator
     fn cid_len(&self) -> usize;
 }
 
+/// CID filled with random number/byte
+///
+/// This struct generates random CID with a customized length.
 #[derive(Debug, Clone, Copy)]
 pub struct RandomConnectionIdGenerator {
     cid_len: usize,
@@ -23,6 +26,7 @@ impl Default for RandomConnectionIdGenerator {
     }
 }
 impl RandomConnectionIdGenerator {
+    /// Initialize Random CID generator with a fixed CID length (which must be less or equal to MAX_CID_SIZE)
     pub fn new(cid_len: usize) -> Self {
         debug_assert!(cid_len <= MAX_CID_SIZE);
         Self { cid_len }

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -45,10 +45,10 @@ impl RandomConnectionIdGenerator {
 }
 impl ConnectionIdGenerator for RandomConnectionIdGenerator {
     fn generate_cid(&mut self) -> ConnectionId {
-        let mut bytes_arr = vec![0; self.cid_len];
-        rand::thread_rng().fill_bytes(&mut bytes_arr);
+        let mut bytes_arr = [0; MAX_CID_SIZE];
+        rand::thread_rng().fill_bytes(&mut bytes_arr[..self.cid_len]);
 
-        ConnectionId::new(&bytes_arr)
+        ConnectionId::new(&bytes_arr[..self.cid_len])
     }
 
     /// Provide the length of dst_cid in short header packet

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -15,10 +15,10 @@ pub trait ConnectionIdGenerator: Send {
     /// Performs any validation if it is needed (e.g. HMAC, etc)
     ///
     /// Apply validation check on those CIDs that may still exist in hash table
-    ///   but considered invalid by application-layer logic.
-    /// e.g., We may want to limit the amount of time for which a CID is valid
-    ///   in order to reduce the number of valid IDs that could be accumulated
-    ///   by an attacker.
+    /// but considered invalid by application-layer logic.
+    /// e.g. we may want to limit the amount of time for which a CID is valid
+    /// in order to reduce the number of valid IDs that could be accumulated
+    /// by an attacker.
     fn validate_cid(&mut self, _cid: &ConnectionId) -> bool {
         true
     }

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use rand::RngCore;
 
 use crate::shared::ConnectionId;
@@ -5,13 +7,15 @@ use crate::MAX_CID_SIZE;
 
 /// Generates connection IDs for incoming connections
 pub trait ConnectionIdGenerator: Send {
-    /// Generates a new CID
+    /// Generates a new CID with finite lifetime
     ///
     /// Connection IDs MUST NOT contain any information that can be used by
     /// an external observer (that is, one that does not cooperate with the
     /// issuer) to correlate them with other connection IDs for the same
     /// connection.
-    fn generate_cid(&mut self) -> ConnectionId;
+    ///
+    /// Connection IDs will be proactively retired if lifetime is given (under development).
+    fn generate_cid(&mut self) -> (ConnectionId, Option<Duration>);
     /// Returns the length of a CID for cononections created by this generator
     fn cid_len(&self) -> usize;
 }
@@ -20,25 +24,38 @@ pub trait ConnectionIdGenerator: Send {
 #[derive(Debug, Clone, Copy)]
 pub struct RandomConnectionIdGenerator {
     cid_len: usize,
+    lifetime: Option<Duration>,
 }
 impl Default for RandomConnectionIdGenerator {
     fn default() -> Self {
-        Self { cid_len: 8 }
+        Self {
+            cid_len: 8,
+            lifetime: None,
+        }
     }
 }
 impl RandomConnectionIdGenerator {
     /// Initialize Random CID generator with a fixed CID length (which must be less or equal to MAX_CID_SIZE)
     pub fn new(cid_len: usize) -> Self {
         debug_assert!(cid_len <= MAX_CID_SIZE);
-        Self { cid_len }
+        Self {
+            cid_len,
+            ..RandomConnectionIdGenerator::default()
+        }
+    }
+
+    /// Set the lifetime of CIDs created by this generator
+    pub fn set_lifetime(&mut self, d: Duration) -> &mut Self {
+        self.lifetime = Some(d);
+        self
     }
 }
 impl ConnectionIdGenerator for RandomConnectionIdGenerator {
-    fn generate_cid(&mut self) -> ConnectionId {
+    fn generate_cid(&mut self) -> (ConnectionId, Option<Duration>) {
         let mut bytes_arr = [0; MAX_CID_SIZE];
         rand::thread_rng().fill_bytes(&mut bytes_arr[..self.cid_len]);
 
-        ConnectionId::new(&bytes_arr[..self.cid_len])
+        (ConnectionId::new(&bytes_arr[..self.cid_len]), self.lifetime)
     }
 
     /// Provide the length of dst_cid in short header packet

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -8,9 +8,9 @@ pub trait ConnectionIdGenerator: Send {
     /// Generates a new CID
     ///
     /// Connection IDs MUST NOT contain any information that can be used by
-    //    an external observer (that is, one that does not cooperate with the
-    //    issuer) to correlate them with other connection IDs for the same
-    //    connection.
+    /// an external observer (that is, one that does not cooperate with the
+    /// issuer) to correlate them with other connection IDs for the same
+    /// connection.
     fn generate_cid(&mut self) -> ConnectionId;
     /// Performs any validation if it is needed (e.g. HMAC, etc)
     ///

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -300,7 +300,8 @@ where
 {
     pub(crate) reset_key: Arc<S::HmacKey>,
     pub(crate) max_udp_payload_size: u64,
-    /// cid generator factory
+    /// CID generator factory
+    ///
     /// Create a cid generator for local cid in Endpoint struct
     pub(crate) connection_id_generator_factory:
         Arc<dyn Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync>,
@@ -321,10 +322,11 @@ where
         }
     }
 
-    /// new_with_cid_generator is designed for backward compatibility
+    /// assign a cid generator factory
     ///
-    /// EndpointConfig can still call fn new() to use a random cid generator
-    /// new_with_cid_generator() can accept any customized cid generator that
+    ///
+    /// EndpointConfig::new() applies a default random CID generator factory.
+    /// This functions accepts any customized CID generator to reset CID generator factory that
     /// implements ConnectionIdGenerator trait
     pub fn set_cid_generator<F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static>(
         &mut self,

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -322,7 +322,12 @@ where
         }
     }
 
-    /// assign a cid generator factory
+    /// Supply a custom connection ID generator factory
+    ///
+    /// Called once by each `Endpoint` constructed from this configuration to obtain the CID generator which will
+    /// be used to generate the CIDs used for incoming packets on all connections involving that  `Endpoint`. A
+    /// custom CID generator allows applications to embed information in local connection IDs, e.g. to support
+    /// stateless packet-level load balancers.
     ///
     ///
     /// EndpointConfig::new() applies a default random CID generator factory.

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -333,7 +333,7 @@ where
     /// EndpointConfig::new() applies a default random CID generator factory.
     /// This functions accepts any customized CID generator to reset CID generator factory that
     /// implements ConnectionIdGenerator trait
-    pub fn set_cid_generator<F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static>(
+    pub fn cid_generator<F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static>(
         &mut self,
         factory: F,
     ) -> &mut Self {

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -6,9 +6,9 @@ use rand::RngCore;
 #[cfg(feature = "rustls")]
 use crate::crypto::types::{Certificate, CertificateChain, PrivateKey};
 use crate::{
+    cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     congestion,
     crypto::{self, ClientConfig as _, HmacKey as _, ServerConfig as _},
-    shared::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     VarInt,
 };
 
@@ -326,9 +326,7 @@ where
     /// EndpointConfig can still call fn new() to use a random cid generator
     /// new_with_cid_generator() can accept any customized cid generator that
     /// implements ConnectionIdGenerator trait
-    pub fn set_cid_generator<
-        F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static,
-    >(
+    pub fn set_cid_generator<F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static>(
         &mut self,
         factory: F,
     ) -> &mut Self {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -16,7 +16,7 @@ use tracing::{debug, error, trace, trace_span, warn};
 use crate::{
     cid_queue::CidQueue,
     coding::BufMutExt,
-    config::{EndpointConfig, ServerConfig, TransportConfig},
+    config::{ServerConfig, TransportConfig},
     crypto::{self, HeaderKey, KeyPair, Keys, PacketKey},
     frame,
     frame::{Close, Datagram, FrameStruct},
@@ -58,7 +58,6 @@ pub struct Connection<S>
 where
     S: crypto::Session,
 {
-    endpoint_config: Arc<EndpointConfig<S>>,
     server_config: Option<Arc<ServerConfig<S>>>,
     config: Arc<TransportConfig>,
     rng: StdRng,
@@ -76,6 +75,8 @@ where
     /// Exactly one prior to `self.rem_cids.offset` except during processing of certain
     /// NEW_CONNECTION_ID frames.
     rem_cid_seq: u64,
+    /// cid length used to decode short packet
+    local_cid_len: usize,
     path: PathData,
     prev_path: Option<PathData>,
     state: State,
@@ -163,7 +164,6 @@ where
     S: crypto::Session,
 {
     pub(crate) fn new(
-        endpoint_config: Arc<EndpointConfig<S>>,
         server_config: Option<Arc<ServerConfig<S>>>,
         config: Arc<TransportConfig>,
         init_cid: ConnectionId,
@@ -172,6 +172,7 @@ where
         remote: SocketAddr,
         crypto: S,
         now: Instant,
+        local_cid_len: usize,
     ) -> Self {
         let side = if server_config.is_some() {
             Side::Server
@@ -192,13 +193,13 @@ where
             .as_ref()
             .map_or(false, |c| c.use_stateless_retry);
         let mut this = Self {
-            endpoint_config,
             server_config,
             crypto,
             handshake_cid: loc_cid,
             rem_cid,
             rem_handshake_cid: rem_cid,
             rem_cid_seq: 0,
+            local_cid_len,
             path: PathData::new(
                 remote,
                 config.initial_rtt,
@@ -1641,7 +1642,7 @@ where
         self.total_recvd = self.total_recvd.wrapping_add(data.len() as u64);
         let mut remaining = Some(data);
         while let Some(data) = remaining {
-            match PartialDecode::new(data, self.endpoint_config.local_cid_len) {
+            match PartialDecode::new(data, self.local_cid_len) {
                 Ok((partial_decode, rest)) => {
                     remaining = rest;
                     self.handle_decode(now, remote, ecn, partial_decode);
@@ -2268,7 +2269,7 @@ where
                     self.streams.received_stop_sending(id, error_code);
                 }
                 Frame::RetireConnectionId { sequence } => {
-                    if self.endpoint_config.local_cid_len == 0 {
+                    if self.local_cid_len == 0 {
                         return Err(TransportError::PROTOCOL_VIOLATION(
                             "RETIRE_CONNECTION_ID when CIDs aren't in use",
                         ));
@@ -2474,7 +2475,7 @@ where
 
     /// Issue an initial set of connection IDs to the peer
     fn issue_cids(&mut self) {
-        if self.endpoint_config.local_cid_len == 0 {
+        if self.local_cid_len == 0 {
             return;
         }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -807,7 +807,7 @@ pub enum ConnectError {
     EndpointStopping,
     /// The number of active connections on the local endpoint is at the limit
     ///
-    /// Try a larger cid length.
+    /// Try using longer connection IDs.
     #[error(display = "too many connections")]
     TooManyConnections,
     /// The domain name supplied was malformed

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -202,9 +202,7 @@ where
 
         let dst_cid = first_decode.dst_cid();
         let known_ch = {
-            let ch = if self.local_cid_generator.cid_len() > 0
-                && self.local_cid_generator.validate_cid(&dst_cid)
-            {
+            let ch = if self.local_cid_generator.cid_len() > 0 {
                 self.connection_ids.get(&dst_cid)
             } else {
                 None

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -15,6 +15,7 @@ use slab::Slab;
 use tracing::{debug, trace, warn};
 
 use crate::{
+    cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     coding::BufMutExt,
     config::{ClientConfig, ConfigError, EndpointConfig, ServerConfig},
     connection::{Connection, ConnectionError},
@@ -25,8 +26,8 @@ use crate::{
     frame,
     packet::{Header, Packet, PacketDecodeError, PacketNumber, PartialDecode},
     shared::{
-        ConnectionEvent, ConnectionEventInner, ConnectionId, ConnectionIdGenerator, EcnCodepoint,
-        EndpointEvent, EndpointEventInner, IssuedCid, RandomConnectionIdGenerator,
+        ConnectionEvent, ConnectionEventInner, ConnectionId, EcnCodepoint, EndpointEvent,
+        EndpointEventInner, IssuedCid,
     },
     transport_parameters::TransportParameters,
     ResetToken, RetryToken, Side, Transmit, TransportError, MAX_CID_SIZE, MIN_INITIAL_SIZE,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -407,7 +407,7 @@ where
                 let params = TransportParameters::new::<S>(
                     &config.transport,
                     &self.config,
-                    &self.local_cid_generator,
+                    self.local_cid_generator.as_ref(),
                     loc_cid,
                     None,
                 );
@@ -425,7 +425,7 @@ where
                 let params = TransportParameters::new(
                     &config.transport,
                     &self.config,
-                    &self.local_cid_generator,
+                    self.local_cid_generator.as_ref(),
                     loc_cid,
                     Some(config),
                 );

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -60,8 +60,9 @@ pub use crate::transport_error::{Code as TransportErrorCode, Error as TransportE
 pub mod congestion;
 
 mod cid_generator;
-mod token;
 pub use crate::cid_generator::ConnectionIdGenerator;
+
+mod token;
 
 use token::{ResetToken, RetryToken};
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::transport_error::{Code as TransportErrorCode, Error as TransportE
 pub mod congestion;
 
 mod cid_generator;
-pub use crate::cid_generator::ConnectionIdGenerator;
+pub use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
 
 mod token;
 use token::{ResetToken, RetryToken};

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -63,7 +63,6 @@ mod cid_generator;
 pub use crate::cid_generator::ConnectionIdGenerator;
 
 mod token;
-
 use token::{ResetToken, RetryToken};
 
 /// Types that are generic over the crypto protocol implementation

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -59,7 +59,10 @@ pub use crate::transport_error::{Code as TransportErrorCode, Error as TransportE
 
 pub mod congestion;
 
+mod cid_generator;
 mod token;
+pub use crate::cid_generator::ConnectionIdGenerator;
+
 use token::{ResetToken, RetryToken};
 
 /// Types that are generic over the crypto protocol implementation

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -67,7 +67,7 @@ pub struct ConnectionId {
 }
 
 impl ConnectionId {
-    pub(crate) fn new(bytes: &[u8]) -> Self {
+    pub fn new(bytes: &[u8]) -> Self {
         debug_assert!(bytes.len() <= MAX_CID_SIZE);
         let mut res = Self {
             len: bytes.len() as u8,

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -67,6 +67,7 @@ pub struct ConnectionId {
 }
 
 impl ConnectionId {
+    /// Construct cid from byte array
     pub fn new(bytes: &[u8]) -> Self {
         debug_assert!(bytes.len() <= MAX_CID_SIZE);
         let mut res = Self {

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -1,9 +1,7 @@
 use std::{fmt, net::SocketAddr, time::Instant};
 
-use bytes::{Buf, BufMut, BytesMut};
-use rand::RngCore;
-
 use crate::{coding::BufExt, packet::PartialDecode, ResetToken, MAX_CID_SIZE};
+use bytes::{Buf, BufMut, BytesMut};
 
 /// Events sent from an Endpoint to a Connection
 #[derive(Debug)]
@@ -61,8 +59,8 @@ pub(crate) enum EndpointEventInner {
 /// Mainly useful for identifying this connection's packets on the wire with tools like Wireshark.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ConnectionId {
-    len: u8,
-    bytes: [u8; MAX_CID_SIZE],
+    pub len: u8,
+    pub bytes: [u8; MAX_CID_SIZE],
 }
 
 impl ConnectionId {
@@ -119,52 +117,6 @@ impl fmt::Display for ConnectionId {
             write!(f, "{:02x}", byte)?;
         }
         Ok(())
-    }
-}
-
-/// Generates connection IDs for incoming connections
-pub trait ConnectionIdGenerator: Send {
-    /// Generates a connection ID for a new connection
-    fn generate_cid(&mut self) -> ConnectionId;
-    /// Performs any validation it needs (e.g. HMAC, etc)
-    fn validate_cid(&mut self, cid: &ConnectionId) -> bool;
-    /// Returns the length of a connection id for cononections created by this generator
-    fn cid_len(&self) -> usize;
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct RandomConnectionIdGenerator {
-    cid_len: usize,
-}
-impl Default for RandomConnectionIdGenerator {
-    fn default() -> Self {
-        Self { cid_len: 8 }
-    }
-}
-impl RandomConnectionIdGenerator {
-    pub fn new(cid_len: usize) -> Self {
-        debug_assert!(cid_len <= MAX_CID_SIZE);
-        Self { cid_len }
-    }
-}
-impl ConnectionIdGenerator for RandomConnectionIdGenerator {
-    fn generate_cid(&mut self) -> ConnectionId {
-        let mut res = ConnectionId {
-            len: self.cid_len as u8,
-            bytes: [0; MAX_CID_SIZE],
-        };
-        rand::thread_rng().fill_bytes(&mut res.bytes[..self.cid_len]);
-        res
-    }
-
-    /// Cid is an array of random bytes. We only verify the length
-    fn validate_cid(&mut self, cid: &ConnectionId) -> bool {
-        cid.len as usize == self.cid_len
-    }
-
-    /// Provide the length of dst_cid in short header packet
-    fn cid_len(&self) -> usize {
-        self.cid_len
     }
 }
 

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -1,7 +1,8 @@
 use std::{fmt, net::SocketAddr, time::Instant};
 
-use crate::{coding::BufExt, packet::PartialDecode, ResetToken, MAX_CID_SIZE};
 use bytes::{Buf, BufMut, BytesMut};
+
+use crate::{coding::BufExt, packet::PartialDecode, ResetToken, MAX_CID_SIZE};
 
 /// Events sent from an Endpoint to a Connection
 #[derive(Debug)]
@@ -60,9 +61,9 @@ pub(crate) enum EndpointEventInner {
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ConnectionId {
     /// length of CID
-    pub len: u8,
+    len: u8,
     /// CID in byte array
-    pub bytes: [u8; MAX_CID_SIZE],
+    bytes: [u8; MAX_CID_SIZE],
 }
 
 impl ConnectionId {

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -59,7 +59,9 @@ pub(crate) enum EndpointEventInner {
 /// Mainly useful for identifying this connection's packets on the wire with tools like Wireshark.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ConnectionId {
+    /// length of CID
     pub len: u8,
+    /// CID in byte array
     pub bytes: [u8; MAX_CID_SIZE],
 }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -14,8 +14,8 @@ use rustls::internal::msgs::enums::AlertDescription;
 use tracing::info;
 
 use super::*;
+use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
 use crate::crypto::Session as _;
-use crate::shared::{ConnectionIdGenerator, RandomConnectionIdGenerator};
 mod util;
 use util::*;
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -15,6 +15,7 @@ use tracing::info;
 
 use super::*;
 use crate::crypto::Session as _;
+use crate::shared::{ConnectionIdGenerator, RandomConnectionIdGenerator};
 mod util;
 use util::*;
 
@@ -49,9 +50,11 @@ fn version_negotiate_server() {
 fn version_negotiate_client() {
     let _guard = subscribe();
     let server_addr = "[::2]:7890".parse().unwrap();
+    let cid_generator_factory: fn() -> Box<dyn ConnectionIdGenerator> =
+        || Box::new(RandomConnectionIdGenerator::new(0));
     let mut client = Endpoint::new(
         Arc::new(EndpointConfig {
-            local_cid_len: 0,
+            connection_id_generator_factory: Arc::new(cid_generator_factory),
             ..Default::default()
         }),
         None,
@@ -1093,9 +1096,11 @@ fn implicit_open() {
 #[test]
 fn zero_length_cid() {
     let _guard = subscribe();
+    let cid_generator_factory: fn() -> Box<dyn ConnectionIdGenerator> =
+        || Box::new(RandomConnectionIdGenerator::new(0));
     let mut pair = Pair::new(
         Arc::new(EndpointConfig {
-            local_cid_len: 0,
+            connection_id_generator_factory: Arc::new(cid_generator_factory),
             ..EndpointConfig::default()
         }),
         server_config(),

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -153,9 +153,11 @@ mod test {
         rand::thread_rng().fill_bytes(&mut key);
         let key = <hmac::Key as HmacKey>::new(&key).unwrap();
         let addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 4433);
-        let retry_src_cid = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
+        let (retry_src_cid, _) = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
         let token = RetryToken {
-            orig_dst_cid: RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid(),
+            orig_dst_cid: RandomConnectionIdGenerator::new(MAX_CID_SIZE)
+                .generate_cid()
+                .0,
             issued: UNIX_EPOCH + Duration::new(42, 0), // Fractional seconds would be lost
         };
         let encoded = token.encode(&key, &addr, &retry_src_cid);

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -140,6 +140,7 @@ mod test {
     #[test]
     fn token_sanity() {
         use super::*;
+        use crate::shared::{ConnectionIdGenerator, RandomConnectionIdGenerator};
         use crate::MAX_CID_SIZE;
         use rand::RngCore;
         use ring::hmac;
@@ -152,9 +153,9 @@ mod test {
         rand::thread_rng().fill_bytes(&mut key);
         let key = <hmac::Key as HmacKey>::new(&key).unwrap();
         let addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 4433);
-        let retry_src_cid = ConnectionId::random(&mut rand::thread_rng(), MAX_CID_SIZE);
+        let retry_src_cid = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
         let token = RetryToken {
-            orig_dst_cid: ConnectionId::random(&mut rand::thread_rng(), MAX_CID_SIZE),
+            orig_dst_cid: RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid(),
             issued: UNIX_EPOCH + Duration::new(42, 0), // Fractional seconds would be lost
         };
         let encoded = token.encode(&key, &addr, &retry_src_cid);

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -140,7 +140,7 @@ mod test {
     #[test]
     fn token_sanity() {
         use super::*;
-        use crate::shared::{ConnectionIdGenerator, RandomConnectionIdGenerator};
+        use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
         use crate::MAX_CID_SIZE;
         use rand::RngCore;
         use ring::hmac;

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -15,11 +15,12 @@ use bytes::{buf::ext::BufExt as _, Buf, BufMut};
 use err_derive::Error;
 
 use crate::{
+    cid_generator::ConnectionIdGenerator,
     cid_queue::CidQueue,
     coding::{BufExt, BufMutExt, UnexpectedEnd},
     config::{EndpointConfig, ServerConfig, TransportConfig},
     crypto,
-    shared::{ConnectionId, ConnectionIdGenerator},
+    shared::ConnectionId,
     ResetToken, Side, TransportError, VarInt, MAX_CID_SIZE, RESET_TOKEN_SIZE,
 };
 

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -117,7 +117,7 @@ impl TransportParameters {
     pub(crate) fn new<S>(
         config: &TransportConfig,
         endpoint_config: &EndpointConfig<S>,
-        cid_gen: &Box<dyn ConnectionIdGenerator>,
+        cid_gen: &dyn ConnectionIdGenerator,
         initial_src_cid: ConnectionId,
         server_config: Option<&ServerConfig<S>>,
     ) -> Self

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -19,7 +19,7 @@ use crate::{
     coding::{BufExt, BufMutExt, UnexpectedEnd},
     config::{EndpointConfig, ServerConfig, TransportConfig},
     crypto,
-    shared::ConnectionId,
+    shared::{ConnectionId, ConnectionIdGenerator},
     ResetToken, Side, TransportError, VarInt, MAX_CID_SIZE, RESET_TOKEN_SIZE,
 };
 
@@ -116,6 +116,7 @@ impl TransportParameters {
     pub(crate) fn new<S>(
         config: &TransportConfig,
         endpoint_config: &EndpointConfig<S>,
+        cid_gen: &Box<dyn ConnectionIdGenerator>,
         initial_src_cid: ConnectionId,
         server_config: Option<&ServerConfig<S>>,
     ) -> Self
@@ -138,7 +139,7 @@ impl TransportParameters {
             }),
             max_ack_delay: 0,
             disable_active_migration: server_config.map_or(false, |c| !c.migration),
-            active_connection_id_limit: if endpoint_config.local_cid_len == 0 {
+            active_connection_id_limit: if cid_gen.cid_len() == 0 {
                 2 // i.e. default, i.e. unsent
             } else {
                 // + 1 to account for the currently used CID, which isn't kept in the queue


### PR DESCRIPTION
Currently Quinn generates cid using random number only. Some use case may require a more sophisticated cid structure. This change mainly add a `ConnectionIdGenerator` trait that allows to use any customized cid generator.